### PR TITLE
Lambda forces disconnect on code completion

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -5,6 +5,7 @@ import static org.code.protocol.InternalErrorKey.INTERNAL_EXCEPTION;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.apigatewaymanagementapi.AmazonApiGatewayManagementApi;
 import com.amazonaws.services.apigatewaymanagementapi.AmazonApiGatewayManagementApiClientBuilder;
+import com.amazonaws.services.apigatewaymanagementapi.model.DeleteConnectionRequest;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.s3.AmazonS3;
@@ -108,6 +109,10 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
       context.getLogger().log(e.getLoggingString());
     } catch (Throwable e) {
       e.printStackTrace();
+    } finally {
+      final DeleteConnectionRequest deleteConnectionRequest =
+          new DeleteConnectionRequest().withConnectionId(connectionId);
+      api.deleteConnection(deleteConnectionRequest);
     }
 
     return "done";


### PR DESCRIPTION
This change makes our Javabuilder lambdas disconnect from the client on code completion.

## Testing story

I was only able to test this change via Postman, with my deployed development version of Javabuilder. Here's what running the default code on /s/allthethings/lessons/44/levels/8 (prints hello world) produced without this change:

![image](https://user-images.githubusercontent.com/25372625/130529562-98a0be93-ea62-4096-a484-bddd8778e0d2.png)

Here's with the change:

![image](https://user-images.githubusercontent.com/25372625/130529586-44594dd2-86bd-4390-bf2b-0463d54508ea.png)


