### PR TITLE
Lambda: increase memory to 1024 mb

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -257,7 +257,7 @@ Resources:
       Runtime: java11
       CodeUri: org-code-javabuilder/lib/build/distributions/lib.zip
       Description: Compile and execute a JavaLab project.
-      MemorySize: 512
+      MemorySize: 1024
       Timeout: 300
       Role:
         Fn::ImportValue: JavabuilderLambdaExecutionRole


### PR DESCRIPTION
We were hitting issues with our 512 mb lambda memory limit on theater. Increase to 1024 mb.