### PR TITLE
Javabuilder: Retrieve assets and update how we get the sources url

### DIFF
--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -41,10 +41,10 @@ def on_connect(event, context)
     :queueUrl => sqs_queue.queue_url,
     :apiEndpoint => api_endpoint,
     :connectionId => request_context["connectionId"],
-    :projectUrl => authorizer["project_url"],
     :levelId => authorizer["level_id"],
     :options => authorizer["options"],
-    :iss => authorizer["iss"]
+    :iss => authorizer["iss"],
+    :channelId => authorizer["channel_id"]
   }
   response = lambda_client.invoke({
     function_name: 'javaBuilderExecuteCode:11',

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
@@ -18,7 +18,7 @@ public class LocalMain {
     // Create and invoke the code execution environment
     try {
       UserProjectFiles userProjectFiles = fileLoader.loadFiles();
-      GlobalProtocol.create(outputAdapter, inputAdapter);
+      GlobalProtocol.create(outputAdapter, inputAdapter, "", "");
       try (CodeBuilder codeBuilder =
           new CodeBuilder(GlobalProtocol.getInstance(), userProjectFiles)) {
         codeBuilder.buildUserCode();

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -39,7 +39,7 @@ public class WebSocketServer {
   @OnOpen
   public void onOpen(Session session) {
     Map<String, List<String>> params = session.getRequestParameterMap();
-    String projectUrl = params.get("projectUrl").get(0);
+    String channelId = params.get("channelId").get(0);
     boolean useNeighborhood = false;
     if (params.containsKey("useNeighborhood")) {
       useNeighborhood = Boolean.parseBoolean(params.get("useNeighborhood").get(0));
@@ -52,10 +52,14 @@ public class WebSocketServer {
 
     outputAdapter = new WebSocketOutputAdapter(session);
     inputAdapter = new WebSocketInputAdapter();
+    String dashboardHostname = "http://localhost-studio.code.org:3000";
+    GlobalProtocol.create(outputAdapter, inputAdapter, dashboardHostname, channelId);
     final UserProjectFileLoader fileLoader =
         new UserProjectFileLoader(
-            projectUrl, levelId, "http://localhost-studio.code.org:3000", useNeighborhood);
-    GlobalProtocol.create(outputAdapter, inputAdapter);
+            GlobalProtocol.getInstance().generateSourcesUrl(),
+            levelId,
+            dashboardHostname,
+            useNeighborhood);
     Thread codeExecutor =
         new Thread(
             () -> {

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -37,8 +37,8 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     final String connectionId = lambdaInput.get("connectionId");
     final String apiEndpoint = lambdaInput.get("apiEndpoint");
     final String queueUrl = lambdaInput.get("queueUrl");
-    final String projectUrl = lambdaInput.get("projectUrl");
     final String levelId = lambdaInput.get("levelId");
+    final String channelId = lambdaInput.get("channelId");
     final String dashboardHostname = "https://" + lambdaInput.get("iss");
     final JSONObject options = new JSONObject(lambdaInput.get("options"));
     boolean useNeighborhood = false;
@@ -61,13 +61,16 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     final AmazonSQS sqsClient = AmazonSQSClientBuilder.defaultClient();
     final AWSInputAdapter inputAdapter = new AWSInputAdapter(sqsClient, queueUrl);
 
-    // Create file loader
-    final UserProjectFileLoader userProjectFileLoader =
-        new UserProjectFileLoader(projectUrl, levelId, dashboardHostname, useNeighborhood);
-
     // Load files to memory and create and invoke the code execution environment
     try {
-      GlobalProtocol.create(outputAdapter, inputAdapter);
+      GlobalProtocol.create(outputAdapter, inputAdapter, dashboardHostname, channelId);
+      // Create file loader
+      final UserProjectFileLoader userProjectFileLoader =
+          new UserProjectFileLoader(
+              GlobalProtocol.getInstance().generateSourcesUrl(),
+              levelId,
+              dashboardHostname,
+              useNeighborhood);
       UserProjectFiles userProjectFiles = userProjectFileLoader.loadFiles();
       try (CodeBuilder codeBuilder =
           new CodeBuilder(GlobalProtocol.getInstance(), userProjectFiles)) {

--- a/org-code-javabuilder/media/build.gradle
+++ b/org-code-javabuilder/media/build.gradle
@@ -18,6 +18,7 @@ repositories {
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
+    implementation project(':protocol')
 }
 
 test {

--- a/org-code-javabuilder/media/src/main/java/org/code/media/Image.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/Image.java
@@ -1,8 +1,15 @@
 package org.code.media;
 
+import java.awt.image.BufferedImage;
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URL;
+import javax.imageio.ImageIO;
+import org.code.protocol.GlobalProtocol;
 
 public class Image {
+  private BufferedImage bufferedImage;
+
   /**
    * Creates a new image object, using the pixel information from the file uploaded to the asset
    * manager.
@@ -10,7 +17,15 @@ public class Image {
    * @param filename the name of the image loaded into the asset manager for the project
    * @throws FileNotFoundException if the file doesn't exist in the asset manager.
    */
-  public Image(String filename) throws FileNotFoundException {}
+  public Image(String filename) throws FileNotFoundException {
+    try {
+      this.bufferedImage =
+          ImageIO.read(new URL(GlobalProtocol.getInstance().generateAssetUrl(filename)));
+    } catch (IOException e) {
+      // TODO: improve error handling
+      throw new FileNotFoundException();
+    }
+  }
 
   /**
    * Create a new image object, copying the source image provided.
@@ -63,7 +78,7 @@ public class Image {
    * @return the width of the image in pixels.
    */
   public int getWidth() {
-    return -1;
+    return this.bufferedImage.getWidth();
   }
 
   /**
@@ -72,7 +87,7 @@ public class Image {
    * @return the height of the image in pixels.
    */
   public int getHeight() {
-    return -1;
+    return this.bufferedImage.getHeight();
   }
 
   /**
@@ -81,4 +96,8 @@ public class Image {
    * @param color the color with which to fill the image.
    */
   public void clear(Color color) {}
+
+  public BufferedImage getBufferedImage() {
+    return this.bufferedImage;
+  }
 }

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
@@ -23,7 +23,7 @@ public class PainterTest {
 
   @BeforeEach
   public void setUp() {
-    GlobalProtocol.create(outputAdapter, mock(InputAdapter.class));
+    GlobalProtocol.create(outputAdapter, mock(InputAdapter.class), "", "");
     System.setOut(new PrintStream(outputStreamCaptor));
     World w = new World(singleSquareGrid);
     World.setInstance(w);

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
@@ -12,14 +12,27 @@ public class GlobalProtocol {
   private static GlobalProtocol protocolInstance;
   private final OutputAdapter outputAdapter;
   private final InputAdapter inputAdapter;
+  private final String dashboardHostname;
+  private final String channelId;
 
-  private GlobalProtocol(OutputAdapter outputAdapter, InputAdapter inputAdapter) {
+  private GlobalProtocol(
+      OutputAdapter outputAdapter,
+      InputAdapter inputAdapter,
+      String dashboardHostname,
+      String channelId) {
     this.outputAdapter = outputAdapter;
     this.inputAdapter = inputAdapter;
+    this.dashboardHostname = dashboardHostname;
+    this.channelId = channelId;
   }
 
-  public static void create(OutputAdapter outputAdapter, InputAdapter inputAdapter) {
-    GlobalProtocol.protocolInstance = new GlobalProtocol(outputAdapter, inputAdapter);
+  public static void create(
+      OutputAdapter outputAdapter,
+      InputAdapter inputAdapter,
+      String dashboardHostname,
+      String channelId) {
+    GlobalProtocol.protocolInstance =
+        new GlobalProtocol(outputAdapter, inputAdapter, dashboardHostname, channelId);
   }
 
   public static GlobalProtocol getInstance() {
@@ -36,5 +49,13 @@ public class GlobalProtocol {
 
   public InputAdapter getInputAdapter() {
     return this.inputAdapter;
+  }
+
+  public String generateAssetUrl(String filename) {
+    return String.format("%s/v3/assets/%s/%s", this.dashboardHostname, this.channelId, filename);
+  }
+
+  public String generateSourcesUrl() {
+    return String.format("%s/v3/sources/%s", this.dashboardHostname, this.channelId);
   }
 }

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
@@ -25,7 +25,7 @@ public class StageTest {
 
   @BeforeEach
   public void setUp() {
-    GlobalProtocol.create(outputAdapter, mock(InputAdapter.class));
+    GlobalProtocol.create(outputAdapter, mock(InputAdapter.class), "", "");
     System.setOut(new PrintStream(outputStreamCaptor));
     bufferedImage = mock(BufferedImage.class);
     graphics = mock(Graphics2D.class);


### PR DESCRIPTION
Previously we sent the sources url over to Javabuilder as a session parameter in order to retrieve project files. Now that we need both the assets url (for things like images and audio) and the sources url, we will instead use the parameters (already sent by the javabuilder session token) `channelId` and `iss` (dashboard hostname) in order to generate the urls we need. 

The url generation is done via the global protocol, which is available to all packages. We only generate the url via the protocol instead of load the file because the file loading logic is dependent on the type of file we want to load (for example, for images we can use an `ImageIO` helper method).

This PR also includes the initial change to use the assets url to load an image into memory. This functionality will be used and expanded upon in a follow-up PR for theater images.

## Links
- jira ticket: [https://codedotorg.atlassian.net/browse/CSA-424](https://codedotorg.atlassian.net/browse/CSA-424)