### PR TITLE
Handle arbitrary message types in Javabuilder

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketInputAdapter.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketInputAdapter.java
@@ -25,6 +25,6 @@ public class WebSocketInputAdapter implements InputAdapter {
   }
 
   public void appendMessage(String message) {
-    messages.add(message + System.lineSeparator());
+    messages.add(message);
   }
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSInputAdapter.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSInputAdapter.java
@@ -37,10 +37,7 @@ public class AWSInputAdapter implements InputAdapter {
     while (messages.peek() == null) {
       List<Message> messages = sqsClient.receiveMessage(request).getMessages();
       for (Message message : messages) {
-        // The Java Lab console is an <input> element that uses the enter key to trigger onSubmit.
-        // Rather than adding an arbitrary line separator from the client, we instead add the
-        // separator here so we can use a line separator that Scanner will recognize.
-        this.messages.add(message.getBody() + System.lineSeparator());
+        this.messages.add(message.getBody());
         sqsClient.deleteMessage(queueUrl, message.getReceiptHandle());
       }
     }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilder.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilder.java
@@ -5,15 +5,12 @@ import java.net.MalformedURLException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import org.code.protocol.GlobalProtocol;
-import org.code.protocol.InputAdapter;
-import org.code.protocol.InternalErrorKey;
-import org.code.protocol.OutputAdapter;
+import org.code.protocol.*;
 
 /** The orchestrator for code compilation and execution. */
 public class CodeBuilder implements AutoCloseable {
   private final OutputAdapter outputAdapter;
-  private final InputAdapter inputAdapter;
+  private final InputHandler inputHandler;
   private final File tempFolder;
   private final PrintStream sysout;
   private final InputStream sysin;
@@ -24,7 +21,7 @@ public class CodeBuilder implements AutoCloseable {
     this.sysout = System.out;
     this.sysin = System.in;
     this.outputAdapter = protocol.getOutputAdapter();
-    this.inputAdapter = protocol.getInputAdapter();
+    this.inputHandler = protocol.getInputHandler();
     this.userProjectFiles = userProjectFiles;
     try {
       this.tempFolder = Files.createTempDirectory("tmpdir").toFile();
@@ -53,7 +50,7 @@ public class CodeBuilder implements AutoCloseable {
   public void runUserCode()
       throws UserFacingException, InternalFacingException, UserInitiatedException {
     System.setOut(new OutputPrintStream(this.outputAdapter));
-    System.setIn(new InputRedirectionStream(this.inputAdapter));
+    System.setIn(new InputRedirectionStream(this.inputHandler));
     JavaRunner runner;
     try {
       runner =

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/InputRedirectionStream.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/InputRedirectionStream.java
@@ -33,9 +33,12 @@ public class InputRedirectionStream extends InputStream {
   @Override
   public int read() {
     if (queue.peek() == null) {
-      byte[] message =
-          (inputAdapter.getNextMessageForType(InputMessageType.SYSTEM_IN) + System.lineSeparator())
-              .getBytes(StandardCharsets.UTF_8);
+      // The Java Lab console is an <input> element that uses the enter key to trigger onSubmit.
+      // Rather than adding an arbitrary line separator from the client, we instead add the
+      // separator here so we can use a line separator that Scanner will recognize.
+      final String messageWithNewline =
+          inputAdapter.getNextMessageForType(InputMessageType.SYSTEM_IN) + System.lineSeparator();
+      byte[] message = messageWithNewline.getBytes(StandardCharsets.UTF_8);
       for (byte b : message) {
         queue.add(b);
       }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/InputRedirectionStream.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/InputRedirectionStream.java
@@ -5,7 +5,8 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.Queue;
-import org.code.protocol.InputAdapter;
+import org.code.protocol.InputHandler;
+import org.code.protocol.InputMessageType;
 
 /**
  * An InputStream that queries an InputAdapter for new bytes. This is intended to redirect system.in
@@ -15,10 +16,10 @@ import org.code.protocol.InputAdapter;
  */
 public class InputRedirectionStream extends InputStream {
   private final Queue<Byte> queue;
-  private final InputAdapter inputAdapter;
+  private final InputHandler inputAdapter;
 
-  public InputRedirectionStream(InputAdapter inputAdapter) {
-    this.inputAdapter = inputAdapter;
+  public InputRedirectionStream(InputHandler inputHandler) {
+    this.inputAdapter = inputHandler;
     this.queue = new LinkedList<>();
   }
 
@@ -32,7 +33,9 @@ public class InputRedirectionStream extends InputStream {
   @Override
   public int read() {
     if (queue.peek() == null) {
-      byte[] message = inputAdapter.getNextMessage().getBytes(StandardCharsets.UTF_8);
+      byte[] message =
+          (inputAdapter.getNextMessageForType(InputMessageType.SYSTEM_IN) + System.lineSeparator())
+              .getBytes(StandardCharsets.UTF_8);
       for (byte b : message) {
         queue.add(b);
       }

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/AWSInputAdapterTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/AWSInputAdapterTest.java
@@ -42,16 +42,16 @@ public class AWSInputAdapterTest {
   }
 
   @Test
-  void addsNewlineToMessage() {
+  void getsNextMessage() {
     messageSetUp(new String[] {"hello"});
-    assertEquals(inputAdapter.getNextMessage(), "hello" + System.lineSeparator());
+    assertEquals(inputAdapter.getNextMessage(), "hello");
   }
 
   @Test
   void addsAllReceivedMessagesToQueue() {
     messageSetUp(new String[] {"", "world"});
     inputAdapter.getNextMessage();
-    assertEquals(inputAdapter.getNextMessage(), "world" + System.lineSeparator());
+    assertEquals(inputAdapter.getNextMessage(), "world");
   }
 
   /**

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
@@ -11,7 +11,7 @@ package org.code.protocol;
 public class GlobalProtocol {
   private static GlobalProtocol protocolInstance;
   private final OutputAdapter outputAdapter;
-  private final InputAdapter inputAdapter;
+  private final InputHandler inputHandler;
   private final JavabuilderFileWriter fileWriter;
   private final String dashboardHostname;
   private final String channelId;
@@ -19,13 +19,13 @@ public class GlobalProtocol {
 
   private GlobalProtocol(
       OutputAdapter outputAdapter,
-      InputAdapter inputAdapter,
+      InputHandler inputHandler,
       String dashboardHostname,
       String channelId,
       JavabuilderFileWriter fileWriter,
       AssetUrlGenerator assetUrlGenerator) {
     this.outputAdapter = outputAdapter;
-    this.inputAdapter = inputAdapter;
+    this.inputHandler = inputHandler;
     this.dashboardHostname = dashboardHostname;
     this.channelId = channelId;
     this.fileWriter = fileWriter;
@@ -42,7 +42,7 @@ public class GlobalProtocol {
     GlobalProtocol.protocolInstance =
         new GlobalProtocol(
             outputAdapter,
-            inputAdapter,
+            new InputHandler(inputAdapter),
             dashboardHostname,
             channelId,
             fileWriter,
@@ -61,8 +61,8 @@ public class GlobalProtocol {
     return this.outputAdapter;
   }
 
-  public InputAdapter getInputAdapter() {
-    return this.inputAdapter;
+  public InputHandler getInputHandler() {
+    return this.inputHandler;
   }
 
   public JavabuilderFileWriter getFileWriter() {

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/InputHandler.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/InputHandler.java
@@ -1,0 +1,62 @@
+package org.code.protocol;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * [PROTOTYPE CODE]
+ *
+ * <p>Handles retrieving various types of JSON messages from the client. Currently expects JSON in
+ * the format:
+ *
+ * <p>{ "messageType": "<message type>", "message": "<message contents>" }
+ */
+public class InputHandler {
+  private final Map<InputMessageType, Queue<String>> inputQueues;
+  private final InputAdapter inputAdapter;
+
+  public InputHandler(InputAdapter inputAdapter) {
+    this.inputAdapter = inputAdapter;
+    this.inputQueues = new HashMap<>();
+  }
+
+  public String getNextMessageForType(InputMessageType type) {
+    if (inputQueues.containsKey(type) && inputQueues.get(type).peek() != null) {
+      return inputQueues.get(type).remove();
+    }
+
+    InputMessageType nextMessageType = null;
+    while (nextMessageType != type) {
+      final String nextMessage = this.inputAdapter.getNextMessage();
+      final Map<String, Object> parsedMessage = this.parseMessage(nextMessage);
+      if (parsedMessage == null) {
+        continue;
+      }
+
+      nextMessageType = InputMessageType.valueOf((String) parsedMessage.get("messageType"));
+      final String message = (String) parsedMessage.get("message");
+
+      if (!inputQueues.containsKey(nextMessageType)) {
+        inputQueues.put(nextMessageType, new LinkedList<>());
+      }
+
+      inputQueues.get(nextMessageType).add(message);
+    }
+
+    return inputQueues.get(type).remove();
+  }
+
+  private Map<String, Object> parseMessage(String message) {
+    try {
+      return new JSONObject(message).toMap();
+    } catch (JSONException e) {
+      // TODO handle error - swallowing for now
+      System.out.println("Error parsing JSON " + e);
+      return null;
+    }
+  }
+}

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/InputHandler.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/InputHandler.java
@@ -46,8 +46,6 @@ public class InputHandler {
           message = nextMessageData;
         }
 
-        System.out.printf("Received message: %s of type: %s\n", message, nextMessageType);
-
         if (!inputQueues.containsKey(nextMessageType)) {
           inputQueues.put(nextMessageType, new LinkedList<>());
         }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/InputHandler.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/InputHandler.java
@@ -8,14 +8,18 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 /**
- * [PROTOTYPE CODE]
- *
- * <p>Handles retrieving various types of JSON messages from the client. Currently expects JSON in
- * the format:
+ * Handles retrieving various types of JSON messages from the client. Expects JSON in the format:
  *
  * <p>{ "messageType": "<message type>", "message": "<message contents>" }
+ *
+ * <p>Currently if JSON is not in this format, then it is assumed that the message is a System.in
+ * message. TODO: This behavior only exists while Javalab has not been updated to use the new
+ * messaging protocol. Remove this once Javalab is updated and published to production.
  */
 public class InputHandler {
+  private static final String MESSAGE_TYPE_KEY = "messageType";
+  private static final String MESSAGE_KEY = "message";
+
   private final Map<InputMessageType, Queue<String>> inputQueues;
   private final InputAdapter inputAdapter;
 
@@ -25,38 +29,33 @@ public class InputHandler {
   }
 
   public String getNextMessageForType(InputMessageType type) {
-    if (inputQueues.containsKey(type) && inputQueues.get(type).peek() != null) {
-      return inputQueues.get(type).remove();
-    }
+    if (!inputQueues.containsKey(type) || inputQueues.get(type).peek() == null) {
+      InputMessageType nextMessageType = null;
+      while (nextMessageType != type) {
+        final String nextMessageData = this.inputAdapter.getNextMessage();
+        String message;
 
-    InputMessageType nextMessageType = null;
-    while (nextMessageType != type) {
-      final String nextMessage = this.inputAdapter.getNextMessage();
-      final Map<String, Object> parsedMessage = this.parseMessage(nextMessage);
-      if (parsedMessage == null) {
-        continue;
+        try {
+          final JSONObject jsonMessage = new JSONObject(nextMessageData);
+          nextMessageType = InputMessageType.valueOf(jsonMessage.getString(MESSAGE_TYPE_KEY));
+          message = jsonMessage.getString(MESSAGE_KEY);
+        } catch (JSONException | IllegalArgumentException e) {
+          // If the message is not JSON, then assume it is a System.in message.
+          // TODO: Remove this and instead throw exception once Javalab is updated to send JSON
+          nextMessageType = InputMessageType.SYSTEM_IN;
+          message = nextMessageData;
+        }
+
+        System.out.printf("Received message: %s of type: %s\n", message, nextMessageType);
+
+        if (!inputQueues.containsKey(nextMessageType)) {
+          inputQueues.put(nextMessageType, new LinkedList<>());
+        }
+
+        inputQueues.get(nextMessageType).add(message);
       }
-
-      nextMessageType = InputMessageType.valueOf((String) parsedMessage.get("messageType"));
-      final String message = (String) parsedMessage.get("message");
-
-      if (!inputQueues.containsKey(nextMessageType)) {
-        inputQueues.put(nextMessageType, new LinkedList<>());
-      }
-
-      inputQueues.get(nextMessageType).add(message);
     }
 
     return inputQueues.get(type).remove();
-  }
-
-  private Map<String, Object> parseMessage(String message) {
-    try {
-      return new JSONObject(message).toMap();
-    } catch (JSONException e) {
-      // TODO handle error - swallowing for now
-      System.out.println("Error parsing JSON " + e);
-      return null;
-    }
   }
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/InputMessageType.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/InputMessageType.java
@@ -1,0 +1,6 @@
+package org.code.protocol;
+
+public enum InputMessageType {
+  SYSTEM_IN,
+  PLAYGROUND
+}

--- a/org-code-javabuilder/protocol/src/test/java/org/code/protocol/InputHandlerTest.java
+++ b/org-code-javabuilder/protocol/src/test/java/org/code/protocol/InputHandlerTest.java
@@ -1,0 +1,84 @@
+package org.code.protocol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.util.Map;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class InputHandlerTest {
+
+  private InputAdapter inputAdapter;
+  private InputHandler unitUnderTest;
+
+  @BeforeEach
+  public void setUp() {
+    inputAdapter = mock(InputAdapter.class);
+    unitUnderTest = new InputHandler(inputAdapter);
+  }
+
+  @Test
+  public void testGetsNextMessageForTypeCorrectly() {
+    final String testMessage = "test message";
+    when(inputAdapter.getNextMessage())
+        .thenReturn(createJsonMessage(InputMessageType.SYSTEM_IN.name(), testMessage));
+    assertEquals(testMessage, unitUnderTest.getNextMessageForType(InputMessageType.SYSTEM_IN));
+  }
+
+  @Test
+  public void testQueuesMessageIfNotOfRequestedType() {
+    final String inputMessage1 = "system in 1";
+    final String inputMessage2 = "system in 2";
+    final String playgroundMessage = "playground message";
+
+    when(inputAdapter.getNextMessage())
+        .thenReturn(createJsonMessage(InputMessageType.SYSTEM_IN.name(), inputMessage1))
+        .thenReturn(createJsonMessage(InputMessageType.SYSTEM_IN.name(), inputMessage2))
+        .thenReturn(createJsonMessage(InputMessageType.PLAYGROUND.name(), playgroundMessage))
+        .thenReturn(createJsonMessage(InputMessageType.PLAYGROUND.name(), "other"));
+
+    assertEquals(
+        playgroundMessage, unitUnderTest.getNextMessageForType(InputMessageType.PLAYGROUND));
+    // Should have called input adapter 3 times (until first PLAYGROUND message was received)
+    verify(inputAdapter, times(3)).getNextMessage();
+
+    reset(inputAdapter);
+
+    assertEquals(inputMessage1, unitUnderTest.getNextMessageForType(InputMessageType.SYSTEM_IN));
+    assertEquals(inputMessage2, unitUnderTest.getNextMessageForType(InputMessageType.SYSTEM_IN));
+    // SYSTEM_IN messages should have already been queued so input adapter should not be called
+    verify(inputAdapter, never()).getNextMessage();
+  }
+
+  /**
+   * TODO: The following tests should be updated to verify that exceptions are thrown once Javalab
+   * is updated to send JSON
+   */
+  @Test
+  public void testDefaultsToSystemInIfMessageIsNotJson() {
+    final String testMessage = "not json";
+    when(inputAdapter.getNextMessage()).thenReturn(testMessage);
+    assertEquals(testMessage, unitUnderTest.getNextMessageForType(InputMessageType.SYSTEM_IN));
+  }
+
+  @Test
+  public void testDefaultsToSystemInIfMessageHasInvalidType() {
+    final String testMessage = createJsonMessage("invalidType", "invalidMessage");
+    when(inputAdapter.getNextMessage()).thenReturn(testMessage);
+    assertEquals(testMessage, unitUnderTest.getNextMessageForType(InputMessageType.SYSTEM_IN));
+  }
+
+  @Test
+  public void testDefaultsToSystemInIfMessageTextIsMissing() {
+    final String testMessage =
+        new JSONObject(Map.of("messageType", InputMessageType.SYSTEM_IN.name())).toString();
+    when(inputAdapter.getNextMessage()).thenReturn(testMessage);
+    assertEquals(testMessage, unitUnderTest.getNextMessageForType(InputMessageType.SYSTEM_IN));
+  }
+
+  private String createJsonMessage(String messageType, String message) {
+    return new JSONObject(Map.of("messageType", messageType, "message", message)).toString();
+  }
+}


### PR DESCRIPTION
Creates a way for routing messages from Javalab to any arbitrary handler based on a message type key. This change also includes a backwards-compatible fallback to treat any non-JSON messages as standard System.in messages, so current behavior doesn't break before Javalab is fully updated to send JSON messages and deployed to production. As a follow-up, the fallback code should be removed once the corresponding Javalab changes have been deployed to production.

Tested locally + unit. Tested against up-to-date staging Javalab to ensure no input behavior was broken.

https://codedotorg.atlassian.net/browse/CSA-730