### PR TITLE
Bumping javabuilder package to version 5

### DIFF
--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -44,7 +44,7 @@ def on_connect(event, context)
     :projectUrl => authorizer["project_url"]
   }
   response = lambda_client.invoke({
-    function_name: 'javaBuilderExecuteCode:4',
+    function_name: 'javaBuilderExecuteCode:5',
     invocation_type: 'Event',
     payload: JSON.generate(payload)
   })


### PR DESCRIPTION
Includes the following
* [Soft Breaking Change] An update to the messaging protocol -  Java Lab will likely continue to work, but any console messages very confusing until this PR is merged: https://github.com/code-dot-org/code-dot-org/pull/40507
* The addition of the Painter student-facing API