### PR TITLE
Neighborhood: Increase "large grid" size and no infinite paint when specified in constructor

### DIFF
--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
@@ -4,12 +4,13 @@ import java.util.HashMap;
 import org.code.protocol.OutputAdapter;
 
 public class Painter {
-  private static final int LARGE_GRID_SIZE = 16;
+  private static final int LARGE_GRID_SIZE = 20;
   private static int lastId = 0;
   private int xLocation;
   private int yLocation;
   private Direction direction;
   private int remainingPaint;
+  private boolean hasInfinitePaint;
   private final Grid grid;
   private final String id;
   private final OutputAdapter outputAdapter;
@@ -22,6 +23,7 @@ public class Painter {
     this.remainingPaint = 0;
     World worldInstance = World.getInstance();
     this.grid = worldInstance.getGrid();
+    this.hasInfinitePaint = (this.grid.getSize() >= LARGE_GRID_SIZE) ? true : false;
     this.outputAdapter = worldInstance.getOutputAdapter();
     this.id = "painter-" + lastId++;
     this.sendInitializationMessage();
@@ -40,6 +42,7 @@ public class Painter {
     this.yLocation = y;
     this.direction = Direction.fromString(direction);
     this.remainingPaint = paint;
+    this.hasInfinitePaint = false;
     World worldInstance = World.getInstance();
     this.grid = worldInstance.getGrid();
     this.outputAdapter = worldInstance.getOutputAdapter();
@@ -147,7 +150,7 @@ public class Painter {
 
   /** @return True if the painter's personal bucket has paint in it. */
   public boolean hasPaint() {
-    if (this.grid.getSize() >= LARGE_GRID_SIZE) {
+    if (this.hasInfinitePaint) {
       return true;
     }
     return this.remainingPaint > 0;

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
@@ -10,7 +10,7 @@ public class Painter {
   private int yLocation;
   private Direction direction;
   private int remainingPaint;
-  private boolean hasInfinitePaint;
+  private final boolean hasInfinitePaint;
   private final Grid grid;
   private final String id;
   private final OutputAdapter outputAdapter;
@@ -23,7 +23,7 @@ public class Painter {
     this.remainingPaint = 0;
     World worldInstance = World.getInstance();
     this.grid = worldInstance.getGrid();
-    this.hasInfinitePaint = (this.grid.getSize() >= LARGE_GRID_SIZE) ? true : false;
+    this.hasInfinitePaint = this.grid.getSize() >= LARGE_GRID_SIZE;
     this.outputAdapter = worldInstance.getOutputAdapter();
     this.id = "painter-" + lastId++;
     this.sendInitializationMessage();

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
@@ -159,8 +159,6 @@ public class PainterTest {
     World.setInstance(w);
     Painter painter = new Painter();
     assertTrue(painter.hasPaint());
-    painter.paint("red");
-    assertTrue(painter.hasPaint());
   }
 
   @Test

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
@@ -154,18 +154,36 @@ public class PainterTest {
   }
 
   @Test
-  void largeGridInfinitePaint() {
-    World w = new World(16);
+  void largeGridInfinitePaintDefaultConstructor() {
+    World w = new World(20);
     World.setInstance(w);
-    Painter painter = new Painter(0, 0, "North", 1);
+    Painter painter = new Painter();
     assertTrue(painter.hasPaint());
     painter.paint("red");
     assertTrue(painter.hasPaint());
   }
 
   @Test
+  void noInfinitePaintDefaultConstructor() {
+    World w = new World(19);
+    World.setInstance(w);
+    Painter painter = new Painter();
+    assertFalse(painter.hasPaint());
+  }
+
+  @Test
+  void largeGridNoInfinitePaintWhenPaintSpecified() {
+    World w = new World(20);
+    World.setInstance(w);
+    Painter painter = new Painter(0, 0, "North", 1);
+    assertTrue(painter.hasPaint());
+    painter.paint("red");
+    assertFalse(painter.hasPaint());
+  }
+
+  @Test
   void noInfinitePaint() {
-    World w = new World(15);
+    World w = new World(19);
     World.setInstance(w);
     Painter painter = new Painter(0, 0, "North", 1);
     assertTrue(painter.hasPaint());


### PR DESCRIPTION
A couple of updates to the Painter constructor, per request from our curriculum team:
- Updates the default painter constructor to use infinite paint only if the grid is 20x20 or larger.
- Updates the parameterized painter constructor to always pay attention to the amount of paint students specify (this is currently ignored if the grid is larger than 16x16)

## Testing story

Tested manually, and added unit tests.