### PR TITLE
Import assets from the level into Javabuilder

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
@@ -18,7 +18,7 @@ public class LocalMain {
     // Create and invoke the code execution environment
     try {
       UserProjectFiles userProjectFiles = fileLoader.loadFiles();
-      GlobalProtocol.create(outputAdapter, inputAdapter, "", "", new NoOpFileWriter());
+      GlobalProtocol.create(outputAdapter, inputAdapter, "", "", "", new NoOpFileWriter());
       try (CodeBuilder codeBuilder =
           new CodeBuilder(GlobalProtocol.getInstance(), userProjectFiles)) {
         codeBuilder.buildUserCode();

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -59,7 +59,7 @@ public class WebSocketServer {
     outputAdapter = new WebSocketOutputAdapter(session);
     inputAdapter = new WebSocketInputAdapter();
     GlobalProtocol.create(
-        outputAdapter, inputAdapter, dashboardHostname, channelId, new NoOpFileWriter());
+        outputAdapter, inputAdapter, dashboardHostname, channelId, levelId, new NoOpFileWriter());
     final UserProjectFileLoader fileLoader =
         new UserProjectFileLoader(
             GlobalProtocol.getInstance().generateSourcesUrl(),

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -76,7 +76,8 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
 
     // Load files to memory and create and invoke the code execution environment
     try {
-      GlobalProtocol.create(outputAdapter, inputAdapter, dashboardHostname, channelId, fileWriter);
+      GlobalProtocol.create(
+          outputAdapter, inputAdapter, dashboardHostname, channelId, levelId, fileWriter);
 
       try {
         // Delete any leftover contents of the tmp folder from previous lambda invocations

--- a/org-code-javabuilder/media/src/test/java/org/code/media/AudioUtilsTest.java
+++ b/org-code-javabuilder/media/src/test/java/org/code/media/AudioUtilsTest.java
@@ -19,8 +19,8 @@ import org.mockito.MockedStatic;
 
 class AudioUtilsTest {
 
-  private static final String TEST_DASHBOARD = "https://localhost-studio.code.org";
-  private static final String TEST_CHANNEL_ID = "0";
+  private static final String TEST_FILE_URL =
+      "https://localhost-studio.code.org/assets/beatbox.wav";
   private static final String TEST_FILE_NAME = "beatbox.wav";
   private static final int TEST_CHANNELS = 1;
 
@@ -33,18 +33,18 @@ class AudioUtilsTest {
     (byte) 0x00, (byte) 0x00 // 0.0
   };
 
+  private MockedStatic<GlobalProtocol> globalProtocol;
   private MockedStatic<AudioSystem> audioSystem;
   private AudioInputStream audioInputStream;
   private AudioFormat audioFormat;
 
   @BeforeEach
   public void setUp() {
-    GlobalProtocol.create(
-        mock(OutputAdapter.class),
-        mock(InputAdapter.class),
-        TEST_DASHBOARD,
-        TEST_CHANNEL_ID,
-        mock(JavabuilderFileWriter.class));
+    globalProtocol = mockStatic(GlobalProtocol.class);
+    final GlobalProtocol globalProtocolInstance = mock(GlobalProtocol.class);
+
+    globalProtocol.when(GlobalProtocol::getInstance).thenReturn(globalProtocolInstance);
+    when(globalProtocolInstance.generateAssetUrl(TEST_FILE_NAME)).thenReturn(TEST_FILE_URL);
 
     audioSystem = mockStatic(AudioSystem.class);
     audioInputStream = mock(AudioInputStream.class);
@@ -56,6 +56,7 @@ class AudioUtilsTest {
 
   @AfterEach
   public void tearDown() {
+    globalProtocol.close();
     audioSystem.close();
   }
 

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
@@ -25,7 +25,7 @@ public class PainterTest {
   @BeforeEach
   public void setUp() {
     GlobalProtocol.create(
-        outputAdapter, mock(InputAdapter.class), "", "", mock(JavabuilderFileWriter.class));
+        outputAdapter, mock(InputAdapter.class), "", "", "", mock(JavabuilderFileWriter.class));
     System.setOut(new PrintStream(outputStreamCaptor));
     World w = new World(singleSquareGrid);
     World.setInstance(w);

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/AssetUrlGenerator.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/AssetUrlGenerator.java
@@ -1,0 +1,100 @@
+package org.code.protocol;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class AssetUrlGenerator {
+  private final String dashboardHostname;
+  private final String channelId;
+  private final String levelId;
+  private final HttpClient httpClient;
+
+  private List<String> starterAssetFilenames;
+
+  public AssetUrlGenerator(String dashboardHostname, String channelId, String levelId) {
+    this(dashboardHostname, channelId, levelId, HttpClient.newBuilder().build());
+  }
+
+  AssetUrlGenerator(
+      String dashboardHostname, String channelId, String levelId, HttpClient httpClient) {
+    this.dashboardHostname = dashboardHostname;
+    this.channelId = channelId;
+    this.levelId = levelId;
+    this.httpClient = httpClient;
+  }
+
+  public String generateAssetUrl(String filename) {
+    if (this.starterAssetFilenames == null) {
+      this.loadStarterAssetsList();
+    }
+
+    return this.starterAssetFilenames.contains(filename)
+        ? this.generateStarterAssetUrl(filename)
+        : this.generateUserAssetUrl(filename);
+  }
+
+  private void loadStarterAssetsList() {
+    try {
+      final JSONObject jsonResponse =
+          new JSONObject(getRequest(this.generateStarterAssetsListUrl(), this.httpClient));
+      this.starterAssetFilenames =
+          !jsonResponse.has("starter_assets")
+              ? Collections.emptyList()
+              : jsonResponse
+                  .getJSONArray("starter_assets")
+                  .toList()
+                  .stream()
+                  // JSONArray.toList() converts contents to Maps and Lists
+                  .filter(entry -> ((Map<String, Object>) entry).containsKey("filename"))
+                  .map(entry -> (String) ((Map<String, Object>) entry).get("filename"))
+                  .collect(Collectors.toList());
+    } catch (JSONException e) {
+      throw new InternalJavabuilderError(InternalErrorKey.INTERNAL_EXCEPTION, e);
+    }
+  }
+
+  private String generateUserAssetUrl(String filename) {
+    // append timestamp to asset url to avoid cached 404s.
+    return String.format(
+        "%s/v3/assets/%s/%s?t=%d",
+        this.dashboardHostname, this.channelId, filename, System.currentTimeMillis());
+  }
+
+  private String generateStarterAssetUrl(String filename) {
+    // append timestamp to asset url to avoid cached 404s.
+    return String.format(
+        "%s/level_starter_assets/%s/%s?t=%d",
+        this.dashboardHostname, this.levelId, filename, System.currentTimeMillis());
+  }
+
+  private String generateStarterAssetsListUrl() {
+    return String.format("%s/level_starter_assets/%s", this.dashboardHostname, this.levelId);
+  }
+
+  // TODO: Create generic HTTP request handler and share with UserProjectFileLoader
+  private String getRequest(String url, HttpClient client) throws InternalJavabuilderError {
+    HttpRequest request =
+        HttpRequest.newBuilder().uri(URI.create(url)).timeout(Duration.ofSeconds(10)).build();
+    HttpResponse<String> response;
+    try {
+      response = client.send(request, HttpResponse.BodyHandlers.ofString());
+    } catch (IOException | InterruptedException e) {
+      throw new InternalJavabuilderError(InternalErrorKey.INTERNAL_EXCEPTION, e);
+    }
+    String body = response.body();
+    if (response.statusCode() > 299) {
+      throw new InternalJavabuilderError(InternalErrorKey.INTERNAL_EXCEPTION, new Exception(body));
+    }
+    return body;
+  }
+}

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
@@ -15,18 +15,21 @@ public class GlobalProtocol {
   private final JavabuilderFileWriter fileWriter;
   private final String dashboardHostname;
   private final String channelId;
+  private final AssetUrlGenerator assetUrlGenerator;
 
   private GlobalProtocol(
       OutputAdapter outputAdapter,
       InputAdapter inputAdapter,
       String dashboardHostname,
       String channelId,
-      JavabuilderFileWriter fileWriter) {
+      JavabuilderFileWriter fileWriter,
+      AssetUrlGenerator assetUrlGenerator) {
     this.outputAdapter = outputAdapter;
     this.inputAdapter = inputAdapter;
     this.dashboardHostname = dashboardHostname;
     this.channelId = channelId;
     this.fileWriter = fileWriter;
+    this.assetUrlGenerator = assetUrlGenerator;
   }
 
   public static void create(
@@ -34,9 +37,16 @@ public class GlobalProtocol {
       InputAdapter inputAdapter,
       String dashboardHostname,
       String channelId,
+      String levelId,
       JavabuilderFileWriter fileWriter) {
     GlobalProtocol.protocolInstance =
-        new GlobalProtocol(outputAdapter, inputAdapter, dashboardHostname, channelId, fileWriter);
+        new GlobalProtocol(
+            outputAdapter,
+            inputAdapter,
+            dashboardHostname,
+            channelId,
+            fileWriter,
+            new AssetUrlGenerator(dashboardHostname, channelId, levelId));
   }
 
   public static GlobalProtocol getInstance() {
@@ -60,10 +70,7 @@ public class GlobalProtocol {
   }
 
   public String generateAssetUrl(String filename) {
-    // append timestamp to asset url to avoid cached 404s.
-    return String.format(
-        "%s/v3/assets/%s/%s?t=%d",
-        this.dashboardHostname, this.channelId, filename, System.currentTimeMillis());
+    return this.assetUrlGenerator.generateAssetUrl(filename);
   }
 
   public String generateSourcesUrl() {

--- a/org-code-javabuilder/protocol/src/test/java/org/code/protocol/AssetUrlGeneratorTest.java
+++ b/org-code-javabuilder/protocol/src/test/java/org/code/protocol/AssetUrlGeneratorTest.java
@@ -1,0 +1,121 @@
+package org.code.protocol;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AssetUrlGeneratorTest {
+  private static final String STARTER_ASSET_FILE = "file1.png";
+  private static final String STARTER_ASSET_DATA =
+      new JSONObject(
+              Map.of(
+                  "starter_assets",
+                  List.of(
+                      Map.of("filename", STARTER_ASSET_FILE, "otherKey", "otherValue"),
+                      Map.of("otherKey", "otherValue")),
+                  "otherKey",
+                  "otherValue"))
+          .toString();
+  private static final String DASHBOARD_URL = "https://localhost-studio.code.org";
+  private static final String CHANNEL_ID = "channelId";
+  private static final String LEVEL_ID = "levelId";
+
+  private HttpClient httpClient;
+  private HttpResponse<String> httpResponse;
+  private AssetUrlGenerator unitUnderTest;
+
+  @BeforeEach
+  public void setUp() throws InterruptedException, IOException {
+    httpClient = mock(HttpClient.class);
+    httpResponse = mock(HttpResponse.class);
+
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(STARTER_ASSET_DATA);
+
+    unitUnderTest = new AssetUrlGenerator(DASHBOARD_URL, CHANNEL_ID, LEVEL_ID, httpClient);
+  }
+
+  @Test
+  public void testGenerateAssetUrlThrowsExceptionIfErrorFetchingStarterAssetsList()
+      throws InterruptedException, IOException {
+    final IOException wrappedException = new IOException();
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenThrow(wrappedException);
+
+    final Exception exception =
+        assertThrows(
+            InternalJavabuilderError.class, () -> unitUnderTest.generateAssetUrl("filename"));
+    assertEquals(exception.getMessage(), InternalErrorKey.INTERNAL_EXCEPTION.toString());
+    assertSame(exception.getCause(), wrappedException);
+  }
+
+  @Test
+  public void testGenerateAssetUrlThrowsExceptionIfInvalidStarterAssetsResponse() {
+    final String errorResponseBody = "error";
+
+    when(httpResponse.statusCode()).thenReturn(500);
+    when(httpResponse.body()).thenReturn(errorResponseBody);
+
+    final Exception exception =
+        assertThrows(
+            InternalJavabuilderError.class, () -> unitUnderTest.generateAssetUrl("filename"));
+    assertEquals(exception.getMessage(), InternalErrorKey.INTERNAL_EXCEPTION.toString());
+    assertEquals(exception.getCause().getMessage(), errorResponseBody);
+  }
+
+  @Test
+  public void testGenerateAssetUrlThrowsExceptionIfErrorParsingStarterAssetJson() {
+    when(httpResponse.body()).thenReturn("[ /// invalid /// ]");
+
+    final Exception exception =
+        assertThrows(
+            InternalJavabuilderError.class, () -> unitUnderTest.generateAssetUrl("filename"));
+    assertEquals(exception.getMessage(), InternalErrorKey.INTERNAL_EXCEPTION.toString());
+    assertTrue(exception.getCause() instanceof JSONException);
+  }
+
+  @Test
+  public void testGenerateAssetUrlReturnsStarterAssetUrlForStarterAssetFilename() throws Exception {
+    assertTrue(
+        unitUnderTest
+            .generateAssetUrl(STARTER_ASSET_FILE)
+            .contains(
+                String.format(
+                    "%s/level_starter_assets/%s/%s", DASHBOARD_URL, LEVEL_ID, STARTER_ASSET_FILE)));
+  }
+
+  @Test
+  public void testGenerateAssetUrlReturnsUserAssetForUserFilename() {
+    final String userAssetFile = "userFile.wav";
+    assertTrue(
+        unitUnderTest
+            .generateAssetUrl(userAssetFile)
+            .contains(
+                String.format("%s/v3/assets/%s/%s", DASHBOARD_URL, CHANNEL_ID, userAssetFile)));
+  }
+
+  @Test
+  public void testGenerateAssetUrlDoesNotLoadStarterAssetsListIfAlreadyLoaded()
+      throws InterruptedException, IOException {
+    verify(httpClient, never()).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+
+    unitUnderTest.generateAssetUrl("file1.wav");
+    verify(httpClient, times(1)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+
+    unitUnderTest.generateAssetUrl("file2.wav");
+    verify(httpClient, times(1)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+  }
+}

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
@@ -36,7 +36,7 @@ public class StageTest {
   @BeforeEach
   public void setUp() {
     GlobalProtocol.create(
-        outputAdapter, mock(InputAdapter.class), "", "", mock(JavabuilderFileWriter.class));
+        outputAdapter, mock(InputAdapter.class), "", "", "", mock(JavabuilderFileWriter.class));
     System.setOut(new PrintStream(outputStreamCaptor));
     bufferedImage = mock(BufferedImage.class);
     graphics = mock(Graphics2D.class);


### PR DESCRIPTION
Previously, Javabuilder wasn't checking the level starter assets when trying to load assets. This change makes Javabuilder first check the list of starter asset file names and use the corresponding URL if it exists, or if not, use the standard assets URL for loading assets.

Testing: local & unit

Related TODO: https://codedotorg.atlassian.net/browse/CSA-690