### PR TITLE
Updated hasPaint to treat a large grid painter as having infinite paint

### DIFF
--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import org.code.protocol.OutputAdapter;
 
 public class Painter {
+  private static final int OVERSIZED_GRID = 16;
   private static int lastId = 0;
   private int xLocation;
   private int yLocation;
@@ -84,7 +85,7 @@ public class Painter {
    * @param color the color of the paint being added
    */
   public void paint(String color) {
-    if (this.remainingPaint > 0) {
+    if (this.hasPaint()) {
       this.grid.getSquare(this.xLocation, this.yLocation).setColor(color);
       this.remainingPaint--;
       HashMap<String, String> details = this.getSignalDetails();
@@ -146,6 +147,9 @@ public class Painter {
 
   /** @return True if the painter's personal bucket has paint in it. */
   public boolean hasPaint() {
+    if (this.grid.getSize() >= OVERSIZED_GRID) {
+      return true;
+    }
     return this.remainingPaint > 0;
   }
 

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import org.code.protocol.OutputAdapter;
 
 public class Painter {
-  private static final int OVERSIZED_GRID = 16;
+  private static final int LARGE_GRID_SIZE = 16;
   private static int lastId = 0;
   private int xLocation;
   private int yLocation;
@@ -147,7 +147,7 @@ public class Painter {
 
   /** @return True if the painter's personal bucket has paint in it. */
   public boolean hasPaint() {
-    if (this.grid.getSize() >= OVERSIZED_GRID) {
+    if (this.grid.getSize() >= LARGE_GRID_SIZE) {
       return true;
     }
     return this.remainingPaint > 0;

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
@@ -150,4 +150,24 @@ public class PainterTest {
     painter.paint("red");
     assertEquals(painter.getMyPaint(), 0);
   }
+
+  @Test
+  void largeGridInfinitePaint() {
+    World w = new World(16);
+    World.setInstance(w);
+    Painter painter = new Painter(0, 0, "North", 1);
+    assertTrue(painter.hasPaint());
+    painter.paint("red");
+    assertTrue(painter.hasPaint());
+  }
+
+  @Test
+  void noInfinitePaint() {
+    World w = new World(15);
+    World.setInstance(w);
+    Painter painter = new Painter(0, 0, "North", 1);
+    assertTrue(painter.hasPaint());
+    painter.paint("red");
+    assertFalse(painter.hasPaint());
+  }
 }


### PR DESCRIPTION
The goal: Painters in large grids never run out of paint!

If a grid size is 16 tiles or larger, we will always return true for hasPaint. Implications: there is no need for paint buckets in large grid sizes. This will be accompanied by a followup task in the cdo repo preventing a save in levelbuilder if a writer tries to insert a paint bucket in the starter code of neighborhoods with grid sizes 16 or larger. 

Jira Task: https://codedotorg.atlassian.net/browse/CSA-409

