### PR TITLE
Theater API: implement geometry drawing methods

### DIFF
--- a/org-code-javabuilder/media/src/main/java/org/code/media/Color.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/Color.java
@@ -13,7 +13,9 @@ public class Color {
    * @throws IllegalArgumentException if the value specifies an unsupported color name or illegal
    *     hexadecimal value
    */
-  public Color(String color) throws IllegalArgumentException {}
+  public Color(String color) throws IllegalArgumentException {
+    // TODO: Implement this method
+  }
 
   /**
    * Create a new color based on the red, green, and blue values provided.

--- a/org-code-javabuilder/media/src/main/java/org/code/media/Color.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/Color.java
@@ -2,6 +2,10 @@ package org.code.media;
 
 public class Color {
 
+  private int red;
+  private int green;
+  private int blue;
+
   /**
    * Creates a color from a string representation.
    *
@@ -18,7 +22,11 @@ public class Color {
    * @param green the green value from 0 - 255
    * @param blue the blue value from 0 - 255
    */
-  public Color(int red, int green, int blue) {}
+  public Color(int red, int green, int blue) {
+    this.red = red;
+    this.green = green;
+    this.blue = blue;
+  }
 
   /**
    * Returns the amount of red (ranging from 0 to 255).
@@ -26,7 +34,7 @@ public class Color {
    * @return a number representing the red value (between 0 and 255)
    */
   public int getRed() {
-    return -1;
+    return this.red;
   }
 
   /**
@@ -35,7 +43,7 @@ public class Color {
    * @return a number representing the green value (between 0 and 255) of the pixel.
    */
   public int getGreen() {
-    return -1;
+    return this.green;
   }
 
   /**
@@ -44,7 +52,7 @@ public class Color {
    * @return a number representing the blue value (between 0 and 255)
    */
   public int getBlue() {
-    return -1;
+    return this.blue;
   }
 
   /**
@@ -53,7 +61,9 @@ public class Color {
    *
    * @param value the amount of red (ranging from 0 to 255) in the color of the pixel.
    */
-  public void setRed(int value) {}
+  public void setRed(int value) {
+    this.red = value;
+  }
 
   /**
    * Sets the amount of green (ranging from 0 to 255). Values below 0 will be ignored and set to 0,
@@ -61,14 +71,18 @@ public class Color {
    *
    * @param value the amount of green (ranging from 0 to 255) in the color of the pixel.
    */
-  public void setGreen(int value) {}
+  public void setGreen(int value) {
+    this.green = value;
+  }
 
   /**
    * Sets the amount of blue (ranging from 0 to 255).
    *
    * @param value the amount of blue (ranging from 0 to 255) in the color of the pixel.
    */
-  public void setBlue(int value) {}
+  public void setBlue(int value) {
+    this.blue = value;
+  }
 
   public static final Color WHITE = new Color(255, 255, 255);
   public static final Color SILVER = new Color(192, 192, 192);

--- a/org-code-javabuilder/media/src/main/java/org/code/media/Color.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/Color.java
@@ -25,9 +25,9 @@ public class Color {
    * @param blue the blue value from 0 - 255
    */
   public Color(int red, int green, int blue) {
-    this.red = red;
-    this.green = green;
-    this.blue = blue;
+    this.red = this.sanitizeValue(red);
+    this.green = this.sanitizeValue(green);
+    this.blue = this.sanitizeValue(blue);
   }
 
   /**
@@ -59,31 +59,52 @@ public class Color {
 
   /**
    * Sets the amount of red (ranging from 0 to 255). Values below 0 will be ignored and set to 0,
-   * and values above 255 with be ignored and set to 255.
+   * and values above 255 will be ignored and set to 255.
    *
    * @param value the amount of red (ranging from 0 to 255) in the color of the pixel.
    */
   public void setRed(int value) {
-    this.red = value;
+    this.red = this.sanitizeValue(value);
   }
 
   /**
    * Sets the amount of green (ranging from 0 to 255). Values below 0 will be ignored and set to 0,
-   * and values above 255 with be ignored and set to 255.
+   * and values above 255 will be ignored and set to 255.
    *
    * @param value the amount of green (ranging from 0 to 255) in the color of the pixel.
    */
   public void setGreen(int value) {
-    this.green = value;
+    this.green = this.sanitizeValue(value);
   }
 
   /**
-   * Sets the amount of blue (ranging from 0 to 255).
+   * Sets the amount of blue (ranging from 0 to 255). Values below 0 will be ignored and set to 0, *
+   * and values above 255 will be ignored and set to 255.
    *
    * @param value the amount of blue (ranging from 0 to 255) in the color of the pixel.
    */
   public void setBlue(int value) {
-    this.blue = value;
+    this.blue = this.sanitizeValue(value);
+  }
+
+  /**
+   * Values below 0 will be set to 0, and values above 255 will be set to 255.
+   *
+   * @param value
+   * @return value if it was in the expected range, or a valid value based on the reset logic.
+   */
+  private int sanitizeValue(int value) {
+    if (value < 0) {
+      return 0;
+    }
+    if (value > 255) {
+      return 255;
+    }
+    return value;
+  }
+
+  public static java.awt.Color convertToAWTColor(Color c) {
+    return new java.awt.Color(c.getRed(), c.getGreen(), c.getBlue());
   }
 
   public static final Color WHITE = new Color(255, 255, 255);

--- a/org-code-javabuilder/media/src/main/java/org/code/media/Color.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/Color.java
@@ -92,7 +92,7 @@ public class Color {
   public static final Color BLACK = new Color(0, 0, 0);
   public static final Color RED = new Color(255, 0, 0);
   public static final Color MAROON = new Color(128, 0, 0);
-  public static final Color YELLOW = new Color(256, 256, 0);
+  public static final Color YELLOW = new Color(255, 255, 0);
   public static final Color OLIVE = new Color(128, 128, 0);
   public static final Color LIME = new Color(0, 256, 0);
   public static final Color GREEN = new Color(0, 128, 0);

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/ExceptionKeys.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/ExceptionKeys.java
@@ -1,0 +1,6 @@
+package org.code.theater;
+
+public enum ExceptionKeys {
+  DUPLICATE_PLAY_COMMAND,
+  INVALID_SHAPE
+}

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -207,7 +207,7 @@ public class Stage {
       throw new TheaterRuntimeException(ExceptionKeys.INVALID_SHAPE);
     }
     if (close) {
-      // we can use the shape functions
+      // For a closed shape, use draw/fill shape functions
       if (this.strokeColor != null || this.fillColor != null) {
         int numPoints = points.length / 2;
         int[] xPoints = new int[numPoints];
@@ -227,7 +227,7 @@ public class Stage {
         }
       }
     } else if (this.strokeColor != null) {
-      // draw shape as a series of lines
+      // For an open shape, draw as a series of lines
       this.graphics.setColor(this.strokeColor);
       for (int i = 0; i <= points.length - 4; i += 2) {
         this.graphics.drawLine(points[i], points[i + 1], points[i + 2], points[i + 3]);

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -91,7 +91,7 @@ public class Stage {
    * @param seconds The number of seconds to wait. This can be a fraction of a second, but the
    *     smallest value can be .1 seconds.
    */
-  public void wait(double seconds) {
+  public void pause(double seconds) {
     this.gifWriter.writeToGif(this.image, (int) (seconds * 1000));
   }
 

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -22,26 +22,42 @@ public class Stage {
   private static final int WIDTH = 400;
   private static final int HEIGHT = 400;
 
-  public Stage() {
+  /**
+   * Initialize Stage with a default image. Stage should be initialized outside of org.code.theater
+   * using Theater.stage.
+   */
+  protected Stage() {
+    this(new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_RGB));
+  }
+
+  /**
+   * Initialize Stage with a specific BufferedImage. Used directly for testing. Stage should be
+   * initialized outside of org.code.theater using Theater.stage.
+   *
+   * @param image
+   */
+  protected Stage(BufferedImage image) {
+    this.image = image;
+    this.graphics = this.image.createGraphics();
     this.outputAdapter = GlobalProtocol.getInstance().getOutputAdapter();
     this.outputStream = new ByteArrayOutputStream();
     this.gifWriter = new GifWriter(this.outputStream);
-
-    // Set up image with white background and black stroke/fill color
-    this.reset();
     this.hasPlayed = false;
+
+    // set up the image for drawing (set a white background and black stroke/fill)
+    this.reset();
 
     System.setProperty("java.awt.headless", "true");
   }
 
-  /** Returns the width of the theater canvas. Right now this will always be 400 pixels. */
-  public double getWidth() {
-    return image.getWidth();
+  /** Returns the width of the theater canvas. */
+  public int getWidth() {
+    return this.image.getWidth();
   }
 
-  /** Returns the height of the theater canvas. Right now this will always be 400 pixels. */
-  public double getHeight() {
-    return image.getHeight();
+  /** Returns the height of the theater canvas. */
+  public int getHeight() {
+    return this.image.getHeight();
   }
 
   /**
@@ -81,11 +97,9 @@ public class Stage {
 
   /** Clear everything, starting from the beginning and emptying the canvas. */
   public void reset() {
-    this.image = new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_RGB);
-    this.graphics = this.image.createGraphics();
     this.graphics.setBackground(java.awt.Color.WHITE);
-    // clearRect removes the default black background
-    this.graphics.clearRect(0, 0, WIDTH, HEIGHT);
+    // clearRect resets the background with the new color
+    this.graphics.clearRect(0, 0, this.getWidth(), this.getHeight());
     this.strokeColor = java.awt.Color.BLACK;
     this.fillColor = java.awt.Color.BLACK;
   }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -1,17 +1,47 @@
 package org.code.theater;
 
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
-import org.code.media.*;
+import org.code.media.Color;
+import org.code.media.Image;
+import org.code.protocol.GlobalProtocol;
+import org.code.protocol.OutputAdapter;
 
 public class Stage {
+  private BufferedImage image;
+  private final OutputAdapter outputAdapter;
+  private final GifWriter gifWriter;
+  private final ByteArrayOutputStream outputStream;
+  private java.awt.Color strokeColor;
+  private java.awt.Color fillColor;
+  private Graphics2D graphics;
+  private boolean hasPlayed;
+
+  private static final int WIDTH = 400;
+  private static final int HEIGHT = 400;
+
+  public Stage() {
+    this.outputAdapter = GlobalProtocol.getInstance().getOutputAdapter();
+    this.outputStream = new ByteArrayOutputStream();
+    this.gifWriter = new GifWriter(this.outputStream);
+
+    // Set up image with white background and black stroke/fill color
+    this.reset();
+    this.hasPlayed = false;
+
+    System.setProperty("java.awt.headless", "true");
+  }
+
   /** Returns the width of the theater canvas. Right now this will always be 400 pixels. */
   public double getWidth() {
-    return -1;
+    return image.getWidth();
   }
 
   /** Returns the height of the theater canvas. Right now this will always be 400 pixels. */
   public double getHeight() {
-    return -1;
+    return image.getHeight();
   }
 
   /**
@@ -45,13 +75,23 @@ public class Stage {
    * @param seconds The number of seconds to wait. This can be a fraction of a second, but the
    *     smallest value can be .1 seconds.
    */
-  public void wait(double seconds) {}
+  public void wait(double seconds) {
+    this.gifWriter.writeToGif(this.image, (int) (seconds * 1000));
+  }
 
   /** Clear everything, starting from the beginning and emptying the canvas. */
-  public void reset() {}
+  public void reset() {
+    this.image = new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_RGB);
+    this.graphics = this.image.createGraphics();
+    this.graphics.setBackground(java.awt.Color.WHITE);
+    // clearRect removes the default black background
+    this.graphics.clearRect(0, 0, WIDTH, HEIGHT);
+    this.strokeColor = java.awt.Color.BLACK;
+    this.fillColor = java.awt.Color.BLACK;
+  }
 
   /**
-   * Draw an image on the canvas at the given location, expanded or shunk to fit the width and
+   * Draw an image on the canvas at the given location, expanded or shrunk to fit the width and
    * height provided
    *
    * @param filename the name of the file in the asset manager
@@ -62,12 +102,11 @@ public class Stage {
    * @param rotation the amount to rotate the image
    * @throws FileNotFoundException if the file can't be found in the project.
    */
-  public void drawImage(
-      String filename, double x, double y, double width, double height, double rotation)
+  public void drawImage(String filename, int x, int y, int width, int height, double rotation)
       throws FileNotFoundException {}
 
   /**
-   * Draw an image on the canvas at the given location, expanded or shunk to fit the width and
+   * Draw an image on the canvas at the given location, expanded or shrunk to fit the width and
    * height provided
    *
    * @param image the Image object to draw on the canvas
@@ -77,8 +116,7 @@ public class Stage {
    * @param height the height to draw the image on the canvas
    * @param rotation the amount to rotate the image
    */
-  public void drawImage(
-      Image image, double x, double y, double width, double height, double rotation) {}
+  public void drawImage(Image image, int x, int y, int width, int height, double rotation) {}
 
   /**
    * Draws text on the image.
@@ -92,7 +130,7 @@ public class Stage {
    * @param rotation the rotation or tilt of the text, in degrees
    */
   public void drawText(
-      String text, double x, double y, String color, String font, double height, double rotation) {}
+      String text, int x, int y, String color, String font, int height, double rotation) {}
 
   /**
    * Draw a line on the canvas.
@@ -102,7 +140,14 @@ public class Stage {
    * @param endX the end X coordinate of the line.
    * @param endY the end Y coordinate of the line.
    */
-  public void drawLine(double startX, double startY, double endX, double endY) {}
+  public void drawLine(int startX, int startY, int endX, int endY) {
+    if (this.strokeColor == null) {
+      this.graphics.setColor(java.awt.Color.BLACK);
+    } else {
+      this.graphics.setColor(this.strokeColor);
+    }
+    this.graphics.drawLine(startX, startY, endX, endY);
+  }
 
   /**
    * Draw a regular polygon on the canvas.
@@ -112,7 +157,25 @@ public class Stage {
    * @param sides the number of sides of the polygon
    * @param radius the distance from the center to each point on the polygon
    */
-  public void drawRegularPolygon(double x, double y, int sides, double radius) {}
+  public void drawRegularPolygon(int x, int y, int sides, int radius) {
+    if (this.strokeColor != null || this.fillColor != null) {
+      Polygon polygon = new Polygon();
+      double theta = 2 * Math.PI / sides;
+      for (int i = 0; i < sides; i++) {
+        int xCoordinate = (int) (Math.cos(theta * i) * radius) + x;
+        int yCoordinate = (int) (Math.sin(theta * i) * radius) + y;
+        polygon.addPoint(xCoordinate, yCoordinate);
+      }
+      if (this.strokeColor != null) {
+        this.graphics.setColor(this.strokeColor);
+        this.graphics.drawPolygon(polygon);
+      }
+      if (this.fillColor != null) {
+        this.graphics.setColor(this.fillColor);
+        this.graphics.fillPolygon(polygon);
+      }
+    }
+  }
 
   /**
    * Draw as a shape by connecting the points provided.
@@ -123,7 +186,40 @@ public class Stage {
    *     point will be connected by a line, and if a fill color is set, the shape will be filled
    *     with that color.
    */
-  public void drawShape(double[] points, boolean close) {}
+  public void drawShape(int[] points, boolean close) {
+    // points should contain an even number of values to represent (x,y) coordinates
+    // We need at least 4 points to draw a single line
+    if (points.length % 2 != 0 || points.length < 4) {
+      throw new TheaterRuntimeException(ExceptionKeys.INVALID_SHAPE);
+    }
+    if (close) {
+      // we can use the shape functions
+      if (this.strokeColor != null || this.fillColor != null) {
+        int numPoints = points.length / 2;
+        int[] xPoints = new int[numPoints];
+        int[] yPoints = new int[numPoints];
+        // split points into x and y arrays
+        for (int i = 0; i < points.length - 1; i += 2) {
+          xPoints[i / 2] = points[i];
+          yPoints[i / 2] = points[i + 1];
+        }
+        if (this.strokeColor != null) {
+          this.graphics.setColor(this.strokeColor);
+          this.graphics.drawPolygon(xPoints, yPoints, numPoints);
+        }
+        if (this.fillColor != null) {
+          this.graphics.setColor(this.fillColor);
+          this.graphics.fillPolygon(xPoints, yPoints, numPoints);
+        }
+      }
+    } else if (this.strokeColor != null) {
+      // draw shape as a series of lines
+      this.graphics.setColor(this.strokeColor);
+      for (int i = 0; i <= points.length - 4; i += 2) {
+        this.graphics.drawLine(points[i], points[i + 1], points[i + 2], points[i + 3]);
+      }
+    }
+  }
 
   /**
    * Draws an ellipse (an oval or a circle) on the canvas.
@@ -133,7 +229,16 @@ public class Stage {
    * @param width the width of the ellipse
    * @param height the height of the ellipse
    */
-  public void drawEllipse(double x, double y, double width, double height) {}
+  public void drawEllipse(int x, int y, int width, int height) {
+    if (this.fillColor != null) {
+      this.graphics.setColor(this.fillColor);
+      this.graphics.fillOval(x, y, width, height);
+    }
+    if (this.strokeColor != null) {
+      this.graphics.setColor(this.strokeColor);
+      this.graphics.drawOval(x, y, width, height);
+    }
+  }
 
   /**
    * Draws a rectangle on the canvas.
@@ -143,37 +248,67 @@ public class Stage {
    * @param width the width of the rectangle.
    * @param height the height of the rectangle.
    */
-  public void drawRectangle(double x, double y, double width, double height) {}
+  public void drawRectangle(int x, int y, int width, int height) {
+    if (this.fillColor != null) {
+      this.graphics.setColor(this.fillColor);
+      this.graphics.fillRect(x, y, width, height);
+    }
+    if (this.strokeColor != null) {
+      this.graphics.setColor(this.strokeColor);
+      this.graphics.drawRect(x, y, width, height);
+    }
+  }
 
   /**
    * Sets the thickness of lines drawn.
    *
    * @param width width in pixels of the line to draw. Zero means no line.
    */
-  public void setStrokeWidth(double width) {}
+  public void setStrokeWidth(double width) {
+    this.graphics.setStroke(new BasicStroke((float) width));
+  }
 
   /**
    * Sets the color of lines drawn.
    *
    * @param color the color to draw lines with.
    */
-  public void setStrokeColor(Color color) {}
+  public void setStrokeColor(Color color) {
+    this.strokeColor = this.convertColor(color);
+  }
 
   /** Removes the stroke color so any shapes have no outlines. */
-  public void removeStrokeColor() {}
+  public void removeStrokeColor() {
+    this.strokeColor = null;
+  }
 
   /**
    * Sets the fill color for all shapes drawn
    *
    * @param color the color value to fill any shape.
    */
-  public void setFillColor(Color color) {}
+  public void setFillColor(Color color) {
+    this.fillColor = this.convertColor(color);
+  }
 
   /** Removes the fill color so any shapes have no fill. */
-  public void removeFillColor() {}
+  public void removeFillColor() {
+    this.fillColor = null;
+  }
 
   /** Plays the instructions. */
   public void play() {
-    System.out.println("play");
+    if (this.hasPlayed) {
+      throw new TheaterRuntimeException(ExceptionKeys.DUPLICATE_PLAY_COMMAND);
+    } else {
+      this.gifWriter.writeToGif(this.image, 0);
+      this.gifWriter.close();
+      outputAdapter.sendMessage(ImageEncoder.encodeStreamToMessage(this.outputStream));
+      this.hasPlayed = true;
+    }
+  }
+
+  private java.awt.Color convertColor(Color color) {
+    return new java.awt.Color(color.getRed(), color.getGreen(), color.getBlue());
   }
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/TheaterRuntimeException.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/TheaterRuntimeException.java
@@ -1,0 +1,13 @@
+package org.code.theater;
+
+import org.code.protocol.JavabuilderRuntimeException;
+
+public class TheaterRuntimeException extends JavabuilderRuntimeException {
+  protected TheaterRuntimeException(ExceptionKeys key) {
+    super(key);
+  }
+
+  protected TheaterRuntimeException(ExceptionKeys key, Throwable cause) {
+    super(key, cause);
+  }
+}

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
@@ -1,0 +1,118 @@
+package org.code.theater;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.code.protocol.GlobalProtocol;
+import org.code.protocol.InputAdapter;
+import org.code.protocol.OutputAdapter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class StageTest {
+  private final OutputAdapter outputAdapter = mock(OutputAdapter.class);
+  private final PrintStream standardOut = System.out;
+  private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+  private BufferedImage bufferedImage;
+  private Graphics2D graphics;
+
+  @BeforeEach
+  public void setUp() {
+    GlobalProtocol.create(outputAdapter, mock(InputAdapter.class));
+    System.setOut(new PrintStream(outputStreamCaptor));
+    bufferedImage = mock(BufferedImage.class);
+    graphics = mock(Graphics2D.class);
+    when(bufferedImage.createGraphics()).thenReturn(graphics);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    System.setOut(standardOut);
+  }
+
+  @Test
+  void drawLineDefaultsToBlack() {
+    Stage s = new Stage(bufferedImage);
+    s.removeStrokeColor();
+    s.drawLine(0, 0, 100, 100);
+    verify(graphics).setColor(Color.BLACK);
+    verify(graphics).drawLine(0, 0, 100, 100);
+  }
+
+  @Test
+  void removingStrokeAndFillPreventsShapeDrawing() {
+    Stage s = new Stage(bufferedImage);
+    s.removeFillColor();
+    s.removeStrokeColor();
+    s.drawRegularPolygon(0, 0, 5, 100);
+    verify(graphics, never()).drawPolygon(any());
+    verify(graphics, never()).fillPolygon(any());
+  }
+
+  @Test
+  void removingStrokeStillCallsFill() {
+    Stage s = new Stage(bufferedImage);
+    s.removeStrokeColor();
+    s.drawEllipse(5, 5, 100, 100);
+    verify(graphics, never()).drawOval(5, 5, 100, 100);
+    verify(graphics).fillOval(5, 5, 100, 100);
+  }
+
+  @Test
+  void drawOpenShapeDrawsLines() {
+    Stage s = new Stage(bufferedImage);
+    s.drawShape(new int[] {0, 0, 25, 30, 0, 100}, false);
+    verify(graphics, Mockito.times(2)).drawLine(anyInt(), anyInt(), anyInt(), anyInt());
+  }
+
+  @Test
+  void drawClosedShapeDrawsAndFillsShape() {
+    Stage s = new Stage(bufferedImage);
+    s.drawShape(new int[] {0, 0, 25, 30, 0, 100}, true);
+    int[] xPoints = new int[] {0, 25, 0};
+    int[] yPoints = new int[] {0, 30, 100};
+    verify(graphics).drawPolygon(xPoints, yPoints, 3);
+    verify(graphics).fillPolygon(xPoints, yPoints, 3);
+  }
+
+  @Test
+  void throwsExceptionIfPlayCalledTwice() {
+    Stage s = new Stage();
+    s.play();
+    Exception exception =
+        assertThrows(
+            TheaterRuntimeException.class,
+            () -> {
+              s.play();
+            });
+    String expectedMessage = ExceptionKeys.DUPLICATE_PLAY_COMMAND.toString();
+    assertEquals(exception.getMessage(), expectedMessage);
+  }
+
+  @Test
+  void throwsExceptionOnInvalidShape() {
+    Stage s = new Stage();
+    int[] tooFewPoints = new int[] {1, 0};
+    int[] oddNumberOfPoints = new int[] {0, 0, 1, 1, 2};
+    verifyInvalidShapeThrowsException(s, tooFewPoints, false);
+    verifyInvalidShapeThrowsException(s, oddNumberOfPoints, true);
+  }
+
+  private void verifyInvalidShapeThrowsException(Stage s, int[] points, boolean close) {
+    Exception exception =
+        assertThrows(
+            TheaterRuntimeException.class,
+            () -> {
+              s.drawShape(points, close);
+            });
+    String expectedMessage = ExceptionKeys.INVALID_SHAPE.toString();
+    assertEquals(exception.getMessage(), expectedMessage);
+  }
+}


### PR DESCRIPTION
Implement all the non-image drawing methods in theater (such as `drawLine`, `drawShape`, etc.). To implement this I also implemented most of the `Color` class, excluding initializing a color via a string. I also added a new `TheaterRuntimeException` and started unit tests for `Stage`.

The drawing is done by creating a blank [BufferedImage](https://docs.oracle.com/en/java/javase/11/docs/api/java.desktop/java/awt/image/BufferedImage.html) and getting the [Graphics2D](https://docs.oracle.com/en/java/javase/11/docs/api/java.desktop/java/awt/Graphics2D.html) associated with that image. We will be able to use the Graphics2D to add images in Part 2 of this work. Every time `pause` is called on `Stage`, we write the existing image to the gif with the specified pause. When play is called we write the final frame and send it to the client. Our method of sending gifs may change to accommodate larger gifs.