### PR TITLE
Theater: Add GifWriter

### DIFF
--- a/org-code-javabuilder/theater/src/main/java/dev/theater/LocalTheater.java
+++ b/org-code-javabuilder/theater/src/main/java/dev/theater/LocalTheater.java
@@ -7,8 +7,8 @@ import org.code.theater.CatImage;
 public class LocalTheater {
   public static void main(String[] args) throws IOException {
     CatImage image = new CatImage();
-    image.buildImageFilter();
-    image.buildCanvas();
+    image.buildImageFilter(0);
+    image.buildCanvas(1000);
     image.play();
   }
 }

--- a/org-code-javabuilder/theater/src/main/java/dev/theater/LocalTheater.java
+++ b/org-code-javabuilder/theater/src/main/java/dev/theater/LocalTheater.java
@@ -1,12 +1,14 @@
 package dev.theater;
 
+import java.io.IOException;
 import org.code.theater.CatImage;
 
 /** Intended for local testing only. */
 public class LocalTheater {
-  public static void main(String[] args) {
-    CatImage image = new CatImage(null);
+  public static void main(String[] args) throws IOException {
+    CatImage image = new CatImage();
     image.buildImageFilter();
     image.buildCanvas();
+    image.play();
   }
 }

--- a/org-code-javabuilder/theater/src/main/java/dev/theater/LocalTheater.java
+++ b/org-code-javabuilder/theater/src/main/java/dev/theater/LocalTheater.java
@@ -1,11 +1,10 @@
 package dev.theater;
 
-import java.io.IOException;
 import org.code.theater.CatImage;
 
 /** Intended for local testing only. */
 public class LocalTheater {
-  public static void main(String[] args) throws IOException {
+  public static void main(String[] args) {
     CatImage image = new CatImage();
     image.buildImageFilter(0);
     image.buildCanvas(1000);

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/CatImage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/CatImage.java
@@ -49,7 +49,7 @@ public class CatImage {
 
     ImageProcessor ip = image.getProcessor();
     BufferedImage bufferedImage = (BufferedImage) ip.createImage();
-    this.gifWriter.writeToSequence(bufferedImage, 1000);
+    this.gifWriter.writeToGif(bufferedImage, 1000);
     // outputAdapter.sendMessage(ImageEncoder.encodeImageToMessage(bufferedImage));
   }
 
@@ -87,7 +87,7 @@ public class CatImage {
     // IJ.save(image, "<my local directory>\beach.gif");
 
     BufferedImage bufferedImage = (BufferedImage) ip.createImage();
-    this.gifWriter.writeToSequence(bufferedImage, 1000);
+    this.gifWriter.writeToGif(bufferedImage, 1000);
     // outputAdapter.sendMessage(ImageEncoder.encodeImageToMessage(bufferedImage));
   }
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/CatImage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/CatImage.java
@@ -32,7 +32,7 @@ public class CatImage {
     this.outputAdapter = outputAdapter;
   }
 
-  public void buildImageFilter() throws IOException {
+  public void buildImageFilter(int delay) {
     ImagePlus image = null;
     try {
       image =
@@ -49,8 +49,7 @@ public class CatImage {
 
     ImageProcessor ip = image.getProcessor();
     BufferedImage bufferedImage = (BufferedImage) ip.createImage();
-    this.gifWriter.writeToGif(bufferedImage, 1000);
-    // outputAdapter.sendMessage(ImageEncoder.encodeImageToMessage(bufferedImage));
+    this.gifWriter.writeToGif(bufferedImage, delay);
   }
 
   public void play() throws IOException {
@@ -58,7 +57,7 @@ public class CatImage {
     outputAdapter.sendMessage(ImageEncoder.encodeStreamToMessage(this.outputStream));
   }
 
-  public void buildCanvas() throws IOException {
+  public void buildCanvas(int delay) {
     ImagePlus image = IJ.createImage("test", 300, 150, 1, 24);
     ImageProcessor ip = image.getProcessor();
 
@@ -87,7 +86,6 @@ public class CatImage {
     // IJ.save(image, "<my local directory>\beach.gif");
 
     BufferedImage bufferedImage = (BufferedImage) ip.createImage();
-    this.gifWriter.writeToGif(bufferedImage, 1000);
-    // outputAdapter.sendMessage(ImageEncoder.encodeImageToMessage(bufferedImage));
+    this.gifWriter.writeToGif(bufferedImage, delay);
   }
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/CatImage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/CatImage.java
@@ -6,7 +6,6 @@ import ij.process.ImageProcessor;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import org.code.protocol.GlobalProtocol;
@@ -22,11 +21,11 @@ public class CatImage {
   private final GifWriter gifWriter;
   private final ByteArrayOutputStream outputStream;
 
-  public CatImage() throws IOException {
+  public CatImage() {
     this(GlobalProtocol.getInstance().getOutputAdapter());
   }
 
-  public CatImage(OutputAdapter outputAdapter) throws IOException {
+  public CatImage(OutputAdapter outputAdapter) {
     this.outputStream = new ByteArrayOutputStream();
     this.gifWriter = new GifWriter(this.outputStream);
     this.outputAdapter = outputAdapter;
@@ -52,7 +51,8 @@ public class CatImage {
     this.gifWriter.writeToGif(bufferedImage, delay);
   }
 
-  public void play() throws IOException {
+  // Play the created gif (close gif writer and send message).
+  public void play() {
     this.gifWriter.close();
     outputAdapter.sendMessage(ImageEncoder.encodeStreamToMessage(this.outputStream));
   }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
@@ -11,9 +11,10 @@ import javax.imageio.stream.ImageOutputStream;
 import org.code.protocol.InternalErrorKey;
 import org.code.protocol.InternalJavabuilderError;
 
-// Writer to generate a gif from a set of images. The gif will be stored in the given
-// ByteArrayOutputStream.
-// Adapted from https://memorynotfound.com/generate-gif-image-java-delay-infinite-loop-example/
+/**
+ * Writer to generate a gif from a set of images. The gif will be stored in the given
+ * ByteArrayOutputStream.
+ */
 public class GifWriter {
   private ImageWriter writer;
   private ImageWriteParam params;
@@ -31,6 +32,12 @@ public class GifWriter {
     }
   }
 
+  /**
+   * Write the given image as the next frame of the gif.
+   *
+   * @param img BufferedImage
+   * @param delay delay in milliseconds until the next frame of the gif.
+   */
   public void writeToGif(BufferedImage img, int delay) {
     try {
       this.writer.writeToSequence(
@@ -40,6 +47,10 @@ public class GifWriter {
     }
   }
 
+  /**
+   * Close the gif stream and flush any remaining bytes. Any updates after close will throw an
+   * exception because the writer has been closed.
+   */
   public void close() {
     try {
       this.writer.endWriteSequence();
@@ -49,6 +60,15 @@ public class GifWriter {
     }
   }
 
+  /**
+   * Update the metadata for the next frame with the given delay and image type. See Gif metadata
+   * specification here:
+   * https://javadoc.scijava.org/Java7/javax/imageio/metadata/doc-files/gif_metadata.html
+   *
+   * @param delay int delay in milliseconds after this frame
+   * @param imageType int
+   * @return Updated IIOMetadata for the next frame
+   */
   private IIOMetadata getMetadataForFrame(int delay, int imageType) {
     IIOMetadata metadata =
         this.writer.getDefaultImageMetadata(
@@ -60,6 +80,7 @@ public class GifWriter {
     graphicsControlExtensionNode.setAttribute("disposalMethod", "none");
     graphicsControlExtensionNode.setAttribute("userInputFlag", "FALSE");
     graphicsControlExtensionNode.setAttribute("transparentColorFlag", "FALSE");
+    // delay is expected in hundredths of a second, divide milliseconds by 10
     graphicsControlExtensionNode.setAttribute("delayTime", Integer.toString(delay / 10));
     graphicsControlExtensionNode.setAttribute("transparentColorIndex", "0");
 
@@ -71,6 +92,13 @@ public class GifWriter {
     return metadata;
   }
 
+  /**
+   * Find metadata node with the given name from the rootNode
+   *
+   * @param rootNode
+   * @param nodeName
+   * @return Requested IIOMetadataNode
+   */
   private static IIOMetadataNode getNode(IIOMetadataNode rootNode, String nodeName) {
     int nNodes = rootNode.getLength();
     for (int i = 0; i < nNodes; i++) {

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
@@ -25,6 +25,16 @@ public class GifWriter {
     this.writer.prepareWriteSequence(null);
   }
 
+  public void writeToGif(BufferedImage img, int delay) throws IOException {
+    this.writer.writeToSequence(
+        new IIOImage(img, null, getMetadataForFrame(delay, img.getType())), params);
+  }
+
+  public void close() throws IOException {
+    this.writer.endWriteSequence();
+    this.imageOutputStream.flush();
+  }
+
   private IIOMetadata getMetadataForFrame(int delay, int imageType) throws IIOInvalidTreeException {
     IIOMetadata metadata =
         this.writer.getDefaultImageMetadata(
@@ -53,15 +63,5 @@ public class GifWriter {
     IIOMetadataNode node = new IIOMetadataNode(nodeName);
     rootNode.appendChild(node);
     return (node);
-  }
-
-  public void writeToSequence(BufferedImage img, int delay) throws IOException {
-    this.writer.writeToSequence(
-        new IIOImage(img, null, getMetadataForFrame(delay, img.getType())), params);
-  }
-
-  public void close() throws IOException {
-    this.writer.endWriteSequence();
-    this.imageOutputStream.flush();
   }
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
@@ -36,7 +36,7 @@ public class GifWriter {
    * Write the given image as the next frame of the gif.
    *
    * @param img BufferedImage
-   * @param delay delay in milliseconds until the next frame of the gif.
+   * @param delay delay in milliseconds after this frame of the gif.
    */
   public void writeToGif(BufferedImage img, int delay) {
     try {
@@ -61,13 +61,13 @@ public class GifWriter {
   }
 
   /**
-   * Update the metadata for the next frame with the given delay and image type. See Gif metadata
+   * Get the metadata for the next frame with the given delay and image type. See Gif metadata
    * specification here:
    * https://javadoc.scijava.org/Java7/javax/imageio/metadata/doc-files/gif_metadata.html
    *
    * @param delay int delay in milliseconds after this frame
    * @param imageType int
-   * @return Updated IIOMetadata for the next frame
+   * @return IIOMetadata for the next frame
    */
   private IIOMetadata getMetadataForFrame(int delay, int imageType) {
     IIOMetadata metadata =

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
@@ -1,0 +1,67 @@
+package org.code.theater;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import javax.imageio.*;
+import javax.imageio.metadata.IIOInvalidTreeException;
+import javax.imageio.metadata.IIOMetadata;
+import javax.imageio.metadata.IIOMetadataNode;
+import javax.imageio.stream.ImageOutputStream;
+
+// Writer to generate a gif from a set of images.
+// Adapted from https://memorynotfound.com/generate-gif-image-java-delay-infinite-loop-example/
+public class GifWriter {
+  private ImageWriter writer;
+  private ImageWriteParam params;
+  private ImageOutputStream imageOutputStream;
+
+  public GifWriter(ByteArrayOutputStream out) throws IOException {
+    this.imageOutputStream = ImageIO.createImageOutputStream(out);
+    this.writer = ImageIO.getImageWritersBySuffix("gif").next();
+    this.params = writer.getDefaultWriteParam();
+
+    this.writer.setOutput(this.imageOutputStream);
+    this.writer.prepareWriteSequence(null);
+  }
+
+  private IIOMetadata getMetadataForFrame(int delay, int imageType) throws IIOInvalidTreeException {
+    IIOMetadata metadata =
+        this.writer.getDefaultImageMetadata(
+            ImageTypeSpecifier.createFromBufferedImageType(imageType), params);
+    String metaFormatName = metadata.getNativeMetadataFormatName();
+    IIOMetadataNode root = (IIOMetadataNode) metadata.getAsTree(metaFormatName);
+
+    IIOMetadataNode graphicsControlExtensionNode = getNode(root, "GraphicControlExtension");
+    graphicsControlExtensionNode.setAttribute("disposalMethod", "none");
+    graphicsControlExtensionNode.setAttribute("userInputFlag", "FALSE");
+    graphicsControlExtensionNode.setAttribute("transparentColorFlag", "FALSE");
+    graphicsControlExtensionNode.setAttribute("delayTime", Integer.toString(delay / 10));
+    graphicsControlExtensionNode.setAttribute("transparentColorIndex", "0");
+
+    metadata.setFromTree(metaFormatName, root);
+    return metadata;
+  }
+
+  private static IIOMetadataNode getNode(IIOMetadataNode rootNode, String nodeName) {
+    int nNodes = rootNode.getLength();
+    for (int i = 0; i < nNodes; i++) {
+      if (rootNode.item(i).getNodeName().equalsIgnoreCase(nodeName)) {
+        return (IIOMetadataNode) rootNode.item(i);
+      }
+    }
+    IIOMetadataNode node = new IIOMetadataNode(nodeName);
+    rootNode.appendChild(node);
+    return (node);
+  }
+
+  public void writeToSequence(BufferedImage img, int delay) throws IOException {
+    this.writer.writeToSequence(
+        new IIOImage(img, null, getMetadataForFrame(delay, img.getType())), params);
+  }
+
+  public void close() throws IOException {
+    this.writer.endWriteSequence();
+    this.imageOutputStream.flush();
+  }
+}

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/ImageEncoder.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/ImageEncoder.java
@@ -1,49 +1,20 @@
 package org.code.theater;
 
-import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
 import java.util.Base64;
 import java.util.HashMap;
-import javax.imageio.ImageIO;
-import org.apache.commons.io.FileUtils;
-import org.code.protocol.InternalErrorKey;
-import org.code.protocol.InternalJavabuilderError;
 
 public class ImageEncoder {
   /**
-   * Takes a buffered image and converts it to an encoding that can be passed across the WebSocket
-   * connection. We expect visual elements to be gifs in a base64 encoding
+   * Takes a ByteArrayOutputStream representing an image and convert it to an encoding that can be
+   * passed across the WebSocket connection. We expect visual elements to be gifs in a base64
+   * encoding
    *
-   * @param image the image to encode
+   * @param stream the stream to encode
    * @return a TheaterMessage with Value "VISUAL" and detail set to {image: "base64EncodedImage"}
    */
-  public static TheaterMessage encodeImageToMessage(BufferedImage image) {
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    try {
-      ImageIO.write(image, "gif", out);
-    } catch (IOException e) {
-      throw new InternalJavabuilderError(InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION);
-    }
-
-    String encodedString = Base64.getEncoder().encodeToString(out.toByteArray());
-    HashMap<String, String> message = new HashMap<>();
-    message.put("image", encodedString);
-    return new TheaterMessage(TheaterSignalKey.VISUAL, message);
-  }
-
   public static TheaterMessage encodeStreamToMessage(ByteArrayOutputStream stream) {
-    System.out.println("stream size: " + stream.size());
     String encodedString = Base64.getEncoder().encodeToString(stream.toByteArray());
-    HashMap<String, String> message = new HashMap<>();
-    message.put("image", encodedString);
-    return new TheaterMessage(TheaterSignalKey.VISUAL, message);
-  }
-
-  public static TheaterMessage encodeFileToMessage(String filePath) throws IOException {
-    byte[] fileContent = FileUtils.readFileToByteArray(new File(filePath));
-    String encodedString = Base64.getEncoder().encodeToString(fileContent);
     HashMap<String, String> message = new HashMap<>();
     message.put("image", encodedString);
     return new TheaterMessage(TheaterSignalKey.VISUAL, message);

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/ImageEncoder.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/ImageEncoder.java
@@ -2,10 +2,12 @@ package org.code.theater;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.util.Base64;
 import java.util.HashMap;
 import javax.imageio.ImageIO;
+import org.apache.commons.io.FileUtils;
 import org.code.protocol.InternalErrorKey;
 import org.code.protocol.InternalJavabuilderError;
 
@@ -26,6 +28,22 @@ public class ImageEncoder {
     }
 
     String encodedString = Base64.getEncoder().encodeToString(out.toByteArray());
+    HashMap<String, String> message = new HashMap<>();
+    message.put("image", encodedString);
+    return new TheaterMessage(TheaterSignalKey.VISUAL, message);
+  }
+
+  public static TheaterMessage encodeStreamToMessage(ByteArrayOutputStream stream) {
+    System.out.println("stream size: " + stream.size());
+    String encodedString = Base64.getEncoder().encodeToString(stream.toByteArray());
+    HashMap<String, String> message = new HashMap<>();
+    message.put("image", encodedString);
+    return new TheaterMessage(TheaterSignalKey.VISUAL, message);
+  }
+
+  public static TheaterMessage encodeFileToMessage(String filePath) throws IOException {
+    byte[] fileContent = FileUtils.readFileToByteArray(new File(filePath));
+    String encodedString = Base64.getEncoder().encodeToString(fileContent);
     HashMap<String, String> message = new HashMap<>();
     message.put("image", encodedString);
     return new TheaterMessage(TheaterSignalKey.VISUAL, message);

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/GifWriterTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/GifWriterTest.java
@@ -1,0 +1,18 @@
+package org.code.theater;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class GifWriterTest {
+  @Test
+  public void writesToStream() {
+    ByteArrayOutputStream stream = new ByteArrayOutputStream();
+    GifWriter writer = new GifWriter(stream);
+    writer.writeToGif(new BufferedImage(1, 1, 1), 1000);
+    writer.writeToGif(new BufferedImage(1, 1, 1), 1000);
+    writer.close();
+    Assertions.assertNotEquals(0, stream.size());
+  }
+}

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/ImageEncoderTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/ImageEncoderTest.java
@@ -1,6 +1,9 @@
 package org.code.theater;
 
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import javax.imageio.ImageIO;
 import org.code.protocol.ClientMessageType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -8,14 +11,17 @@ import org.junit.jupiter.api.Test;
 public class ImageEncoderTest {
   @Test
   public void returnsTheaterMessageWithVisualKey() {
-    TheaterMessage message = ImageEncoder.encodeImageToMessage(new BufferedImage(1, 1, 1));
+    TheaterMessage message = ImageEncoder.encodeStreamToMessage(new ByteArrayOutputStream());
     Assertions.assertEquals(message.getType(), ClientMessageType.THEATER);
     Assertions.assertEquals(message.getValue(), TheaterSignalKey.VISUAL.toString());
   }
 
   @Test
-  public void returnsBase64Image() {
-    TheaterMessage message = ImageEncoder.encodeImageToMessage(new BufferedImage(1, 1, 1));
+  public void returnsBase64Image() throws IOException {
+    BufferedImage testImage = new BufferedImage(1, 1, 1);
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    ImageIO.write(testImage, "gif", outputStream);
+    TheaterMessage message = ImageEncoder.encodeStreamToMessage(outputStream);
     Assertions.assertTrue(message.getDetail().toString().contains("\"image\""));
     Assertions.assertTrue(
         message


### PR DESCRIPTION
Add a new GifWriter class which writes `BufferedImage`s to a `ByteArrayOutputStream` to create a gif. Each frame of the gif specifies the delay between it and the next frame. That gif can then be sent as an encoded Base64 String to the client. 

`GifWriter` can only generate one gif per instantiation, and the consuming class must call `close` in order to complete the gif. The `CatImage` sample program now includes a `play` method that closes the gif and sends it to the client. This PR also updates `ImageEncoder` to accept a `ByteArrayOutputStream` instead of a single `BufferedImage`.

Note: we will need to update the code-dot-org client to accept a gif properly, as of now it uses a canvas which will only display the first frame of the gif. We can update to use an `img` to show the gif fully.