### PR TITLE
Updated server-side code to send Neighborhood messages to the client

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/DebuggingMessage.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/DebuggingMessage.java
@@ -6,6 +6,6 @@ import org.code.protocol.ClientMessageType;
 /** A message directed to the client's terminal. Equivalent to System.out.print. */
 public class DebuggingMessage extends ClientMessage {
   DebuggingMessage(String value) {
-    super(ClientMessageType.DEBUG, value, null);
+    super(ClientMessageType.DEBUG, value);
   }
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/OutputRedirectionStream.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/OutputRedirectionStream.java
@@ -1,7 +1,7 @@
 package org.code.javabuilder;
 
 import java.io.OutputStream;
-import org.code.util.FormattedClientMessage;
+import org.code.protocol.FormattedClientMessage;
 
 /**
  * An OutputStream that passes output to an OutputAdapter. It is intended to redirect output from

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/OutputRedirectionStream.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/OutputRedirectionStream.java
@@ -1,7 +1,6 @@
 package org.code.javabuilder;
 
 import java.io.OutputStream;
-import org.code.util.ClientMessage;
 import org.code.util.FormattedClientMessage;
 
 /**
@@ -63,7 +62,7 @@ public class OutputRedirectionStream extends OutputStream {
       return;
     }
 
-    ClientMessage message = FormattedClientMessage.buildClientMessage(buffer.toString());
+    FormattedClientMessage message = FormattedClientMessage.buildClientMessage(buffer.toString());
     if (message != null) {
       // This is a hack that we are temporarily using while we design a better system to handle
       // passing signals from Javabuilder mini apps to Java Lab

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/OutputRedirectionStream.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/OutputRedirectionStream.java
@@ -1,6 +1,8 @@
 package org.code.javabuilder;
 
 import java.io.OutputStream;
+import org.code.util.ClientMessage;
+import org.code.util.FormattedClientMessage;
 
 /**
  * An OutputStream that passes output to an OutputAdapter. It is intended to redirect output from
@@ -60,7 +62,15 @@ public class OutputRedirectionStream extends OutputStream {
     if (buffer.length() == 0) {
       return;
     }
-    outputAdapter.sendMessage(new SystemOutMessage(buffer.toString()));
+
+    ClientMessage message = FormattedClientMessage.buildClientMessage(buffer.toString());
+    if (message != null) {
+      // This is a hack that we are temporarily using while we design a better system to handle
+      // passing signals from Javabuilder mini apps to Java Lab
+      outputAdapter.sendMessage(message);
+    } else {
+      outputAdapter.sendMessage(new SystemOutMessage(buffer.toString()));
+    }
     buffer.delete(0, buffer.length());
   }
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/SystemOutMessage.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/SystemOutMessage.java
@@ -6,6 +6,6 @@ import org.code.protocol.ClientMessageType;
 /** A message directed to the client's terminal. Equivalent to System.out.print. */
 public class SystemOutMessage extends ClientMessage {
   public SystemOutMessage(String value) {
-    super(ClientMessageType.SYSTEM_OUT, value, null);
+    super(ClientMessageType.SYSTEM_OUT, value);
   }
 }

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/UserFacingExceptionTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/UserFacingExceptionTest.java
@@ -20,6 +20,6 @@ public class UserFacingExceptionTest {
         new UserFacingException(
             UserFacingExceptionKey.INTERNAL_EXCEPTION, new Exception("the cause of the exception"));
     UserFacingExceptionMessage message = exception.getExceptionMessage();
-    assertTrue(message.getDetail().get("cause").contains("the cause of the exception"));
+    assertTrue(message.getDetail().getString("cause").contains("the cause of the exception"));
   }
 }

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/UserInitiatedExceptionTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/UserInitiatedExceptionTest.java
@@ -11,6 +11,6 @@ public class UserInitiatedExceptionTest {
         new UserInitiatedException(
             UserInitiatedExceptionKey.COMPILER_ERROR, new Exception("the cause of the exception"));
     UserInitiatedExceptionMessage message = exception.getExceptionMessage();
-    assertTrue(message.getDetail().get("cause").contains("the cause of the exception"));
+    assertTrue(message.getDetail().getString("cause").contains("the cause of the exception"));
   }
 }

--- a/org-code-javabuilder/neighborhood/build.gradle
+++ b/org-code-javabuilder/neighborhood/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
     // https://mvnrepository.com/artifact/org.json/json
     implementation group: 'org.json', name: 'json', version: '20210307'
-    implementation project(':util')
+    implementation project(':protocol')
 }
 
 // Builds the Neighborhood fat-jar (i.e. jar with all dependencies) and copies it to the resources

--- a/org-code-javabuilder/neighborhood/build.gradle
+++ b/org-code-javabuilder/neighborhood/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
     // https://mvnrepository.com/artifact/org.json/json
     implementation group: 'org.json', name: 'json', version: '20210307'
+    implementation project(':util')
 }
 
 // Builds the Neighborhood fat-jar (i.e. jar with all dependencies) and copies it to the resources

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/NeighborhoodOutputHandler.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/NeighborhoodOutputHandler.java
@@ -1,0 +1,9 @@
+package org.code.neighborhood;
+
+public class NeighborhoodOutputHandler {
+  public static void sendMessage(NeighborhoodSignalMessage message) {
+    // This is a hack that we are temporarily using while we design a better system to handle passing signals from Javabuilder mini apps to Java Lab
+    // TODO: replace this with a more formal messaging system.
+    System.out.print(message.getFormattedMessage());
+  }
+}

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/NeighborhoodOutputHandler.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/NeighborhoodOutputHandler.java
@@ -2,7 +2,8 @@ package org.code.neighborhood;
 
 public class NeighborhoodOutputHandler {
   public static void sendMessage(NeighborhoodSignalMessage message) {
-    // This is a hack that we are temporarily using while we design a better system to handle passing signals from Javabuilder mini apps to Java Lab
+    // This is a hack that we are temporarily using while we design a better
+    // system to handle passing signals from Javabuilder mini apps to Java Lab
     // TODO: replace this with a more formal messaging system.
     System.out.print(message.getFormattedMessage());
   }

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/NeighborhoodSignalKey.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/NeighborhoodSignalKey.java
@@ -1,0 +1,6 @@
+package org.code.neighborhood;
+
+public enum NeighborhoodSignalKey {
+  // Move the painter one space forward
+  MOVE
+}

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/NeighborhoodSignalMessage.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/NeighborhoodSignalMessage.java
@@ -1,0 +1,12 @@
+package org.code.neighborhood;
+
+import org.code.util.ClientMessage;
+import org.code.util.ClientMessageType;
+
+import java.util.HashMap;
+
+public class NeighborhoodSignalMessage extends ClientMessage {
+  NeighborhoodSignalMessage(NeighborhoodSignalKey key, HashMap<String, String> detail) {
+    super(ClientMessageType.NEIGHBORHOOD, key.toString(), detail);
+  }
+}

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/NeighborhoodSignalMessage.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/NeighborhoodSignalMessage.java
@@ -1,7 +1,7 @@
 package org.code.neighborhood;
 
-import org.code.util.ClientMessage;
-import org.code.util.ClientMessageType;
+import org.code.protocol.ClientMessage;
+import org.code.protocol.ClientMessageType;
 
 import java.util.HashMap;
 

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
@@ -1,5 +1,7 @@
 package org.code.neighborhood;
 
+import java.util.HashMap;
+
 public class Painter {
   private static int lastId = 0;
   private int xLocation;
@@ -60,7 +62,10 @@ public class Painter {
     } else {
       throw new UnsupportedOperationException(ExceptionKeys.INVALID_MOVE.toString());
     }
-    System.out.println("New (x,y) : (" + this.xLocation + "," + this.yLocation + ")");
+    HashMap<String, String> details = new HashMap<>();
+    details.put("id", this.id);
+    details.put("direction", this.direction.getDirectionString());
+    NeighborhoodOutputHandler.sendMessage(new NeighborhoodSignalMessage(NeighborhoodSignalKey.MOVE, details));
   }
 
   /**

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessage.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessage.java
@@ -25,12 +25,24 @@ import org.json.JSONObject;
 public abstract class ClientMessage {
   private final ClientMessageType type;
   private final String value;
-  private final HashMap<String, String> detail;
+  private final JSONObject detail;
 
   protected ClientMessage(ClientMessageType type, String value, HashMap<String, String> detail) {
     this.type = type;
     this.value = value;
-    this.detail = detail == null ? new HashMap<>() : detail;
+    this.detail = new JSONObject(detail);
+  }
+
+  protected ClientMessage(ClientMessageType type, String value) {
+    this.type = type;
+    this.value = value;
+    this.detail = new JSONObject();
+  }
+
+  protected ClientMessage(ClientMessageType type, String value, JSONObject detail) {
+    this.type = type;
+    this.value = value;
+    this.detail = detail;
   }
 
   public ClientMessageType getType() {
@@ -41,7 +53,7 @@ public abstract class ClientMessage {
     return value;
   }
 
-  public HashMap<String, String> getDetail() {
+  public JSONObject getDetail() {
     return detail;
   }
 
@@ -50,7 +62,7 @@ public abstract class ClientMessage {
     JSONObject formattedMessage = new JSONObject();
     formattedMessage.put("type", this.type);
     formattedMessage.put("value", this.value);
-    if (this.detail.size() > 0) {
+    if (this.detail.length() > 0) {
       formattedMessage.put("detail", this.detail);
     }
     return formattedMessage.toString();

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/FormattedClientMessage.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/FormattedClientMessage.java
@@ -1,4 +1,4 @@
-package org.code.util;
+package org.code.protocol;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/org-code-javabuilder/util/src/main/java/org/code/util/FormattedClientMessage.java
+++ b/org-code-javabuilder/util/src/main/java/org/code/util/FormattedClientMessage.java
@@ -10,7 +10,8 @@ public class FormattedClientMessage extends ClientMessage {
   }
 
   /**
-   * Create a client message from a formatted message. This only supports Neighborhood messages now as this exists specifically as a short-term hack to unblock neighborhood level writing.
+   * Create a client message from a formatted message. This only supports Neighborhood messages now as this exists
+   * specifically as a short-term hack to unblock neighborhood level writing.
    * @deprecated
    * This method is only here as a workaround until we have designed a more formal method for client-facing communication
    * from sub-projects of javabuilder.

--- a/org-code-javabuilder/util/src/main/java/org/code/util/FormattedClientMessage.java
+++ b/org-code-javabuilder/util/src/main/java/org/code/util/FormattedClientMessage.java
@@ -16,7 +16,7 @@ public class FormattedClientMessage extends ClientMessage {
    * from sub-projects of javabuilder.
    * @param formattedMessage a message created by ClientMessage.getFormattedMessage
    */
-  public static ClientMessage buildClientMessage(String formattedMessage) {
+  public static FormattedClientMessage buildClientMessage(String formattedMessage) {
     JSONObject message;
     try {
       message = new JSONObject(formattedMessage);

--- a/org-code-javabuilder/util/src/main/java/org/code/util/FormattedClientMessage.java
+++ b/org-code-javabuilder/util/src/main/java/org/code/util/FormattedClientMessage.java
@@ -1,0 +1,40 @@
+package org.code.util;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class FormattedClientMessage extends ClientMessage {
+
+  private FormattedClientMessage(ClientMessageType type, String value, JSONObject detail) {
+    super(type, value, detail);
+  }
+
+  /**
+   * Create a client message from a formatted message. This only supports Neighborhood messages now as this exists specifically as a short-term hack to unblock neighborhood level writing.
+   * @deprecated
+   * This method is only here as a workaround until we have designed a more formal method for client-facing communication
+   * from sub-projects of javabuilder.
+   * @param formattedMessage a message created by ClientMessage.getFormattedMessage
+   */
+  public static ClientMessage buildClientMessage(String formattedMessage) {
+    JSONObject message;
+    try {
+      message = new JSONObject(formattedMessage);
+      String type = message.getString("type");
+      if (!type.equals(ClientMessageType.NEIGHBORHOOD.toString())) {
+        // We only support neighborhood messages now.
+        return null;
+      }
+      String value = message.getString("value");
+      JSONObject detail = null;
+      if (message.has("detail")) {
+        // A message doesn't need a detail object.
+        detail = message.getJSONObject("detail");
+      }
+      return new FormattedClientMessage(ClientMessageType.NEIGHBORHOOD, value, detail);
+    } catch (JSONException e) {
+      // This is not a client message. return null
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
With this change, we set up server-side messaging in Neighborhood in order to send signals to Javalab. 

This is paired with this pr from the code-dot-org repo: https://github.com/code-dot-org/code-dot-org/pull/40616

Task: https://codedotorg.atlassian.net/browse/CSA-340
Neighborhood Doc: https://docs.google.com/document/d/1SqSLogXsOKJD8QexbZAbxCpUGRdNP9Yj7zW8tN6oADI/edit#

### Concern
This PR sets up a hacky, immediately deprecated method of passing messages from Neighborhood to Javabuilder. What we do here is call system.out from Neighborhood. This passes a normal "system out" message to Javabuilder. Javabuilder checks whether the message is formatted as a command from Neighborhood. If so, it passes it to the client as such. 

This has a number of problems: 
1. If a student happens to call System.out on a json string formatted like a Neighborhood command, they will not see their message and Javalab will likely throw an exception.
1. A Java PrintStream does not guarantee when it will call flush(). We could end up with half of a Neighborhood command passed to students. This would print to the user-facing console and would not invoke the intended Neighborhood command.

This should be seen as a hacky workaround to temporarily unblock curriculum writing. We must do a more formal design of this system before users can access it.

Design Task: https://codedotorg.atlassian.net/browse/CSA-342