### PR TITLE
Fix CloudFormation template to actually invoke Lambda runtime wrapper script

### DIFF
--- a/org-code-javabuilder/change_runtime_directory
+++ b/org-code-javabuilder/change_runtime_directory
@@ -1,6 +1,7 @@
 #!/bin/bash
-# This script is deployed as a lambda layer to ensure our lambda runs from a temporary folder.
-# This enables File I/O on our lambda.
-rm -rf /tmp/*
-cd $(mktemp -d)
+# This script is deployed as an AWS Lambda Layer and is invoked as a Lambda runtime wrapper script. It changes
+# the Java runtime to launch from the only write-able directory (/tmp) to make it easier for student projects to
+# write files. The Lambda Request Handler is responsible for clearing the contents of this directory at the start/end
+# of each Lambda Invocation to prevent files created by one student session from leaking into the next session.
+cd /tmp
 exec "$@"

--- a/template.yml
+++ b/template.yml
@@ -244,7 +244,7 @@ Resources:
       CompatibleRuntimes:
         - java11
       ContentUri: org-code-javabuilder/change_runtime_directory
-      Description: Change AWS Lambda Java runtime directory to a temporary directory to enable student projects to read/write Files more easily.
+      Description: Change Java runtime to launch from the writeable /tmp directory to enable student projects to write files more easily.
       LayerName: change-java-runtime-directory
   BuildAndRunJavaProjectFunction:
     Type: AWS::Serverless::Function
@@ -259,6 +259,9 @@ Resources:
       Timeout: 300
       Role:
         Fn::ImportValue: JavabuilderLambdaExecutionRole
+      Environment:
+        Variables:
+          AWS_LAMBDA_EXEC_WRAPPER: /opt/change_runtime_directory
 Outputs:
   JavabuilderURL:
     Value:


### PR DESCRIPTION
The CloudFormation template was correctly deploying (via a Layer) the bash script that changes the Java runtime launch directory, but it wasn't actually configuring the Lambda to execute it. Add the environment variable to launch it. Also simplify the script to just change the `/tmp` directory. This script is only executed during the Init phase, so creating a randomly named subdirectory does not prevent files from one Invocation from persisting to a subsequent Invocation. The Request Handler will need to clear out the contents of the `/tmp` directory on each Invocation.