### PR TITLE
Switched coordinates so 0,0 is in the top left

### DIFF
--- a/org-code-javabuilder/neighborhood/build.gradle
+++ b/org-code-javabuilder/neighborhood/build.gradle
@@ -31,6 +31,10 @@ dependencies {
     implementation project(':protocol')
 }
 
+test {
+    useJUnitPlatform()
+}
+
 // Builds the Neighborhood fat-jar (i.e. jar with all dependencies) and copies it to the resources
 // folder in the javabuilder sub-project (currently named 'lib'). This will allow student code to
 // access the Neighborhood package.

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Grid.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Grid.java
@@ -15,7 +15,7 @@ public class Grid {
   }
 
   public void printGrid() {
-    for (int y = height - 1; y >= 0; y--) {
+    for (int y = 0; y < height; y++) {
       ArrayList<String> squares = new ArrayList<String>();
       for (int x = 0; x < width; x++) {
         squares.add(this.grid[x][y].getPrintableDescription());

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/GridFactory.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/GridFactory.java
@@ -47,10 +47,8 @@ public class GridFactory {
 
       // We start at the maximum height because we're reading the grid from top to bottom in the
       // file.
-      int currentHeight = height;
       for (int currentY = 0; currentY < height; currentY++) {
-        currentHeight--;
-        JSONArray line = (JSONArray) gridSquares.get(currentHeight);
+        JSONArray line = (JSONArray) gridSquares.get(currentY);
         if (line.length() != width) {
           throw new IOException(ExceptionKeys.INVALID_GRID.toString());
         }

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/GridFactory.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/GridFactory.java
@@ -45,8 +45,7 @@ public class GridFactory {
       }
       GridSquare[][] grid = new GridSquare[width][height];
 
-      // We start at the maximum height because we're reading the grid from top to bottom in the
-      // file.
+      // Read the grid from top to bottom
       for (int currentY = 0; currentY < height; currentY++) {
         JSONArray line = (JSONArray) gridSquares.get(currentY);
         if (line.length() != width) {

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
@@ -56,9 +56,9 @@ public class Painter {
   public void move() {
     if (this.isValidMovement(this.direction)) {
       if (this.direction.isNorth()) {
-        this.yLocation++;
-      } else if (this.direction.isSouth()) {
         this.yLocation--;
+      } else if (this.direction.isSouth()) {
+        this.yLocation++;
       } else if (this.direction.isEast()) {
         this.xLocation++;
       } else {
@@ -181,9 +181,9 @@ public class Painter {
    */
   private boolean isValidMovement(Direction movementDirection) {
     if (movementDirection.isNorth()) {
-      return this.grid.validLocation(this.xLocation, this.yLocation + 1);
-    } else if (movementDirection.isSouth()) {
       return this.grid.validLocation(this.xLocation, this.yLocation - 1);
+    } else if (movementDirection.isSouth()) {
+      return this.grid.validLocation(this.xLocation, this.yLocation + 1);
     } else if (movementDirection.isEast()) {
       return this.grid.validLocation(this.xLocation + 1, this.yLocation);
     } else {

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
@@ -84,11 +84,12 @@ public class PainterTest {
   void movePrintsNewLocationIfValidMovement() {
     World w = new World(multiSquareGrid);
     World.setInstance(w);
-    Painter painter = new Painter(0, 0, "East", 5);
+    Painter painter = new Painter(0, 0, "West", 5);
     painter.turnLeft();
-    assertTrue(painter.canMove("North"));
+    assertTrue(painter.canMove("South"));
     painter.move();
-    assertTrue(outputStreamCaptor.toString().trim().contains("New (x,y) : (0,1)"));
+    assertTrue(outputStreamCaptor.toString().trim().contains("direction"));
+    assertTrue(outputStreamCaptor.toString().trim().contains("south"));
   }
 
   @Test

--- a/org-code-javabuilder/protocol/build.gradle
+++ b/org-code-javabuilder/protocol/build.gradle
@@ -29,3 +29,7 @@ dependencies {
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
 }
+
+test {
+    useJUnitPlatform()
+}


### PR DESCRIPTION
Originally, we wanted to set up Neighborhood with the origin in the bottom left. However, since we are planning to support pixel operations on the curriculum units following Neighborhood, we'll want to use origin in the top left for consistency. This updates the coordinates.

This pairs with a similar change in the code-dot-org repo: https://github.com/code-dot-org/code-dot-org/pull/40889

![originTopLeft](https://user-images.githubusercontent.com/8324574/120408247-7e869700-c303-11eb-967d-129b08c841fd.gif)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- spec: [Slack discussion](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1622146181166200)
- jira ticket: [CSA-407](https://codedotorg.atlassian.net/browse/CSA-407)