### PR TITLE
Implement audio commands from the Theater API

### DIFF
--- a/org-code-javabuilder/media/src/main/java/org/code/media/AudioUtils.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/AudioUtils.java
@@ -3,6 +3,7 @@ package org.code.media;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import javax.sound.sampled.AudioFileFormat;
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioInputStream;
@@ -10,7 +11,7 @@ import javax.sound.sampled.AudioSystem;
 import org.code.protocol.InternalErrorKey;
 import org.code.protocol.InternalJavabuilderError;
 
-public class AudioUtils {
+class AudioUtils {
   private static final int MONO_CHANNELS = 1;
   private static final int STEREO_CHANNELS = 2;
   private static final double MAX_16_BIT_VALUE = 32768; // Max signed 16-bit value
@@ -118,10 +119,8 @@ public class AudioUtils {
    *
    * @param bytes
    * @param outputStream
-   * @throws SoundException
    */
-  public static void writeBytesToOutputStream(byte[] bytes, ByteArrayOutputStream outputStream)
-      throws InternalJavabuilderError {
+  public static void writeBytesToOutputStream(byte[] bytes, ByteArrayOutputStream outputStream) {
     final ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
     final AudioInputStream audioInputStream =
         new AudioInputStream(inputStream, DEFAULT_AUDIO_FORMAT, bytes.length / 2);
@@ -131,6 +130,22 @@ public class AudioUtils {
     } catch (IOException e) {
       throw new InternalJavabuilderError(InternalErrorKey.INTERNAL_EXCEPTION, e);
     }
+  }
+
+  /**
+   * Truncates the array of audio samples to the desired duration in seconds provided. If the
+   * desired duration is greater than the duration of the samples, the samples are unchanged.
+   *
+   * @param samples
+   * @param lengthSeconds
+   * @return truncated samples
+   */
+  public static double[] truncateSamples(double[] samples, double lengthSeconds) {
+    final int newLength = (int) (lengthSeconds * (double) DEFAULT_SAMPLE_RATE);
+    if (newLength > samples.length) {
+      return samples;
+    }
+    return Arrays.copyOf(samples, newLength);
   }
 
   public static int getDefaultSampleRate() {

--- a/org-code-javabuilder/media/src/main/java/org/code/media/SoundLoader.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/SoundLoader.java
@@ -20,8 +20,7 @@ public class SoundLoader {
    * @throws SoundException if there is an error reading the file, or FileNotFoundException when the
    *     file cannot be found
    */
-  public static double[] read(String filename)
-      throws SoundException, InternalJavabuilderError, FileNotFoundException {
+  public static double[] read(String filename) throws SoundException, FileNotFoundException {
     // Acquire AudioInputStream
     final AudioInputStream audioInputStream = getAudioInputStream(filename);
     final AudioFormat audioFormat = audioInputStream.getFormat();

--- a/org-code-javabuilder/media/src/test/java/org/code/media/AudioUtilsTest.java
+++ b/org-code-javabuilder/media/src/test/java/org/code/media/AudioUtilsTest.java
@@ -2,6 +2,7 @@ package org.code.media;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Arrays;
 import javax.sound.sampled.AudioFormat;
 import org.junit.jupiter.api.Test;
 
@@ -78,5 +79,23 @@ class AudioUtilsTest {
   @Test
   public void testConvertDoubleArrayConvertsCorrectly() throws SoundException {
     assertArrayEquals(BYTE_ARRAY_MONO, AudioUtils.convertDoubleArrayToByteArray(DOUBLE_ARRAY));
+  }
+
+  @Test
+  public void testTruncateSamplesTruncatesCorrectly() {
+    final double[] samples = new double[5 * 44100]; // 5 second audio
+    Arrays.fill(samples, 0.5);
+
+    final double[] expected = new double[3 * 44100];
+    Arrays.fill(expected, 0.5);
+    assertArrayEquals(expected, AudioUtils.truncateSamples(samples, 3.0));
+  }
+
+  @Test
+  public void testTruncateSamplesDoesNothingIfAudioShorterThanRequestedLength() {
+    final double[] samples = new double[5 * 44100]; // 5 second audio
+    Arrays.fill(samples, 0.5);
+
+    assertSame(samples, AudioUtils.truncateSamples(samples, 7.0));
   }
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/CatMusic.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/CatMusic.java
@@ -28,18 +28,19 @@ public class CatMusic {
   CatMusic(OutputAdapter outputAdapter, ByteArrayOutputStream audioOutputStream) {
     this.outputAdapter = outputAdapter;
     this.audioOutputStream = audioOutputStream;
-    this.audioWriter = new AudioWriter(this.audioOutputStream);
+    this.audioWriter = new AudioWriter.Factory().createAudioWriter(this.audioOutputStream);
   }
 
-  public double[] readSampleSound() {
-    try {
-      final String audioFilename =
-          Paths.get(CatMusic.class.getClassLoader().getResource("beatbox.wav").toURI()).toString();
-      return SoundLoader.read(audioFilename);
-    } catch (URISyntaxException | SoundException | FileNotFoundException e) {
-      e.printStackTrace();
-    }
-    return null;
+  public double[] readSampleSound()
+      throws FileNotFoundException, SoundException, URISyntaxException {
+    return this.read("beatbox.wav");
+  }
+
+  public double[] read(String audioFilename)
+      throws FileNotFoundException, SoundException, URISyntaxException {
+    final String fullAudioPath =
+        Paths.get(CatMusic.class.getClassLoader().getResource(audioFilename).toURI()).toString();
+    return SoundLoader.read(fullAudioPath);
   }
 
   public void playSound(double[] samples) {
@@ -50,21 +51,13 @@ public class CatMusic {
     }
   }
 
-  public void wait(int delayMs) {
-    try {
-      this.audioWriter.addDelay(delayMs);
-    } catch (SoundException e) {
-      e.printStackTrace();
-    }
+  public void pause(double delaySeconds) throws SoundException {
+    this.audioWriter.addDelay(delaySeconds);
   }
 
-  public void play() {
-    try {
-      this.audioWriter.writeToAudioStreamAndClose();
-      this.outputAdapter.sendMessage(SoundEncoder.encodeStreamToMessage(this.audioOutputStream));
-    } catch (SoundException e) {
-      e.printStackTrace();
-    }
+  public void play() throws SoundException {
+    this.audioWriter.writeToAudioStreamAndClose();
+    this.outputAdapter.sendMessage(SoundEncoder.encodeStreamToMessage(this.audioOutputStream));
   }
 
   public void reset() {

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/InstrumentSampleLoader.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/InstrumentSampleLoader.java
@@ -1,0 +1,46 @@
+package org.code.theater;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class InstrumentSampleLoader {
+
+  private static Map<Instrument, Map<Integer, String>> generateInstrumentFileMap() {
+    // TODO: Populate map with file paths once created
+    return new HashMap<>();
+  }
+
+  // Map of Instrument -> Map of note value (int) -> file path / name
+  private final Map<Instrument, Map<Integer, String>> instrumentFileMap;
+
+  public InstrumentSampleLoader() {
+    this(InstrumentSampleLoader.generateInstrumentFileMap());
+  }
+
+  InstrumentSampleLoader(Map<Instrument, Map<Integer, String>> instrumentFileMap) {
+    this.instrumentFileMap = instrumentFileMap;
+  }
+
+  /**
+   * Retrieves the sample file for the given instrument and note value. Returns null if no sample is
+   * found.
+   *
+   * @param instrument
+   * @param note
+   * @return filename of sample, or null if no sample is found.
+   */
+  public String getSampleFile(Instrument instrument, int note) {
+    if (!instrumentFileMap.containsKey(instrument)) {
+      System.out.printf("No notes available for instrument %s%n", instrument);
+      return null;
+    }
+
+    final Map<Integer, String> noteToFileMap = instrumentFileMap.get(instrument);
+    if (!noteToFileMap.containsKey(note)) {
+      System.out.printf("Can't play note %s on instrument %s%n", note, instrument);
+      return null;
+    }
+
+    return noteToFileMap.get(note);
+  }
+}

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/SoundEncoder.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/SoundEncoder.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.Base64;
 import java.util.HashMap;
 
-public class SoundEncoder {
+class SoundEncoder {
 
   public static TheaterMessage encodeStreamToMessage(ByteArrayOutputStream stream) {
     final String encodedString = Base64.getEncoder().encodeToString(stream.toByteArray());

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -4,6 +4,7 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
+import org.code.media.AudioWriter;
 import org.code.media.Color;
 import org.code.media.Image;
 import org.code.protocol.GlobalProtocol;
@@ -13,10 +14,14 @@ public class Stage {
   private final BufferedImage image;
   private final OutputAdapter outputAdapter;
   private final GifWriter gifWriter;
-  private final ByteArrayOutputStream outputStream;
+  private final ByteArrayOutputStream imageOutputStream;
+  private final Graphics2D graphics;
+  private final ByteArrayOutputStream audioOutputStream;
+  private final AudioWriter.Factory audioWriterFactory;
+  private final AudioWriter audioWriter;
+  private final InstrumentSampleLoader instrumentSampleLoader;
   private java.awt.Color strokeColor;
   private java.awt.Color fillColor;
-  private Graphics2D graphics;
   private boolean hasPlayed;
 
   private static final int WIDTH = 400;
@@ -28,7 +33,10 @@ public class Stage {
    * using Theater.stage.
    */
   protected Stage() {
-    this(new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_RGB));
+    this(
+        new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_RGB),
+        new AudioWriter.Factory(),
+        new InstrumentSampleLoader());
   }
 
   /**
@@ -37,12 +45,19 @@ public class Stage {
    *
    * @param image
    */
-  protected Stage(BufferedImage image) {
+  protected Stage(
+      BufferedImage image,
+      AudioWriter.Factory audioWriterFactory,
+      InstrumentSampleLoader instrumentSampleLoader) {
     this.image = image;
     this.graphics = this.image.createGraphics();
     this.outputAdapter = GlobalProtocol.getInstance().getOutputAdapter();
-    this.outputStream = new ByteArrayOutputStream();
-    this.gifWriter = new GifWriter(this.outputStream);
+    this.imageOutputStream = new ByteArrayOutputStream();
+    this.gifWriter = new GifWriter(this.imageOutputStream);
+    this.audioOutputStream = new ByteArrayOutputStream();
+    this.audioWriterFactory = audioWriterFactory;
+    this.audioWriter = audioWriterFactory.createAudioWriter(this.audioOutputStream);
+    this.instrumentSampleLoader = instrumentSampleLoader;
     this.hasPlayed = false;
 
     // set up the image for drawing (set a white background and black stroke/fill)
@@ -66,7 +81,9 @@ public class Stage {
    *
    * @param sound an array of samples to play.
    */
-  public void playSound(double[] sound) {}
+  public void playSound(double[] sound) {
+    this.audioWriter.writeAudioSamples(sound);
+  }
 
   /**
    * Plays the sound referenced by the file name.
@@ -74,7 +91,9 @@ public class Stage {
    * @param filename the file to play in the asset manager.
    * @throws FileNotFoundException if the file can't be found in the project.
    */
-  public void playSound(String filename) throws FileNotFoundException {}
+  public void playSound(String filename) throws FileNotFoundException {
+    this.audioWriter.writeAudioFile(filename);
+  }
 
   /**
    * Plays a note with the selected instrument.
@@ -84,7 +103,18 @@ public class Stage {
    * @param seconds length of the note. Implementer's note: Behind the scenes, this should just be
    *     implemented using an array of loopable sounds (Mike can generate these).
    */
-  public void playNote(Instrument instrument, int note, double seconds) {}
+  public void playNote(Instrument instrument, int note, double seconds) {
+    final String sampleFile = instrumentSampleLoader.getSampleFile(instrument, note);
+    if (sampleFile == null) {
+      return;
+    }
+
+    try {
+      this.audioWriter.writeAudioFile(sampleFile, seconds);
+    } catch (FileNotFoundException e) {
+      System.out.printf("Could not play instrument: %s at note: %s%n", instrument, note);
+    }
+  }
 
   /**
    * Wait the provided number of seconds before performing the next draw or play command.
@@ -93,7 +123,8 @@ public class Stage {
    *     smallest value can be .1 seconds.
    */
   public void pause(double seconds) {
-    this.gifWriter.writeToGif(this.image, (int) (seconds * 1000));
+    this.gifWriter.writeToGif(this.image, (int) (Math.max(seconds, 0.1) * 1000));
+    this.audioWriter.addDelay(Math.max(seconds, 0.1));
   }
 
   /**
@@ -325,7 +356,11 @@ public class Stage {
     } else {
       this.gifWriter.writeToGif(this.image, 0);
       this.gifWriter.close();
-      outputAdapter.sendMessage(ImageEncoder.encodeStreamToMessage(this.outputStream));
+      this.outputAdapter.sendMessage(ImageEncoder.encodeStreamToMessage(this.imageOutputStream));
+
+      this.audioWriter.writeToAudioStreamAndClose();
+      this.outputAdapter.sendMessage(SoundEncoder.encodeStreamToMessage(this.audioOutputStream));
+
       this.hasPlayed = true;
     }
   }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -356,9 +356,9 @@ public class Stage {
     } else {
       this.gifWriter.writeToGif(this.image, 0);
       this.gifWriter.close();
-      this.outputAdapter.sendMessage(ImageEncoder.encodeStreamToMessage(this.imageOutputStream));
-
       this.audioWriter.writeToAudioStreamAndClose();
+
+      this.outputAdapter.sendMessage(ImageEncoder.encodeStreamToMessage(this.imageOutputStream));
       this.outputAdapter.sendMessage(SoundEncoder.encodeStreamToMessage(this.audioOutputStream));
 
       this.hasPlayed = true;

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -17,7 +17,6 @@ public class Stage {
   private final ByteArrayOutputStream imageOutputStream;
   private final Graphics2D graphics;
   private final ByteArrayOutputStream audioOutputStream;
-  private final AudioWriter.Factory audioWriterFactory;
   private final AudioWriter audioWriter;
   private final InstrumentSampleLoader instrumentSampleLoader;
   private java.awt.Color strokeColor;
@@ -55,7 +54,6 @@ public class Stage {
     this.imageOutputStream = new ByteArrayOutputStream();
     this.gifWriter = new GifWriter(this.imageOutputStream);
     this.audioOutputStream = new ByteArrayOutputStream();
-    this.audioWriterFactory = audioWriterFactory;
     this.audioWriter = audioWriterFactory.createAudioWriter(this.audioOutputStream);
     this.instrumentSampleLoader = instrumentSampleLoader;
     this.hasPlayed = false;

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/InstrumentSampleLoaderTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/InstrumentSampleLoaderTest.java
@@ -1,0 +1,42 @@
+package org.code.theater;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class InstrumentSampleLoaderTest {
+  private static final Instrument VALID_INSTRUMENT = Instrument.PIANO;
+  private static final int VALID_NOTE = 60;
+  private static final String VALID_FILE = "file.wav";
+
+  private InstrumentSampleLoader unitUnderTest;
+
+  @BeforeEach
+  public void setUp() {
+    final Map<Integer, String> instrumentMap = new HashMap<>();
+    instrumentMap.put(VALID_NOTE, VALID_FILE);
+
+    final Map<Instrument, Map<Integer, String>> testMap = new HashMap<>();
+    testMap.put(VALID_INSTRUMENT, instrumentMap);
+
+    unitUnderTest = new InstrumentSampleLoader(testMap);
+  }
+
+  @Test
+  public void testGetSampleFileReturnsNullForMissingInstrument() {
+    assertNull(unitUnderTest.getSampleFile(Instrument.BASS, VALID_NOTE));
+  }
+
+  @Test
+  public void testGetSampleFileReturnsNullForMissingNote() {
+    assertNull(unitUnderTest.getSampleFile(VALID_INSTRUMENT, 12));
+  }
+
+  @Test
+  public void testGetSampleFileReturnsFileNameForValidInstrumentAndNote() {
+    assertEquals(VALID_FILE, unitUnderTest.getSampleFile(VALID_INSTRUMENT, VALID_NOTE));
+  }
+}

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
@@ -7,7 +7,9 @@ import static org.mockito.Mockito.*;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
 import java.io.PrintStream;
+import org.code.media.AudioWriter;
 import org.code.protocol.GlobalProtocol;
 import org.code.protocol.InputAdapter;
 import org.code.protocol.OutputAdapter;
@@ -22,6 +24,11 @@ public class StageTest {
   private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
   private BufferedImage bufferedImage;
   private Graphics2D graphics;
+  private AudioWriter.Factory audioWriterFactory;
+  private AudioWriter audioWriter;
+  private InstrumentSampleLoader instrumentSampleLoader;
+
+  private Stage s;
 
   @BeforeEach
   public void setUp() {
@@ -30,6 +37,13 @@ public class StageTest {
     bufferedImage = mock(BufferedImage.class);
     graphics = mock(Graphics2D.class);
     when(bufferedImage.createGraphics()).thenReturn(graphics);
+    audioWriterFactory = mock(AudioWriter.Factory.class);
+    audioWriter = mock(AudioWriter.class);
+    when(audioWriterFactory.createAudioWriter(any(ByteArrayOutputStream.class)))
+        .thenReturn(audioWriter);
+    instrumentSampleLoader = mock(InstrumentSampleLoader.class);
+
+    s = new Stage(bufferedImage, audioWriterFactory, instrumentSampleLoader);
   }
 
   @AfterEach
@@ -39,7 +53,6 @@ public class StageTest {
 
   @Test
   void drawLineDefaultsToBlack() {
-    Stage s = new Stage(bufferedImage);
     s.removeStrokeColor();
     s.drawLine(0, 0, 100, 100);
     verify(graphics).setColor(Color.BLACK);
@@ -48,7 +61,6 @@ public class StageTest {
 
   @Test
   void removingStrokeAndFillPreventsShapeDrawing() {
-    Stage s = new Stage(bufferedImage);
     s.removeFillColor();
     s.removeStrokeColor();
     s.drawRegularPolygon(0, 0, 5, 100);
@@ -58,7 +70,6 @@ public class StageTest {
 
   @Test
   void removingStrokeStillCallsFill() {
-    Stage s = new Stage(bufferedImage);
     s.removeStrokeColor();
     s.drawEllipse(5, 5, 100, 100);
     verify(graphics, never()).drawOval(5, 5, 100, 100);
@@ -67,14 +78,12 @@ public class StageTest {
 
   @Test
   void drawOpenShapeDrawsLines() {
-    Stage s = new Stage(bufferedImage);
     s.drawShape(new int[] {0, 0, 25, 30, 0, 100}, false);
     verify(graphics, Mockito.times(2)).drawLine(anyInt(), anyInt(), anyInt(), anyInt());
   }
 
   @Test
   void drawClosedShapeDrawsAndFillsShape() {
-    Stage s = new Stage(bufferedImage);
     s.drawShape(new int[] {0, 0, 25, 30, 0, 100}, true);
     int[] xPoints = new int[] {0, 25, 0};
     int[] yPoints = new int[] {0, 30, 100};
@@ -103,6 +112,44 @@ public class StageTest {
     int[] oddNumberOfPoints = new int[] {0, 0, 1, 1, 2};
     verifyInvalidShapeThrowsException(s, tooFewPoints, false);
     verifyInvalidShapeThrowsException(s, oddNumberOfPoints, true);
+  }
+
+  @Test
+  void testPlaySoundWithArrayCallsAudioWriter() {
+    final double[] testSamples = {1.0, -1.0, 0.0};
+    s.playSound(testSamples);
+    verify(audioWriter).writeAudioSamples(testSamples);
+  }
+
+  @Test
+  void testPlaySoundWithFilenameCallsAudioWriter() throws FileNotFoundException {
+    final String testFile = "test.wav";
+    s.playSound(testFile);
+    verify(audioWriter).writeAudioFile(testFile);
+  }
+
+  @Test
+  void testPlayNoteDoesNothingWhenFileNotFound() throws FileNotFoundException {
+    when(instrumentSampleLoader.getSampleFile(any(Instrument.class), anyInt())).thenReturn(null);
+
+    s.playNote(Instrument.PIANO, 60, 1);
+
+    verify(instrumentSampleLoader).getSampleFile(Instrument.PIANO, 60);
+    verify(audioWriter, never()).writeAudioFile(anyString(), anyDouble());
+  }
+
+  @Test
+  void testPlayNoteCallsAudioWriterIfFileExists() throws FileNotFoundException {
+    final String testSampleFile = "test.wav";
+    final int note = 60;
+    final double seconds = 2.0;
+    when(instrumentSampleLoader.getSampleFile(any(Instrument.class), anyInt()))
+        .thenReturn(testSampleFile);
+
+    s.playNote(Instrument.PIANO, note, seconds);
+
+    verify(instrumentSampleLoader).getSampleFile(Instrument.PIANO, note);
+    verify(audioWriter).writeAudioFile(testSampleFile, seconds);
   }
 
   private void verifyInvalidShapeThrowsException(Stage s, int[] points, boolean close) {


### PR DESCRIPTION
This hooks up the theater audio API to the existing audio code, which enables most of the Theater audio functionality, except for:
- Actually loading audio files from asset URLs (pending implementation of asset URL construction)
- Playing instruments via `playNote()`. The underlying code is written assuming that we will have a list of file paths and/or URLs for the various audio samples, so all the logic for looking up audio samples exists, but the actual map of instrument and note to file/URL is empty (see `InstrumentSampleLoader`).


Tested locally & with unit tests.