### PR TITLE
Remove input handler fallback for non-JSON messages

### DIFF
--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/InputHandler.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/InputHandler.java
@@ -11,10 +11,6 @@ import org.json.JSONObject;
  * Handles retrieving various types of JSON messages from the client. Expects JSON in the format:
  *
  * <p>{ "messageType": "<message type>", "message": "<message contents>" }
- *
- * <p>Currently if JSON is not in this format, then it is assumed that the message is a System.in
- * message. TODO: This behavior only exists while Javalab has not been updated to use the new
- * messaging protocol. Remove this once Javalab is updated and published to production.
  */
 public class InputHandler {
   private static final String MESSAGE_TYPE_KEY = "messageType";
@@ -40,10 +36,7 @@ public class InputHandler {
           nextMessageType = InputMessageType.valueOf(jsonMessage.getString(MESSAGE_TYPE_KEY));
           message = jsonMessage.getString(MESSAGE_KEY);
         } catch (JSONException | IllegalArgumentException e) {
-          // If the message is not JSON, then assume it is a System.in message.
-          // TODO: Remove this and instead throw exception once Javalab is updated to send JSON
-          nextMessageType = InputMessageType.SYSTEM_IN;
-          message = nextMessageData;
+          throw new InternalServerRuntimeError(InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION, e);
         }
 
         if (!inputQueues.containsKey(nextMessageType)) {

--- a/org-code-javabuilder/protocol/src/test/java/org/code/protocol/InputHandlerTest.java
+++ b/org-code-javabuilder/protocol/src/test/java/org/code/protocol/InputHandlerTest.java
@@ -1,6 +1,7 @@
 package org.code.protocol;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 import java.util.Map;
@@ -52,30 +53,38 @@ class InputHandlerTest {
     verify(inputAdapter, never()).getNextMessage();
   }
 
-  /**
-   * TODO: The following tests should be updated to verify that exceptions are thrown once Javalab
-   * is updated to send JSON
-   */
   @Test
-  public void testDefaultsToSystemInIfMessageIsNotJson() {
+  public void testThrowsExceptionIfMessageIsNotJson() {
     final String testMessage = "not json";
     when(inputAdapter.getNextMessage()).thenReturn(testMessage);
-    assertEquals(testMessage, unitUnderTest.getNextMessageForType(InputMessageType.SYSTEM_IN));
+    Exception e =
+        assertThrows(
+            InternalServerRuntimeError.class,
+            () -> unitUnderTest.getNextMessageForType(InputMessageType.SYSTEM_IN));
+    assertEquals(InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION.name(), e.getMessage());
   }
 
   @Test
-  public void testDefaultsToSystemInIfMessageHasInvalidType() {
+  public void testThrowsExceptionIfMessageHasInvalidType() {
     final String testMessage = createJsonMessage("invalidType", "invalidMessage");
     when(inputAdapter.getNextMessage()).thenReturn(testMessage);
-    assertEquals(testMessage, unitUnderTest.getNextMessageForType(InputMessageType.SYSTEM_IN));
+    Exception e =
+        assertThrows(
+            InternalServerRuntimeError.class,
+            () -> unitUnderTest.getNextMessageForType(InputMessageType.SYSTEM_IN));
+    assertEquals(InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION.name(), e.getMessage());
   }
 
   @Test
-  public void testDefaultsToSystemInIfMessageTextIsMissing() {
+  public void testThrowsExceptionIfMessageTextIsMissing() {
     final String testMessage =
         new JSONObject(Map.of("messageType", InputMessageType.SYSTEM_IN.name())).toString();
     when(inputAdapter.getNextMessage()).thenReturn(testMessage);
-    assertEquals(testMessage, unitUnderTest.getNextMessageForType(InputMessageType.SYSTEM_IN));
+    Exception e =
+        assertThrows(
+            InternalServerRuntimeError.class,
+            () -> unitUnderTest.getNextMessageForType(InputMessageType.SYSTEM_IN));
+    assertEquals(InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION.name(), e.getMessage());
   }
 
   private String createJsonMessage(String messageType, String message) {


### PR DESCRIPTION
Follow-up for https://codedotorg.atlassian.net/browse/CSA-730 / https://github.com/code-dot-org/javabuilder/pull/97. This removes fallback logic and instead throws an exception if we get an invalid or non-JSON message from Javalab. NOTE: This change should not be merged or deployed until https://github.com/code-dot-org/code-dot-org/pull/42254 has been deployed to production.

Tested locally + unit.