### PR TITLE
Theater: Play audio in parallel instead of sequentially

### DIFF
--- a/org-code-javabuilder/media/src/main/java/org/code/media/AudioUtils.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/AudioUtils.java
@@ -133,6 +133,30 @@ class AudioUtils {
     return Arrays.copyOf(samples, newLength);
   }
 
+  /**
+   * Blends audio samples from newSamples into originalSamples starting at the sample index
+   * indicated by sampleOffset
+   *
+   * @param originalSamples original samples to blend into
+   * @param newSamples new samples to blend
+   * @param sampleOffset sample index to start blending
+   * @return
+   */
+  public static double[] blendSamples(
+      double[] originalSamples, double[] newSamples, int sampleOffset) {
+    final double[] blendedSamples =
+        Arrays.copyOf(
+            originalSamples, Math.max(originalSamples.length, sampleOffset + newSamples.length));
+
+    for (int i = 0; i < newSamples.length; i++) {
+      // Blend samples by adding and clamping to range (-1.0, 1.0)
+      final double blendedSample = blendedSamples[i + sampleOffset] + newSamples[i];
+      blendedSamples[i + sampleOffset] = Math.max(-1.0, Math.min(1.0, blendedSample));
+    }
+
+    return blendedSamples;
+  }
+
   public static int getDefaultSampleRate() {
     return DEFAULT_SAMPLE_RATE;
   }

--- a/org-code-javabuilder/media/src/test/java/org/code/media/AudioUtilsTest.java
+++ b/org-code-javabuilder/media/src/test/java/org/code/media/AudioUtilsTest.java
@@ -169,9 +169,7 @@ class AudioUtilsTest {
     when(audioInputStream.readAllBytes()).thenReturn(BYTE_ARRAY_MONO);
 
     final double[] converted = AudioUtils.readSamplesFromAssetFile(TEST_FILE_NAME);
-    for (int i = 0; i < converted.length; i++) {
-      assertEquals(DOUBLE_ARRAY[i], Math.round(converted[i] * 10) / 10.0);
-    }
+    assertSampleArraysMatch(DOUBLE_ARRAY, converted);
 
     verify(audioFormat).getChannels();
   }
@@ -203,10 +201,7 @@ class AudioUtilsTest {
   @Test
   public void testConvertByteArrayConvertsCorrectly() throws SoundException {
     double[] converted = AudioUtils.convertByteArrayToDoubleArray(BYTE_ARRAY_MONO, 1);
-    // Verify values are correct when rounded
-    for (int i = 0; i < converted.length; i++) {
-      assertEquals(DOUBLE_ARRAY[i], Math.round(converted[i] * 10) / 10.0);
-    }
+    assertSampleArraysMatch(DOUBLE_ARRAY, converted);
   }
 
   @Test
@@ -242,5 +237,28 @@ class AudioUtilsTest {
     Arrays.fill(samples, 0.5);
 
     assertSame(samples, AudioUtils.truncateSamples(samples, 7.0));
+  }
+
+  @Test
+  public void testBlendSamplesBlendsCorrectly() {
+    final double[] samples = new double[] {0.2, -0.4, 0.7, -0.9};
+    // blend starting at index 0
+    double[] expected = new double[] {0.4, -0.8, 1.0, -1.0};
+    assertSampleArraysMatch(expected, AudioUtils.blendSamples(samples, samples, 0));
+
+    // blend starting at index 1
+    expected = new double[] {0.2, -0.2, 0.3, -0.2, -0.9};
+    assertSampleArraysMatch(expected, AudioUtils.blendSamples(samples, samples, 1));
+
+    // blend starting at index 2
+    expected = new double[] {0.2, -0.4, 0.9, -1.0, 0.7, -0.9};
+    assertSampleArraysMatch(expected, AudioUtils.blendSamples(samples, samples, 2));
+  }
+
+  // Verify values are correct when rounded
+  private void assertSampleArraysMatch(double[] expected, double[] actual) {
+    for (int i = 0; i < expected.length; i++) {
+      assertEquals(expected[i], Math.round(actual[i] * 10) / 10.0);
+    }
   }
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/CatMusic.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/CatMusic.java
@@ -59,8 +59,4 @@ public class CatMusic {
     this.audioWriter.writeToAudioStreamAndClose();
     this.outputAdapter.sendMessage(SoundEncoder.encodeStreamToMessage(this.audioOutputStream));
   }
-
-  public void reset() {
-    this.audioWriter.reset();
-  }
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
@@ -20,7 +20,13 @@ class GifWriter {
   private ImageWriteParam params;
   private ImageOutputStream imageOutputStream;
 
-  public GifWriter(ByteArrayOutputStream out) {
+  public static class Factory {
+    public GifWriter createGifWriter(ByteArrayOutputStream out) {
+      return new GifWriter(out);
+    }
+  }
+
+  GifWriter(ByteArrayOutputStream out) {
     try {
       this.imageOutputStream = ImageIO.createImageOutputStream(out);
       this.writer = ImageIO.getImageWritersBySuffix("gif").next();

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -105,22 +105,21 @@ public class Stage {
    *
    * @param instrument the instrument to play.
    * @param note the note to play. 60 represents middle C on a piano.
-   * @param seconds length of the note. Implementer's note: Behind the scenes, this should just be
-   *     implemented using an array of loopable sounds (Mike can generate these).
+   * @param seconds length of the note.
    */
   public void playNote(Instrument instrument, int note, double seconds) {
     this.playNote(instrument, note, seconds, false);
   }
 
   /**
-   * Plays a note with the selected instrument and adds a pause for the duration of the note.
+   * Plays a note with the selected instrument and adds a pause in drawing/audio for the duration of
+   * the note, so that subsequent play commands begin after the note has finished playing.
    * Convenience method for playing notes in sequence without needing to call pause() between each
    * one.
    *
    * @param instrument the instrument to play.
    * @param note the note to play. 60 represents middle C on a piano.
-   * @param seconds length of the note. Implementer's note: Behind the scenes, this should just be
-   *     implemented using an array of loopable sounds (Mike can generate these).
+   * @param seconds length of the note.
    */
   public void playNoteAndPause(Instrument instrument, int note, double seconds) {
     this.playNote(instrument, note, seconds, true);

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
@@ -26,7 +26,7 @@ public class StageTest {
   private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
   private BufferedImage bufferedImage;
   private Graphics2D graphics;
-  private AudioWriter.Factory audioWriterFactory;
+  private GifWriter gifWriter;
   private AudioWriter audioWriter;
   private InstrumentSampleLoader instrumentSampleLoader;
 
@@ -39,13 +39,18 @@ public class StageTest {
     bufferedImage = mock(BufferedImage.class);
     graphics = mock(Graphics2D.class);
     when(bufferedImage.createGraphics()).thenReturn(graphics);
-    audioWriterFactory = mock(AudioWriter.Factory.class);
+
+    gifWriter = mock(GifWriter.class);
+    final GifWriter.Factory gifWriterFactory = mock(GifWriter.Factory.class);
+    when(gifWriterFactory.createGifWriter(any(ByteArrayOutputStream.class))).thenReturn(gifWriter);
+
+    final AudioWriter.Factory audioWriterFactory = mock(AudioWriter.Factory.class);
     audioWriter = mock(AudioWriter.class);
     when(audioWriterFactory.createAudioWriter(any(ByteArrayOutputStream.class)))
         .thenReturn(audioWriter);
     instrumentSampleLoader = mock(InstrumentSampleLoader.class);
 
-    s = new Stage(bufferedImage, audioWriterFactory, instrumentSampleLoader);
+    s = new Stage(bufferedImage, gifWriterFactory, audioWriterFactory, instrumentSampleLoader);
   }
 
   @AfterEach
@@ -153,6 +158,31 @@ public class StageTest {
 
     verify(instrumentSampleLoader).getSampleFilePath(Instrument.PIANO, note);
     verify(audioWriter).writeAudioFromLocalFile(testSampleFile, seconds);
+    verify(audioWriter, never()).addDelay(anyDouble());
+  }
+
+  @Test
+  void testPlayNoteAndPauseDoesNotPauseWhenFileNotFound() throws FileNotFoundException {
+    when(instrumentSampleLoader.getSampleFilePath(any(Instrument.class), anyInt()))
+        .thenReturn(null);
+
+    s.playNoteAndPause(Instrument.PIANO, 60, 1);
+
+    verify(audioWriter, never()).addDelay(anyDouble());
+  }
+
+  @Test
+  void testPlayNoteAndPauseDoesPauseIfFileExists() throws FileNotFoundException {
+    final String testSampleFile = "test.wav";
+    final int note = 60;
+    final double seconds = 2.0;
+    when(instrumentSampleLoader.getSampleFilePath(any(Instrument.class), eq(note)))
+        .thenReturn(testSampleFile);
+
+    s.playNoteAndPause(Instrument.PIANO, note, seconds);
+
+    verify(audioWriter).addDelay(seconds);
+    verify(gifWriter).writeToGif(any(BufferedImage.class), eq((int) (seconds * 1000)));
   }
 
   @Test


### PR DESCRIPTION
As per curriculum/product this changes audio API behavior to have audio APIs play back audio in parallel rather than sequentially. This mirrors how draw commands work as well. Also adds the `playNoteWithPause` method to the API which allows users to play notes in sequence without having to explicitly call `pause` between each play command. 

Tested locally.