### PR TITLE
Add git hook back in and ensure mini apps are built when the websocket server is launched

### DIFF
--- a/org-code-javabuilder/lib/build.gradle
+++ b/org-code-javabuilder/lib/build.gradle
@@ -72,4 +72,6 @@ build.dependsOn installGitHook
 afterEvaluate {
     tasks.prepareInplaceWebAppFolder.dependsOn project(':neighborhood').getTasksByName('buildNeighborhood', false)
     tasks.prepareInplaceWebAppFolder.dependsOn project(':theater').getTasksByName('buildTheater', false)
+    // This ensures updates to the githook will be installed
+    tasks.prepareInplaceWebAppFolder.dependsOn installGitHook
 }

--- a/org-code-javabuilder/lib/build.gradle
+++ b/org-code-javabuilder/lib/build.gradle
@@ -40,11 +40,6 @@ test {
     useJUnitPlatform()
 }
 
-task packageSmall(type: Zip) {
-    from compileJava
-    from processResources
-}
-
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
@@ -55,8 +50,6 @@ gretty {
     contextPath = '/'
 }
 
-build.dependsOn packageSmall
-
 task buildZip(type: Zip) {
     from project(':neighborhood').getTasksByName('buildNeighborhood', false)
     from project(':theater').getTasksByName('buildTheater', false)
@@ -65,4 +58,18 @@ task buildZip(type: Zip) {
     into('lib') {
         from configurations.runtimeClasspath
     }
+}
+
+task installGitHook(type: Copy) {
+    from new File(rootProject.rootDir, 'scripts/pre-commit')
+    into { new File(rootProject.rootDir, '../.git/hooks') }
+    fileMode 0777
+}
+
+build.dependsOn buildZip
+build.dependsOn installGitHook
+
+afterEvaluate {
+    tasks.prepareInplaceWebAppFolder.dependsOn project(':neighborhood').getTasksByName('buildNeighborhood', false)
+    tasks.prepareInplaceWebAppFolder.dependsOn project(':theater').getTasksByName('buildTheater', false)
 }

--- a/org-code-javabuilder/scripts/pre-commit
+++ b/org-code-javabuilder/scripts/pre-commit
@@ -1,9 +1,12 @@
+#!/bin/sh
 org-code-javabuilder/gradlew verGJF -p org-code-javabuilder
+LINT_RESULT=$?
 org-code-javabuilder/gradlew test -p org-code-javabuilder
-RESULT=$?
+TEST_RESULT=$?
 
 RED='\033[0;31m'
 
 # return 1 exit code if running checks fails
-[ $RESULT -ne 0 ] && echo "${RED}\nJava linting errors were detected. These can be fixed by running 'gradle goJF'\n" && exit 1
+[ $LINT_RESULT -ne 0 ] && echo "${RED}\nJava linting errors were detected. These can be fixed by running 'gradle goJF'\n" && exit 1
+[ $TEST_RESULT -ne 0 ] && echo "${RED}\nSome tests failed. Run 'org-code-javabuilder/gradlew test' to see which tests failed.\n" && exit 1
 exit 0

--- a/org-code-javabuilder/scripts/pre-commit
+++ b/org-code-javabuilder/scripts/pre-commit
@@ -1,4 +1,5 @@
 org-code-javabuilder/gradlew verGJF -p org-code-javabuilder
+org-code-javabuilder/gradlew test -p org-code-javabuilder
 RESULT=$?
 
 RED='\033[0;31m'


### PR DESCRIPTION
This cleans up our build.gradle to do a couple things:

1. Ensure the pre-commit git hook gets added back in. We now run tests and the linter every commit. This can be skipped by using `git commit --no-verify`
2. Ensure the Theater and Neighborhood mini apps get built when the appRun command is triggered.