### PR TITLE
Theater/Javabuilder: Support uploading .wav files with alternate formats

### DIFF
--- a/org-code-javabuilder/media/src/main/java/org/code/media/AudioUtils.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/AudioUtils.java
@@ -35,15 +35,20 @@ class AudioUtils {
       AudioFileFormat.Type.WAVE;
 
   /**
-   * Determines if given {@link AudioFormat} is a valid format we can read
+   * Converts the given {@link AudioInputStream} to the default audio format for consistent
+   * reading/writing
    *
-   * @param audioFormat
-   * @return if audio format is valid
+   * @param stream
+   * @return converted AudioInputStream
+   * @throws SoundException if conversion is not supported
    */
-  public static boolean isAudioFormatValid(AudioFormat audioFormat) {
-    return audioFormat.getSampleRate() == DEFAULT_SAMPLE_RATE
-        && audioFormat.getSampleSizeInBits() == DEFAULT_BITS_PER_SAMPLE
-        && audioFormat.isBigEndian() == IS_NOT_BIG_ENDIAN;
+  public static AudioInputStream convertStreamToDefaultAudioFormat(AudioInputStream stream)
+      throws SoundException {
+    if (!AudioSystem.isConversionSupported(DEFAULT_AUDIO_FORMAT, stream.getFormat())) {
+      throw new SoundException(SoundExceptionKeys.INVALID_AUDIO_FILE_FORMAT);
+    }
+
+    return AudioSystem.getAudioInputStream(DEFAULT_AUDIO_FORMAT, stream);
   }
 
   /**

--- a/org-code-javabuilder/media/src/main/java/org/code/media/SoundLoader.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/SoundLoader.java
@@ -3,7 +3,6 @@ package org.code.media;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
-import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.UnsupportedAudioFileException;
@@ -25,17 +24,13 @@ public class SoundLoader {
     // Acquire AudioInputStream
     final AudioInputStream audioInputStream;
     try {
+      final URL audioFileUrl = new URL(GlobalProtocol.getInstance().generateAssetUrl(filename));
       audioInputStream =
-          AudioSystem.getAudioInputStream(
-              new URL(GlobalProtocol.getInstance().generateAssetUrl(filename)));
+          AudioUtils.convertStreamToDefaultAudioFormat(
+              AudioSystem.getAudioInputStream(audioFileUrl));
     } catch (IOException e) {
       throw new FileNotFoundException("Could not find file: " + filename);
     } catch (UnsupportedAudioFileException e) {
-      throw new SoundException(SoundExceptionKeys.INVALID_AUDIO_FILE_FORMAT);
-    }
-
-    final AudioFormat audioFormat = audioInputStream.getFormat();
-    if (!AudioUtils.isAudioFormatValid(audioFormat)) {
       throw new SoundException(SoundExceptionKeys.INVALID_AUDIO_FILE_FORMAT);
     }
 
@@ -48,6 +43,7 @@ public class SoundLoader {
       throw new InternalJavabuilderError(InternalErrorKey.INTERNAL_EXCEPTION, e);
     }
 
-    return AudioUtils.convertByteArrayToDoubleArray(bytes, audioFormat.getChannels());
+    return AudioUtils.convertByteArrayToDoubleArray(
+        bytes, audioInputStream.getFormat().getChannels());
   }
 }

--- a/org-code-javabuilder/media/src/test/java/org/code/media/SoundLoaderTest.java
+++ b/org-code-javabuilder/media/src/test/java/org/code/media/SoundLoaderTest.java
@@ -80,18 +80,22 @@ class SoundLoaderTest {
   }
 
   @Test
-  public void testReadThrowsSoundExceptionIfAudioFormatInvalid() {
+  public void testReadThrowsSoundExceptionIfFormatConversionNotSupported() {
+    final SoundException soundException =
+        new SoundException(SoundExceptionKeys.INVALID_AUDIO_FILE_FORMAT);
     audioSystem
         .when(() -> AudioSystem.getAudioInputStream(any(URL.class)))
         .thenReturn(audioInputStream);
-    audioUtils.when(() -> AudioUtils.isAudioFormatValid(audioFormat)).thenReturn(false);
+    audioUtils
+        .when(() -> AudioUtils.convertStreamToDefaultAudioFormat(audioInputStream))
+        .thenThrow(soundException);
     Exception exception =
         assertThrows(
             SoundException.class,
             () -> {
               SoundLoader.read(TEST_FILE_NAME);
             });
-    assertEquals(SoundExceptionKeys.INVALID_AUDIO_FILE_FORMAT.toString(), exception.getMessage());
+    assertSame(soundException, exception);
   }
 
   @Test
@@ -99,7 +103,9 @@ class SoundLoaderTest {
     audioSystem
         .when(() -> AudioSystem.getAudioInputStream(any(URL.class)))
         .thenReturn(audioInputStream);
-    audioUtils.when(() -> AudioUtils.isAudioFormatValid(audioFormat)).thenReturn(true);
+    audioUtils
+        .when(() -> AudioUtils.convertStreamToDefaultAudioFormat(audioInputStream))
+        .thenReturn(audioInputStream);
 
     when(audioInputStream.readAllBytes()).thenThrow(IOException.class);
 
@@ -119,7 +125,9 @@ class SoundLoaderTest {
     audioSystem
         .when(() -> AudioSystem.getAudioInputStream(any(URL.class)))
         .thenReturn(audioInputStream);
-    audioUtils.when(() -> AudioUtils.isAudioFormatValid(audioFormat)).thenReturn(true);
+    audioUtils
+        .when(() -> AudioUtils.convertStreamToDefaultAudioFormat(audioInputStream))
+        .thenReturn(audioInputStream);
 
     when(audioInputStream.readAllBytes()).thenReturn(TEST_BYTE_ARRAY);
     doThrow(IOException.class).when(audioInputStream).close();
@@ -141,7 +149,9 @@ class SoundLoaderTest {
     audioSystem
         .when(() -> AudioSystem.getAudioInputStream(any(URL.class)))
         .thenReturn(audioInputStream);
-    audioUtils.when(() -> AudioUtils.isAudioFormatValid(audioFormat)).thenReturn(true);
+    audioUtils
+        .when(() -> AudioUtils.convertStreamToDefaultAudioFormat(audioInputStream))
+        .thenReturn(audioInputStream);
     audioUtils
         .when(() -> AudioUtils.convertByteArrayToDoubleArray(TEST_BYTE_ARRAY, TEST_CHANNELS))
         .thenReturn(TEST_DOUBLE_ARRAY);


### PR DESCRIPTION
Allows for uploading .wav files of any format (e.g. 48kHz, 96kHz, 24-bit, 8-bit, etc) as well as any other file format the Java sound library supports (includes .aiff).

https://codedotorg.atlassian.net/browse/CSA-534

Tested locally with various .wav files.