### PR TITLE
Handle wav file creation when there is no audio output by the student's project

### DIFF
--- a/org-code-javabuilder/media/src/main/java/org/code/media/AudioWriter.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/AudioWriter.java
@@ -68,6 +68,12 @@ public class AudioWriter {
    * closes output streams.
    */
   public void writeToAudioStreamAndClose() {
+    if (this.audioSamples.length == 0) {
+      // Add a silent audio sample so we can build a valid wav file.
+      // TODO: Send a "No audio" signal instead
+      this.audioSamples = new double[] {0};
+    }
+
     AudioUtils.writeBytesToOutputStream(
         AudioUtils.convertDoubleArrayToByteArray(this.audioSamples), this.audioOutputStream);
     this.currentSampleIndex = 0;

--- a/org-code-javabuilder/media/src/test/java/org/code/media/AudioWriterTest.java
+++ b/org-code-javabuilder/media/src/test/java/org/code/media/AudioWriterTest.java
@@ -1,0 +1,35 @@
+package org.code.media;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.Test;
+
+public class AudioWriterTest {
+  @Test
+  public void testWriteAddsSilentSoundIfEmpty() {
+    ByteArrayOutputStream stream = new ByteArrayOutputStream();
+    AudioWriter writer = new AudioWriter(stream);
+    writer.writeToAudioStreamAndClose();
+    byte[] result = stream.toByteArray();
+    // The length is 46 because there is a lot of metadata before the data begins. The data are
+    // zeros because we add in a single silent sound sample.
+    assertEquals(46, result.length);
+    assertEquals(0, result[result.length - 1]);
+    assertEquals(0, result[result.length - 2]);
+  }
+
+  @Test
+  public void testWriteUsesExistingAudioData() {
+    ByteArrayOutputStream stream = new ByteArrayOutputStream();
+    AudioWriter writer = new AudioWriter(stream);
+    writer.writeAudioSamples(new double[] {1});
+    writer.writeToAudioStreamAndClose();
+    byte[] result = stream.toByteArray();
+    // The exact values don't matter so much as ensuring they are something specific and not zero.
+    // The length is 46 because there is a lot of metadata before the data begins.
+    assertEquals(46, result.length);
+    assertEquals(127, result[result.length - 1]);
+    assertEquals(-1, result[result.length - 2]);
+  }
+}


### PR DESCRIPTION
A wav file will be created in an un-readable state if it has no data in it. This adds a single sample of silent audio to the generated wav file so it can be read by the client. 

This fixes a bug on firefox where an error while reading an empty audio file prevents the visual file from displaying.

Additional details start here: https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1630693486126100