### PR TITLE
Add Error type and migrate Neighborhood to use the JavabuilderThrowableProtocol

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
@@ -1,8 +1,8 @@
 package dev.javabuilder;
 
 import org.code.javabuilder.*;
-import org.code.protocol.JavabuilderError;
 import org.code.protocol.JavabuilderException;
+import org.code.protocol.JavabuilderRuntimeException;
 
 /**
  * Intended for local testing only. This is a local version of the Javabuilder lambda function. The
@@ -22,7 +22,7 @@ public class LocalMain {
         codeBuilder.buildUserCode();
         codeBuilder.runUserCode();
       }
-    } catch (JavabuilderException | JavabuilderError e) {
+    } catch (JavabuilderException | JavabuilderRuntimeException e) {
       outputAdapter.sendMessage(e.getExceptionMessage());
       System.out.println("\n" + e.getLoggingString());
     } catch (InternalFacingException e) {

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
@@ -1,6 +1,7 @@
 package dev.javabuilder;
 
 import org.code.javabuilder.*;
+import org.code.protocol.JavabuilderError;
 import org.code.protocol.JavabuilderException;
 
 /**
@@ -21,7 +22,7 @@ public class LocalMain {
         codeBuilder.buildUserCode();
         codeBuilder.runUserCode();
       }
-    } catch (JavabuilderException e) {
+    } catch (JavabuilderException | JavabuilderError e) {
       outputAdapter.sendMessage(e.getExceptionMessage());
       System.out.println("\n" + e.getLoggingString());
     } catch (InternalFacingException e) {

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -11,8 +11,8 @@ import javax.websocket.PongMessage;
 import javax.websocket.Session;
 import javax.websocket.server.ServerEndpoint;
 import org.code.javabuilder.*;
-import org.code.protocol.JavabuilderError;
 import org.code.protocol.JavabuilderException;
+import org.code.protocol.JavabuilderRuntimeException;
 import org.code.protocol.Properties;
 
 /**
@@ -64,7 +64,7 @@ public class WebSocketServer {
                   codeBuilder.buildUserCode();
                   codeBuilder.runUserCode();
                 }
-              } catch (JavabuilderException | JavabuilderError e) {
+              } catch (JavabuilderException | JavabuilderRuntimeException e) {
                 outputAdapter.sendMessage(e.getExceptionMessage());
                 outputAdapter.sendMessage(new DebuggingMessage("\n" + e.getLoggingString()));
               } catch (InternalFacingException e) {

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -11,6 +11,7 @@ import javax.websocket.PongMessage;
 import javax.websocket.Session;
 import javax.websocket.server.ServerEndpoint;
 import org.code.javabuilder.*;
+import org.code.protocol.JavabuilderError;
 import org.code.protocol.JavabuilderException;
 import org.code.protocol.Properties;
 
@@ -63,7 +64,7 @@ public class WebSocketServer {
                   codeBuilder.buildUserCode();
                   codeBuilder.runUserCode();
                 }
-              } catch (JavabuilderException e) {
+              } catch (JavabuilderException | JavabuilderError e) {
                 outputAdapter.sendMessage(e.getExceptionMessage());
                 outputAdapter.sendMessage(new DebuggingMessage("\n" + e.getLoggingString()));
               } catch (InternalFacingException e) {

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -8,6 +8,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import java.util.Map;
+import org.code.protocol.JavabuilderError;
 import org.code.protocol.JavabuilderException;
 import org.code.protocol.Properties;
 import org.json.JSONObject;
@@ -71,7 +72,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
         codeBuilder.buildUserCode();
         codeBuilder.runUserCode();
       }
-    } catch (JavabuilderException e) {
+    } catch (JavabuilderException | JavabuilderError e) {
       // Send user-facing exceptions to the user and log the stack trace to CloudWatch
       outputAdapter.sendMessage(e.getExceptionMessage());
       context.getLogger().log(e.getLoggingString());

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -8,8 +8,8 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import java.util.Map;
-import org.code.protocol.JavabuilderError;
 import org.code.protocol.JavabuilderException;
+import org.code.protocol.JavabuilderRuntimeException;
 import org.code.protocol.Properties;
 import org.json.JSONObject;
 
@@ -72,7 +72,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
         codeBuilder.buildUserCode();
         codeBuilder.runUserCode();
       }
-    } catch (JavabuilderException | JavabuilderError e) {
+    } catch (JavabuilderException | JavabuilderRuntimeException e) {
       // Send user-facing exceptions to the user and log the stack trace to CloudWatch
       outputAdapter.sendMessage(e.getExceptionMessage());
       context.getLogger().log(e.getLoggingString());

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Direction.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Direction.java
@@ -56,7 +56,7 @@ public enum Direction {
     } else if (text.equalsIgnoreCase("west")) {
       return WEST;
     } else {
-      throw new UnsupportedOperationException(ExceptionKeys.INVALID_DIRECTION.toString());
+      throw new NeighborhoodRuntimeException(ExceptionKeys.INVALID_DIRECTION);
     }
   }
 }

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Grid.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Grid.java
@@ -36,7 +36,7 @@ public class Grid {
     if (validLocation(x, y)) {
       return this.grid[x][y];
     } else {
-      throw new UnsupportedOperationException(ExceptionKeys.GET_SQUARE_FAILED.toString());
+      throw new NeighborhoodRuntimeException(ExceptionKeys.GET_SQUARE_FAILED);
     }
   }
 

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/GridFactory.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/GridFactory.java
@@ -23,7 +23,7 @@ public class GridFactory {
       fis.close();
       return createGridFromString(new String(data, "UTF-8"));
     } catch (IOException e) {
-      throw new IOException(ExceptionKeys.INVALID_GRID.toString());
+      throw new NeighborhoodRuntimeException(ExceptionKeys.INVALID_GRID);
     }
   }
 
@@ -37,11 +37,11 @@ public class GridFactory {
       JSONArray gridSquares = new JSONArray(parseLine);
       int height = gridSquares.length();
       if (height == 0) {
-        throw new IOException(ExceptionKeys.INVALID_GRID.toString());
+        throw new NeighborhoodRuntimeException(ExceptionKeys.INVALID_GRID);
       }
       int width = ((JSONArray) gridSquares.get(0)).length();
       if (width != height) {
-        throw new IOException(ExceptionKeys.INVALID_GRID.toString());
+        throw new NeighborhoodRuntimeException(ExceptionKeys.INVALID_GRID);
       }
       GridSquare[][] grid = new GridSquare[width][height];
 
@@ -49,7 +49,7 @@ public class GridFactory {
       for (int currentY = 0; currentY < height; currentY++) {
         JSONArray line = (JSONArray) gridSquares.get(currentY);
         if (line.length() != width) {
-          throw new IOException(ExceptionKeys.INVALID_GRID.toString());
+          throw new NeighborhoodRuntimeException(ExceptionKeys.INVALID_GRID);
         }
         for (int currentX = 0; currentX < line.length(); currentX++) {
           JSONObject descriptor = (JSONObject) line.get(currentX);
@@ -66,13 +66,13 @@ public class GridFactory {
               grid[currentX][currentY] = new GridSquare(tileType, assetId);
             }
           } catch (NumberFormatException e) {
-            throw new IOException(ExceptionKeys.INVALID_GRID.toString());
+            throw new NeighborhoodRuntimeException(ExceptionKeys.INVALID_GRID);
           }
         }
       }
       return new Grid(grid);
     } catch (JSONException e) {
-      throw new IOException(ExceptionKeys.INVALID_GRID.toString());
+      throw new NeighborhoodRuntimeException(ExceptionKeys.INVALID_GRID);
     }
   }
 

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/GridSquare.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/GridSquare.java
@@ -34,7 +34,7 @@ public class GridSquare {
   // Sets the color of the square to the given color
   public void setColor(String color) {
     if (!ColorHelpers.isColor(color)) {
-      throw new UnsupportedOperationException(ExceptionKeys.INVALID_COLOR.toString());
+      throw new NeighborhoodRuntimeException(ExceptionKeys.INVALID_COLOR);
     }
     if (this.passable && this.paintCount == 0) {
       this.color = color;

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/NeighborhoodRuntimeException.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/NeighborhoodRuntimeException.java
@@ -1,0 +1,12 @@
+package org.code.neighborhood;
+
+import org.code.protocol.JavabuilderRuntimeException;
+
+public class NeighborhoodRuntimeException extends JavabuilderRuntimeException {
+  protected NeighborhoodRuntimeException(ExceptionKeys key) {
+    super(key);
+  }
+  protected NeighborhoodRuntimeException(ExceptionKeys key, Throwable cause) {
+    super(key, cause);
+  }
+}

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
@@ -38,7 +38,7 @@ public class Painter {
     this.grid = World.getInstance().getGrid();
     int gridSize = this.grid.getSize();
     if (x < 0 || y < 0 || x >= gridSize || y >= gridSize) {
-      throw new UnsupportedOperationException(ExceptionKeys.INVALID_LOCATION.toString());
+      throw new NeighborhoodRuntimeException(ExceptionKeys.INVALID_LOCATION);
     }
     this.id = "painter-" + lastId++;
     this.sendInitializationMessage();
@@ -65,7 +65,7 @@ public class Painter {
         this.xLocation--;
       }
     } else {
-      throw new UnsupportedOperationException(ExceptionKeys.INVALID_MOVE.toString());
+      throw new NeighborhoodRuntimeException(ExceptionKeys.INVALID_MOVE);
     }
     HashMap<String, String> details = this.getSignalDetails();
     details.put("direction", this.direction.getDirectionString());

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/DirectionTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/DirectionTest.java
@@ -32,7 +32,7 @@ public class DirectionTest {
   void throwsErrorIfBadDirectionGiven() {
     Exception exception =
         assertThrows(
-            UnsupportedOperationException.class,
+            NeighborhoodRuntimeException.class,
             () -> {
               Direction.fromString("not a direction");
             });

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/GridFactoryTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/GridFactoryTest.java
@@ -35,7 +35,7 @@ public class GridFactoryTest {
     GridFactory gridFactory = new GridFactory();
     Exception exception =
         assertThrows(
-            IOException.class,
+            NeighborhoodRuntimeException.class,
             () -> {
               gridFactory.createGridFromString("not valid json here:");
             });
@@ -49,7 +49,7 @@ public class GridFactoryTest {
     GridFactory gridFactory = new GridFactory();
     Exception exception =
         assertThrows(
-            IOException.class,
+            NeighborhoodRuntimeException.class,
             () -> {
               gridFactory.createGridFromString(
                   "[[\n{\"tileType\": 1, \"assetId\": 0}, {\"tileType\": 1, \"assetId\": 0}], \n[{\"tileType\": 1, \"assetId\": 0}]]");
@@ -63,7 +63,7 @@ public class GridFactoryTest {
     GridFactory gridFactory = new GridFactory();
     Exception exception =
         assertThrows(
-            IOException.class,
+            NeighborhoodRuntimeException.class,
             () -> {
               gridFactory.createGridFromString(
                   "[[\n{\"tileType\": 1, \"assetId\": 0}], \n[{\"tileType\": 1, \"assetId\": 0}]]");
@@ -77,7 +77,7 @@ public class GridFactoryTest {
     GridFactory gridFactory = new GridFactory();
     Exception exception =
         assertThrows(
-            IOException.class,
+            NeighborhoodRuntimeException.class,
             () -> {
               gridFactory.createGridFromString("[[\n{\"tileType\": \"invalid\", \"assetId\": 0}]]");
             });
@@ -90,7 +90,7 @@ public class GridFactoryTest {
     GridFactory gridFactory = new GridFactory();
     Exception exception =
         assertThrows(
-            IOException.class,
+            NeighborhoodRuntimeException.class,
             () -> {
               gridFactory.createGridFromString("[[\n{\"assetId\": \"invalid\", \"tileType\": 1}]]");
             });
@@ -103,7 +103,7 @@ public class GridFactoryTest {
     GridFactory gridFactory = new GridFactory();
     Exception exception =
         assertThrows(
-            IOException.class,
+            NeighborhoodRuntimeException.class,
             () -> {
               gridFactory.createGridFromString(
                   "[[\n{\"tileType\": 1, \"value\": \"invalid\", \"assetId\": 0}]]");
@@ -117,7 +117,7 @@ public class GridFactoryTest {
     GridFactory gridFactory = new GridFactory();
     Exception exception =
         assertThrows(
-            IOException.class,
+            NeighborhoodRuntimeException.class,
             () -> {
               gridFactory.createGridFromString("[]");
             });

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/GridSquareTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/GridSquareTest.java
@@ -83,7 +83,7 @@ public class GridSquareTest {
     assertEquals(s.getColor(), "red");
     Exception exception =
         assertThrows(
-            UnsupportedOperationException.class,
+            NeighborhoodRuntimeException.class,
             () -> {
               s.setColor("r");
             });

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/GridTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/GridTest.java
@@ -45,7 +45,7 @@ public class GridTest {
     Grid grid = new Grid(squares);
     Exception exception =
         assertThrows(
-            UnsupportedOperationException.class,
+            NeighborhoodRuntimeException.class,
             () -> {
               GridSquare sq = grid.getSquare(-1, -1);
             });

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
@@ -38,7 +38,7 @@ public class PainterTest {
   void constructorThrowsErrorIfDirectionInvalid() {
     Exception exception =
         assertThrows(
-            UnsupportedOperationException.class,
+            NeighborhoodRuntimeException.class,
             () -> {
               new Painter(0, 0, "not a direction", 5);
             });
@@ -50,7 +50,7 @@ public class PainterTest {
   void constructorThrowsErrorIfStartLocationInvalid() {
     Exception exception =
         assertThrows(
-            UnsupportedOperationException.class,
+            NeighborhoodRuntimeException.class,
             () -> {
               new Painter(-1, -1, "West", 5);
             });
@@ -72,7 +72,7 @@ public class PainterTest {
     Painter painter = new Painter(0, 0, "North", 5);
     Exception exception =
         assertThrows(
-            UnsupportedOperationException.class,
+            NeighborhoodRuntimeException.class,
             () -> {
               painter.move();
             });

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderError.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderError.java
@@ -5,17 +5,17 @@ import java.io.StringWriter;
 import java.util.HashMap;
 
 /**
- * Parent exception for all exceptions that will be displayed to the user.
+ * Parent error for all errors that will be displayed to the user.
  */
-public abstract class JavabuilderException extends Exception implements JavabuilderThrowableProtocol {
+public abstract class JavabuilderError extends Error implements JavabuilderThrowableProtocol {
   private final Enum key;
 
-  protected JavabuilderException(Enum key) {
+  protected JavabuilderError(Enum key) {
     super(key.toString());
     this.key = key;
   }
 
-  protected JavabuilderException(Enum key, Throwable cause) {
+  protected JavabuilderError(Enum key, Throwable cause) {
     super(key.toString(), cause);
     this.key = key;
   }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderRuntimeException.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderRuntimeException.java
@@ -7,15 +7,15 @@ import java.util.HashMap;
 /**
  * Parent error for all errors that will be displayed to the user.
  */
-public abstract class JavabuilderError extends Error implements JavabuilderThrowableProtocol {
+public abstract class JavabuilderRuntimeException extends RuntimeException implements JavabuilderThrowableProtocol {
   private final Enum key;
 
-  protected JavabuilderError(Enum key) {
+  protected JavabuilderRuntimeException(Enum key) {
     super(key.toString());
     this.key = key;
   }
 
-  protected JavabuilderError(Enum key, Throwable cause) {
+  protected JavabuilderRuntimeException(Enum key, Throwable cause) {
     super(key.toString(), cause);
     this.key = key;
   }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderThrowableProtocol.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderThrowableProtocol.java
@@ -1,0 +1,6 @@
+package org.code.protocol;
+
+public interface JavabuilderThrowableProtocol {
+  JavabuilderThrowableMessage getExceptionMessage();
+  String getLoggingString();
+}


### PR DESCRIPTION
This is a prefactor for a larger change that unifies our output protocol to enable mini-apps to use our output adapter. The full change can be viewed here: https://github.com/code-dot-org/javabuilder/pull/41 

This adds a `JavabuilderRuntimeException` type that can be used for [unchecked exceptions](https://www.geeksforgeeks.org/checked-vs-unchecked-exceptions-in-java/). This is especially important for mini-apps such as Neighborhood where our setup code can throw errors that should not be caught by the student. As part of this change, Neighborhood is migrated to using this Error type.