### PR TITLE
Add Output Bucket to CloudFormation template

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -20,6 +20,8 @@ Globals:
     Timeout: 30
     MemorySize: 3008
     Tracing: Active
+Conditions:
+  IsDevCondition: !Equals [!Ref BaseDomainName, "dev-code.org"] 
 Resources:
   Domain:
     Type: AWS::Route53::RecordSet
@@ -267,7 +269,7 @@ Resources:
   OutputBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub  "cdo-dev-${SubDomainName}-output"
+      BucketName: !If [IsDevCondition, !Sub "cdo-dev-${SubDomainName}-output", !Sub "cdo-${SubDomainName}-output"] 
       CorsConfiguration:
         CorsRules:
           - AllowedMethods: [GET]

--- a/template.yml
+++ b/template.yml
@@ -262,6 +262,8 @@ Resources:
       Environment:
         Variables:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/change_runtime_directory
+          OUTPUT_BUCKET_NAME: !Ref OutputBucket
+          GET_OUTPUT_URL: !Sub "https://${OutputDomain}"
   OutputBucket:
     Type: AWS::S3::Bucket
     Properties:
@@ -274,7 +276,7 @@ Resources:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
-              SSEAlgorithm: 'aws:kms'
+              SSEAlgorithm: 'AES256'
       LifecycleConfiguration:
         Rules:
           - Id: ExpirationRule

--- a/template.yml
+++ b/template.yml
@@ -262,6 +262,82 @@ Resources:
       Environment:
         Variables:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/change_runtime_directory
+  OutputBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub  "cdo-dev-${SubDomainName}-output"
+      CorsConfiguration:
+        CorsRules:
+          - AllowedMethods: [GET]
+            AllowedOrigins: ['*']
+            AllowedHeaders: ['*']
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: 'aws:kms'
+  OutputBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref OutputBucket
+      PolicyDocument:
+        Statement:
+        - Action: ['s3:GetObject']
+          Effect: Allow
+          Resource: !Sub "arn:aws:s3:::${OutputBucket}/*"
+          Principal: '*'
+  OutputAPICertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !Sub "${SubDomainName}-output.${BaseDomainName}"
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        - DomainName: !Sub "${SubDomainName}-output.${BaseDomainName}"
+          HostedZoneId: !Ref BaseDomainNameHostedZonedID
+  OutputDomain:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneName: !Sub "${BaseDomainName}."
+      Name: !Sub "${SubDomainName}-output.${BaseDomainName}"
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt OutputCDN.DomainName
+        HostedZoneId: Z2FDTNDATAQYW2 # static ID for cloudfront aliases
+  OutputCDN:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        Aliases: [!Sub "${SubDomainName}-output.${BaseDomainName}"]
+        ViewerCertificate:
+          AcmCertificateArn: !Ref OutputAPICertificate
+          MinimumProtocolVersion: TLSv1
+          SslSupportMethod: sni-only
+        CustomErrorResponses:
+          - ErrorCode: 403
+            ErrorCachingMinTTL: 0
+        Logging:
+          Bucket: !Ref LogBucket
+          IncludeCookies: false
+          Prefix: !Sub "${SubDomainName}-output.${BaseDomainName}"
+        Origins:
+          - Id: OutputBucket
+            DomainName: !GetAtt OutputBucket.DomainName
+            S3OriginConfig: {}
+        DefaultCacheBehavior:
+          TargetOriginId: API
+          AllowedMethods: [DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT]
+          Compress: true
+          DefaultTTL: 0
+          ForwardedValues: {QueryString: false}
+          ViewerProtocolPolicy: redirect-to-https
+        CacheBehaviors:
+          - TargetOriginId: OutputBucket
+            PathPattern: /output/*
+            AllowedMethods: [DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT]
+            Compress: true
+            DefaultTTL: 0
+            ForwardedValues: {QueryString: true}
+            ViewerProtocolPolicy: redirect-to-https
 Outputs:
   JavabuilderURL:
     Value:

--- a/template.yml
+++ b/template.yml
@@ -322,6 +322,7 @@ Resources:
         CustomErrorResponses:
           - ErrorCode: 403
             ErrorCachingMinTTL: 0
+        # TODO: enable logging when LogBucket is set up
         # Logging:
         #   Bucket: !Ref LogBucket
         #   IncludeCookies: false

--- a/template.yml
+++ b/template.yml
@@ -275,6 +275,11 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: 'aws:kms'
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpirationRule
+            Status: Enabled
+            ExpirationInDays: 1
   OutputBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
@@ -315,29 +320,21 @@ Resources:
         CustomErrorResponses:
           - ErrorCode: 403
             ErrorCachingMinTTL: 0
-        Logging:
-          Bucket: !Ref LogBucket
-          IncludeCookies: false
-          Prefix: !Sub "${SubDomainName}-output.${BaseDomainName}"
+        # Logging:
+        #   Bucket: !Ref LogBucket
+        #   IncludeCookies: false
+        #   Prefix: !Sub "${SubDomainName}-output.${BaseDomainName}"
         Origins:
           - Id: OutputBucket
             DomainName: !GetAtt OutputBucket.DomainName
             S3OriginConfig: {}
         DefaultCacheBehavior:
-          TargetOriginId: API
+          TargetOriginId: OutputBucket
           AllowedMethods: [DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT]
           Compress: true
           DefaultTTL: 0
-          ForwardedValues: {QueryString: false}
+          ForwardedValues: {QueryString: true}
           ViewerProtocolPolicy: redirect-to-https
-        CacheBehaviors:
-          - TargetOriginId: OutputBucket
-            PathPattern: /output/*
-            AllowedMethods: [DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT]
-            Compress: true
-            DefaultTTL: 0
-            ForwardedValues: {QueryString: true}
-            ViewerProtocolPolicy: redirect-to-https
 Outputs:
   JavabuilderURL:
     Value:


### PR DESCRIPTION
Additions to the Javabuilder CloudFormation Template to add new components needed for writing theater files to S3. New components are:
- S3 Bucket with public read access. Objects in the bucket expire after 1 day since these are temporary files.
- Output Domain name configured via CloudFront 
- API Certificate for Output Domain Name

This is similar to our [p5-replay template](https://github.com/code-dot-org/p5-replay/blob/main/template.yml)