### PR TITLE
Clean up SAM template

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,17 +1,16 @@
 #!/bin/bash -xe
 
-# Deploys API service CloudFormation stack.
+# Create/Update a Javabuilder CloudFormation stack.
 
-S3_BUCKET=${S3_BUCKET?Required}
+TEMPLATE_BUCKET=${TEMPLATE_BUCKET?Required}
 SUB_DOMAIN=${SUB_DOMAIN?Required}
 
 # Default to dev-code.org domain name and the Route 53 Hosted Zone ID in the Dev AWS account for that base domain name.
 BASE_DOMAIN=${BASE_DOMAIN-'dev-code.org'}
 BASE_DOMAIN_HOSTED_ZONE_ID=${BASE_DOMAIN_HOSTED_ZONE_ID-'Z07248463JGJ44FME5BZ5'}
 
-# CloudFormation stack names can't contain periods ("."), so replace them with hyphens ("-").
-FULLY_QUALIFIED_DOMAIN_NAME="${SUB_DOMAIN}.${BASE_DOMAIN}"
-STACK=${FULLY_QUALIFIED_DOMAIN_NAME//./-}
+# Use sub domain name as the CloudFormation Stack name.
+STACK=${SUB_DOMAIN}
 
 PROVISIONED_CONCURRENT_EXECUTIONS=${PROVISIONED_CONCURRENT_EXECUTIONS-'1'}
 
@@ -24,7 +23,7 @@ OUTPUT_TEMPLATE=$(mktemp)
 
 aws cloudformation package \
   --template-file ${TEMPLATE} \
-  --s3-bucket ${S3_BUCKET} \
+  --s3-bucket ${TEMPLATE_BUCKET} \
   --output-template-file ${OUTPUT_TEMPLATE}
 
 aws cloudformation deploy \

--- a/deploy.sh
+++ b/deploy.sh
@@ -27,10 +27,8 @@ aws cloudformation package \
   --s3-bucket ${S3_BUCKET} \
   --output-template-file ${OUTPUT_TEMPLATE}
 
-# TODO: Remove CAPABILITY_IAM temporarily added during testing.
 aws cloudformation deploy \
   --template-file ${OUTPUT_TEMPLATE} \
   --parameter-overrides SubDomainName=$SUB_DOMAIN BaseDomainName=$BASE_DOMAIN BaseDomainNameHostedZonedID=$BASE_DOMAIN_HOSTED_ZONE_ID ProvisionedConcurrentExecutions=$PROVISIONED_CONCURRENT_EXECUTIONS \
   --stack-name ${STACK} \
-  --capabilities CAPABILITY_IAM \
   "$@"

--- a/template.yml
+++ b/template.yml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Transform: AWS::Serverless-2016-10-31
-Description: Provision an instance of the Javabuilder service.
+Description: Provision an instance of the Javabuilder service. Empty the OutputBucket before deleting this Stack.
 Parameters:
   BaseDomainName:
     Type: String
@@ -85,7 +85,7 @@ Resources:
     Properties:
       ApiId: !Ref WebSocketAPI
       AuthorizerType: REQUEST
-      AuthorizerUri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${JavabuilderAuthorizerLambda.Arn}/invocations"
+      AuthorizerUri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${WebsocketAuthorizerLambda.Arn}/invocations"
       IdentitySource:
         - route.request.querystring.Authorization
       Name: WebSocketAuthorizer
@@ -194,12 +194,7 @@ Resources:
       Action: lambda:InvokeFunction
       FunctionName: !Ref StartSessionAndRelayMessagesFunction
       Principal: apigateway.amazonaws.com
-  APIGatewayCloudWatchLogs:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName:
-        Fn::Sub: ${SubDomainName}.${BaseDomainName}
-  JavabuilderAuthorizerLambda:
+  WebsocketAuthorizerLambda:
     Type: AWS::Serverless::Function
     Properties:
       Handler: lambda_function.lambda_handler
@@ -245,7 +240,7 @@ Resources:
       - WebSocketAuthorizer
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !Ref JavabuilderAuthorizerLambda
+      FunctionName: !Ref WebsocketAuthorizerLambda
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${WebSocketAPI}/authorizers/${WebSocketAuthorizer}"
   ChangeJavaRuntimeDirectoryLayer:
@@ -354,4 +349,4 @@ Resources:
 Outputs:
   JavabuilderURL:
     Value:
-      Fn::Sub: https://${SubDomainName}.${BaseDomainName}
+      Fn::Sub: wss://${SubDomainName}.${BaseDomainName}


### PR DESCRIPTION
Remove usage of `CAPABILITY_IAM` to create/update a Javabuilder CloudFormation Stack, a pre-requisite for engineers to be able to deploy / update Javabuilder Stacks in our production AWS account.

Also clean up arguments to better align with the build scripts used by the upcoming AWS CodePipeline, and clean up naming conventions.

After this change is merged, engineers will use a new syntax to run the deploy script (substituting `TEMPLATE_BUCKET=` for `S3_BUCKET=`.

Also, engineers will need to empty the Output Bucket in their Javabuilder environment, delete their entire Javabuilder CloudFormation Stack, and re-deploy their Javabuilder environment because the Stack naming convention is new.