### PR TITLE
Theater: fix opacity issue

### DIFF
--- a/org-code-javabuilder/media/src/main/java/org/code/media/Color.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/Color.java
@@ -7,6 +7,7 @@ public class Color {
   private int red;
   private int green;
   private int blue;
+  private int alpha;
 
   /**
    * Creates a color from a string representation.
@@ -23,10 +24,11 @@ public class Color {
     this.red = colorToCopy.getRed();
     this.green = colorToCopy.getGreen();
     this.blue = colorToCopy.getBlue();
+    this.setFullOpacity();
   }
 
   /**
-   * Create a new color based on the red, green, and blue values provided.
+   * Create a new color based on the red, green, and blue values provided. Assumes 100% opacity
    *
    * @param red the red value from 0 - 255
    * @param green the green value from 0 - 255
@@ -36,6 +38,7 @@ public class Color {
     this.red = this.sanitizeValue(red);
     this.green = this.sanitizeValue(green);
     this.blue = this.sanitizeValue(blue);
+    this.setFullOpacity();
   }
 
   /**
@@ -47,12 +50,13 @@ public class Color {
     this.red = color.getRed();
     this.green = color.getGreen();
     this.blue = color.getBlue();
+    this.alpha = color.getAlpha();
   }
 
   /**
-   * Initialize a color with the combined RGB integer value consisting of the red component in bits
-   * 16-23, the green component in bits 8-15, and the blue component in bits 0-7. Only used for
-   * conversion between BufferedImage and org.code.media.Image
+   * Initialize a color with the combined RGB integer value consisting of the alpha component in
+   * bits 24-31, the red component in bits 16-23, the green component in bits 8-15, and the blue
+   * component in bits 0-7. Only used for conversion between BufferedImage and org.code.media.Image
    *
    * @param rgb
    */
@@ -60,6 +64,14 @@ public class Color {
     this.red = (rgb >> 16) & 255;
     this.blue = rgb & 255;
     this.green = (rgb >> 8) & 255;
+    this.alpha = (rgb >> 24) & 255;
+  }
+
+  protected Color(int red, int green, int blue, int alpha) {
+    this.red = this.sanitizeValue(red);
+    this.green = this.sanitizeValue(green);
+    this.blue = this.sanitizeValue(blue);
+    this.alpha = this.sanitizeValue(alpha);
   }
 
   /**
@@ -89,6 +101,10 @@ public class Color {
     return this.blue;
   }
 
+  protected int getAlpha() {
+    return this.alpha;
+  }
+
   /**
    * Sets the amount of red (ranging from 0 to 255). Values below 0 will be ignored and set to 0,
    * and values above 255 will be ignored and set to 255.
@@ -97,6 +113,8 @@ public class Color {
    */
   public void setRed(int value) {
     this.red = this.sanitizeValue(value);
+    // for now, setting the color implies we want full opacity
+    this.setFullOpacity();
   }
 
   /**
@@ -107,6 +125,8 @@ public class Color {
    */
   public void setGreen(int value) {
     this.green = this.sanitizeValue(value);
+    // for now, setting the color implies we want full opacity
+    this.setFullOpacity();
   }
 
   /**
@@ -117,14 +137,17 @@ public class Color {
    */
   public void setBlue(int value) {
     this.blue = this.sanitizeValue(value);
+    // for now, setting the color implies we want full opacity
+    this.setFullOpacity();
   }
 
   /**
-   * @return the combined RGB integer value consisting of the red component in bits 16-23, the green
-   *     component in bits 8-15, and the blue component in bits 0-7.
+   * @return the combined RGB integer value consisting of the alpha component in bits 24-31, the red
+   *     component in bits 16-23, the green component in bits 8-15, and the blue component in bits
+   *     0-7.
    */
   protected int getRGB() {
-    return (this.red << 16 | this.green << 8 | this.blue);
+    return (this.alpha << 24 | this.red << 16 | this.green << 8 | this.blue);
   }
 
   /**
@@ -141,6 +164,10 @@ public class Color {
       return 255;
     }
     return value;
+  }
+
+  private void setFullOpacity() {
+    this.alpha = 255;
   }
 
   public static java.awt.Color convertToAWTColor(Color c) {

--- a/org-code-javabuilder/media/src/main/java/org/code/media/Color.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/Color.java
@@ -28,7 +28,8 @@ public class Color {
   }
 
   /**
-   * Create a new color based on the red, green, and blue values provided. Assumes 100% opacity
+   * Create a new color based on the red, green, and blue values provided. The alpha value will be
+   * maximum opacity.
    *
    * @param red the red value from 0 - 255
    * @param green the green value from 0 - 255

--- a/org-code-javabuilder/media/src/main/java/org/code/media/Image.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/Image.java
@@ -128,7 +128,7 @@ public class Image {
    */
   public BufferedImage getBufferedImage() {
     BufferedImage bufferedImage =
-        new BufferedImage(this.width, this.height, BufferedImage.TYPE_INT_RGB);
+        new BufferedImage(this.width, this.height, BufferedImage.TYPE_INT_ARGB);
     for (int x = 0; x < this.width; x++) {
       for (int y = 0; y < this.height; y++) {
         bufferedImage.setRGB(x, y, this.pixels[x][y].getColor().getRGB());

--- a/org-code-javabuilder/media/src/test/java/org/code/media/ColorTest.java
+++ b/org-code-javabuilder/media/src/test/java/org/code/media/ColorTest.java
@@ -1,0 +1,22 @@
+package org.code.media;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class ColorTest {
+  @Test
+  public void defaultAlphaIs255() {
+    Color c = new Color(0, 0, 0);
+    assertEquals(255, c.getAlpha());
+  }
+
+  @Test
+  public void resettingColorSetsAlpha() {
+    Color c = new Color(0, 0, 0, 0);
+    assertEquals(0, c.getAlpha());
+    c.setBlue(255);
+    // now alpha should be 255 (max opacity), since we set the blue value on the color
+    assertEquals(255, c.getAlpha());
+  }
+}


### PR DESCRIPTION
We were ignoring opacity when creating images from file in the `Image` class. This change keeps track of the alpha value for each pixel instead of assuming all pixels are at full opacity. This means `.png`s with transparent backgrounds will maintain their transparent backgrounds (before this change, `.png`s with transparent backgrounds would end up with a green background).

Since we don't allow students to set the alpha value of a pixel, if a student resets any color value on a pixel, we will assume they want it to be at full opacity, even if the pixel was previously transparent.