### PR TITLE
Neighborhood: add all client signals

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserFileData.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserFileData.java
@@ -5,14 +5,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class UserFileData {
   private String text;
-  private boolean visible;
+  private boolean isVisible;
 
   public String getText() {
     return this.text;
   }
 
   public boolean getVisible() {
-    return this.visible;
+    return this.isVisible;
   }
 
   public void setText(String text) {
@@ -20,6 +20,6 @@ public class UserFileData {
   }
 
   public void setVisible(boolean visible) {
-    this.visible = visible;
+    this.isVisible = visible;
   }
 }

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Grid.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Grid.java
@@ -1,6 +1,7 @@
 package org.code.neighborhood;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 public class Grid {
   private GridSquare[][] grid;
@@ -41,12 +42,16 @@ public class Grid {
 
   // Hides all buckets from the screen
   public void hideBuckets() {
-    System.out.println("You hid the buckets");
+    NeighborhoodOutputHandler.sendMessage(
+            new NeighborhoodSignalMessage(NeighborhoodSignalKey.HIDE_BUCKETS, new HashMap<>())
+    );
   }
 
   // Displays all buckets on the screen
   public void showBuckets() {
-    System.out.println("You displayed the buckets");
+    NeighborhoodOutputHandler.sendMessage(
+            new NeighborhoodSignalMessage(NeighborhoodSignalKey.SHOW_BUCKETS, new HashMap<>())
+    );
   }
 
   protected int getSize() {

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/NeighborhoodSignalKey.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/NeighborhoodSignalKey.java
@@ -2,7 +2,7 @@ package org.code.neighborhood;
 
 public enum NeighborhoodSignalKey {
   // Initialize a new painter
-  INITIALIZE,
+  INITIALIZE_PAINTER,
   // Move the painter one space forward
   MOVE,
   // Paint the current location
@@ -14,5 +14,11 @@ public enum NeighborhoodSignalKey {
   // Hide the painter on the screen
   HIDE_PAINTER,
   // Show the painter on the screen
-  SHOW_PAINTER
+  SHOW_PAINTER,
+  // Turn the painter left
+  TURN_LEFT,
+  // Hide all paint buckets
+  HIDE_BUCKETS,
+  // Show all paint buckets
+  SHOW_BUCKETS
 }

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/NeighborhoodSignalKey.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/NeighborhoodSignalKey.java
@@ -1,6 +1,18 @@
 package org.code.neighborhood;
 
 public enum NeighborhoodSignalKey {
+  // Initialize a new painter
+  INITIALIZE,
   // Move the painter one space forward
-  MOVE
+  MOVE,
+  // Paint the current location
+  PAINT,
+  // Remove all paint from current location
+  REMOVE_PAINT,
+  // Take paint from the bucket
+  TAKE_PAINT,
+  // Hide the painter on the screen
+  HIDE_PAINTER,
+  // Show the painter on the screen
+  SHOW_PAINTER
 }

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
@@ -47,6 +47,9 @@ public class Painter {
   /** Turns the painter one compass direction left (i.e. North -> West). */
   public void turnLeft() {
     this.direction = this.direction.turnLeft();
+    HashMap<String, String> details = this.getSignalDetails();
+    details.put("direction", this.direction.getDirectionString());
+    this.sendOutputMessage(NeighborhoodSignalKey.TURN_LEFT, details);
   }
 
   /** Move the painter one square forward in the direction the painter is facing. */
@@ -203,6 +206,6 @@ public class Painter {
     initDetails.put("direction", this.direction.getDirectionString());
     initDetails.put("x", Integer.toString(this.xLocation));
     initDetails.put("y", Integer.toString(this.yLocation));
-    this.sendOutputMessage(NeighborhoodSignalKey.INITIALIZE, initDetails);
+    this.sendOutputMessage(NeighborhoodSignalKey.INITIALIZE_PAINTER, initDetails);
   }
 }

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
@@ -19,6 +19,7 @@ public class Painter {
     this.remainingPaint = 0;
     this.grid = World.getInstance().getGrid();
     this.id = "painter-" + lastId++;
+    this.sendInitializationMessage();
   }
 
   /**
@@ -40,6 +41,7 @@ public class Painter {
       throw new UnsupportedOperationException(ExceptionKeys.INVALID_LOCATION.toString());
     }
     this.id = "painter-" + lastId++;
+    this.sendInitializationMessage();
   }
 
   /** Turns the painter one compass direction left (i.e. North -> West). */
@@ -62,10 +64,9 @@ public class Painter {
     } else {
       throw new UnsupportedOperationException(ExceptionKeys.INVALID_MOVE.toString());
     }
-    HashMap<String, String> details = new HashMap<>();
-    details.put("id", this.id);
+    HashMap<String, String> details = this.getSignalDetails();
     details.put("direction", this.direction.getDirectionString());
-    NeighborhoodOutputHandler.sendMessage(new NeighborhoodSignalMessage(NeighborhoodSignalKey.MOVE, details));
+    this.sendOutputMessage(NeighborhoodSignalKey.MOVE, details);
   }
 
   /**
@@ -77,6 +78,9 @@ public class Painter {
     if (this.remainingPaint > 0) {
       this.grid.getSquare(this.xLocation, this.yLocation).setColor(color);
       this.remainingPaint--;
+      HashMap<String, String> details = this.getSignalDetails();
+      details.put("color", color);
+      this.sendOutputMessage(NeighborhoodSignalKey.PAINT, details);
     } else {
       System.out.println("There is no more paint in the painter's bucket");
     }
@@ -85,6 +89,7 @@ public class Painter {
   /** Removes all paint on the square where the painter is standing. */
   public void scrapePaint() {
     this.grid.getSquare(this.xLocation, this.yLocation).removePaint();
+    this.sendOutputMessage(NeighborhoodSignalKey.REMOVE_PAINT, this.getSignalDetails());
   }
 
   /**
@@ -98,12 +103,12 @@ public class Painter {
 
   /** Hides the painter on the screen. */
   public void hidePainter() {
-    System.out.println("You hid the painter");
+    this.sendOutputMessage(NeighborhoodSignalKey.HIDE_PAINTER, this.getSignalDetails());
   }
 
   /** Shows the painter on the screen. */
   public void showPainter() {
-    System.out.println("You displayed the painter");
+    this.sendOutputMessage(NeighborhoodSignalKey.SHOW_PAINTER, this.getSignalDetails());
   }
 
   /**
@@ -114,6 +119,7 @@ public class Painter {
     if (this.grid.getSquare(this.xLocation, this.yLocation).containsPaint()) {
       this.grid.getSquare(this.xLocation, this.yLocation).collectPaint();
       this.remainingPaint++;
+      this.sendOutputMessage(NeighborhoodSignalKey.TAKE_PAINT, this.getSignalDetails());
     } else {
       System.out.println("There is no paint to collect here");
     }
@@ -180,5 +186,23 @@ public class Painter {
     } else {
       return this.grid.validLocation(this.xLocation - 1, this.yLocation);
     }
+  }
+
+  private HashMap<String, String> getSignalDetails() {
+    HashMap<String, String> details = new HashMap<>();
+    details.put("id", this.id);
+    return details;
+  }
+
+  private void sendOutputMessage(NeighborhoodSignalKey signalKey, HashMap<String, String> details) {
+    NeighborhoodOutputHandler.sendMessage(new NeighborhoodSignalMessage(signalKey, details));
+  }
+
+  private void sendInitializationMessage() {
+    HashMap<String, String> initDetails = this.getSignalDetails();
+    initDetails.put("direction", this.direction.getDirectionString());
+    initDetails.put("x", Integer.toString(this.xLocation));
+    initDetails.put("y", Integer.toString(this.yLocation));
+    this.sendOutputMessage(NeighborhoodSignalKey.INITIALIZE, initDetails);
   }
 }


### PR DESCRIPTION
Add all the signals neighborhood needs to send to the client for various client-facing actions. Move had been implemented previously. This PR adds:
- INITIALIZE
- PAINT
- REMOVE_PAINT
- TAKE_PAINT
- HIDE_PAINTER
- SHOW_PAINTER

These signals will be used on javalab to invoke various painter actions.
As a part of this PR, also updated the variable `visible` on `UserFileData` to be `isVisible` since we have updated the variable on the javalab side.