### PR TITLE
Add adhoc public key to Javabuilder

### DIFF
--- a/javabuilder-authorizer/lambda_function.rb
+++ b/javabuilder-authorizer/lambda_function.rb
@@ -95,6 +95,8 @@ def get_public_key(origin)
     stage_name = "levelbuilder"
   elsif origin.include? "test"
     stage_name = "test"
+  elsif origin.include? "adhoc"
+    stage_name = "adhoc"
   else
     stage_name = "production"
   end

--- a/template.yml
+++ b/template.yml
@@ -234,6 +234,11 @@ Resources:
             82lnuUHekrW+j3sCimbhFPM+HDXJI03g5Uv698oiSXp8+dqB7VzGD4ux9lwlB6Dr\n 3+8Pz/c7t8me0CJquotr7p7kYtoPo6kK9NL74zu4KsAcotDvRw8tHRs3cZ/X3KEl\n
             vb2YtSsq4ecf7sZeQgSbeZ6PdwEIBp0dl5AG6SgIWPcweNwmZmJg917i0lSGgWxW\n OlIo9VurlVd3AgMBAAE=\n
             -----END RSA PUBLIC KEY-----'
+          rsa_pub_adhoc: '-----BEGIN RSA PUBLIC KEY-----\n MIIBCgKCAQEAoGqR0M5qbi+XSH9XCAEQhlEVXbUaIFYXnw0Sxk7YhfAWLpUQMiHW\n
+            DWJemqP54cJ0GPjhHTvL/BdsURkA5ZXpApXWvzQ0kr0kfp7NvC7o2LnB/U78xSsG\n /uwBz+xaCmW71X4uxcXnKT9AFLRRaB1z7RLZoE8NhJErRS+25UqbTBYVdsZkvsIy\n
+            ZUbJMN3hMFIFP4smAtjkKqguLJPFdcMij7WFDjL5kPQpxuc4RSq97iXRODIBjW1B\n zdN9ZpGRA4MDOu3BtLC69PwoFrSULAzlUmC5fJIwpaXoRGZEYRMQThlJ9VsRGwTG\n
+            JTJJ4dWJ2cw61prbeU/HVCWD8OaNumz9tQIDAQAB\n
+            -----END RSA PUBLIC KEY-----'
   WebSocketAuthorizerPermission:
     Type: AWS::Lambda::Permission
     DependsOn:


### PR DESCRIPTION
Created a new public/private RSA key pair and added the public key to Javabuilder so we no longer have to add our own keys to our dev Javabuilder instances and dashboard when using adhocs.

Tested with development instance (wss://javabuilder-sanchit.dev-code.org) + adhoc (https://adhoc-playground-backend-prototype-studio.cdn-code.org/)

Note: for this to work on future adhocs, a small config is change is also required to make sure adhocs grab the javabuilder private key and password from AWS Secrets Manager: https://github.com/code-dot-org/code-dot-org/pull/42326

https://codedotorg.atlassian.net/browse/CSA-767