### PR TITLE
Code doesn't compile if there is an empty file

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavaRunner.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavaRunner.java
@@ -6,7 +6,6 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.List;
-import org.code.protocol.InternalErrorKey;
 
 /** The class that executes the student's code */
 public class JavaRunner {
@@ -83,8 +82,8 @@ public class JavaRunner {
           }
         }
       } catch (ClassNotFoundException e) {
-        // this should be caught earlier in compilation
-        throw new UserFacingException(InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION, e);
+        // May be thrown if file is empty or contains only comments
+        throw new UserInitiatedException(UserInitiatedExceptionKey.CLASS_NOT_FOUND, e);
       }
     }
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserInitiatedExceptionKey.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserInitiatedExceptionKey.java
@@ -15,5 +15,7 @@ public enum UserInitiatedExceptionKey {
   // The user tried to include a source file that did not end in .java
   JAVA_EXTENSION_MISSING,
   // The user is writing to file too many times
-  TOO_MANY_WRITES
+  TOO_MANY_WRITES,
+  // The user tried to run a file without a class definition
+  CLASS_NOT_FOUND
 }


### PR DESCRIPTION
Handles the case where a student tries to run a project with an empty Java file (blank or only comments). I opted to keep this as a runtime error since technically the empty files do compile, but throw a ClassNotFoundException when trying to run.

Related code-dot-org PR for interpreting this error on the client: https://github.com/code-dot-org/code-dot-org/pull/41767

Repro steps:
- Navigate to a Javalab level
- Open and save a new file with the extension .java
- Run the program

Tested locally.