### PR TITLE
Remove tmp files at the start of each lambda execution

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilder.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilder.java
@@ -4,7 +4,6 @@ import java.io.*;
 import java.net.MalformedURLException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.List;
 import org.code.protocol.GlobalProtocol;
 import org.code.protocol.InputAdapter;
@@ -78,10 +77,7 @@ public class CodeBuilder implements AutoCloseable {
     if (this.tempFolder != null) {
       try {
         // Recursively delete the temp folder
-        Files.walk(this.tempFolder.toPath())
-            .sorted(Comparator.reverseOrder())
-            .map(Path::toFile)
-            .forEach(File::delete);
+        Util.recursivelyClearDirectory(this.tempFolder.toPath());
       } catch (IOException e) {
         throw new InternalFacingException(e.toString(), e);
       }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/Util.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/Util.java
@@ -1,9 +1,14 @@
 package org.code.javabuilder;
 
+import java.io.File;
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Comparator;
 import org.code.protocol.InternalErrorKey;
 import org.code.protocol.InternalJavabuilderError;
 
@@ -35,5 +40,9 @@ public class Util {
     }
 
     return String.join(System.getProperty("path.separator"), allJarPaths);
+  }
+
+  public static void recursivelyClearDirectory(Path directory) throws IOException {
+    Files.walk(directory).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
   }
 }


### PR DESCRIPTION
The lambda invocation happens from the `tmp` directory so student code can read and write files from their programs ([how and why we invoke from the tmp directory](https://github.com/code-dot-org/javabuilder/pull/26)). However, AWS Lambda [does not clear the contents of the `tmp` directory between invocations](https://docs.aws.amazon.com/lambda/latest/dg/best-practices.html) and may reuse these in future invocations. 

In our case, the `tmp` directory will only contain files created by a student's project. When the next student code uses this same lambda, those files will remain, potentially causing leaks between projects.

A student project could cause a fatal error in the middle of execution, causing the lambda to close prematurely. Because of this, we cannot guarantee clearing of the `tmp` folder after a student's code executes.

Therefore, we clear the `tmp` folder before any student code executes.

### Repro
An example of what the bug looked like in the past:
<img src="https://user-images.githubusercontent.com/8324574/126720893-c0e7d83a-c03e-4d76-b92b-5566e8f68d2a.png" width="400">

### Fix
An example of us fixing this bug in a dev deploy of Javabuilder:
<img src="https://user-images.githubusercontent.com/8324574/126720939-271caf9b-c97c-402e-8a5f-e6712524d656.png" width="450">
