### PR TITLE
Theater: append timestamp to asset url

### DIFF
--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
@@ -60,7 +60,10 @@ public class GlobalProtocol {
   }
 
   public String generateAssetUrl(String filename) {
-    return String.format("%s/v3/assets/%s/%s", this.dashboardHostname, this.channelId, filename);
+    // append timestamp to asset url to avoid cached 404s.
+    return String.format(
+        "%s/v3/assets/%s/%s?t=%d",
+        this.dashboardHostname, this.channelId, filename, System.currentTimeMillis());
   }
 
   public String generateSourcesUrl() {


### PR DESCRIPTION
The assets endpoint seems to be caching 404s. Append a timestamp to the url to ensure we don't get a cached 404 after an asset has been uploaded.

Tested on an adhoc.