### PR TITLE
Updated readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,19 @@ doc.
   contains the script and Cloud Formation template for deploying Javabuilder to
   production.
 
+## Deploying Production Javabuilder
+To deploy Javabuilder to production, see the
+[Deploying Javabuilder](https://docs.google.com/document/d/1mMQK6HhniLsz9lynzhUcm7Tcw_2WVLBxADe0WzqL6rM/edit#)
+instruction doc.
+
 ## Developing Javabuilder
-For developing core Javabuilder (the engine that builds & runs student code) you can skip
-directly to the
-[Java README](https://github.com/code-dot-org/javabuilder/blob/main/org-code-javabuilder/README.md).
+For developing "core" Javabuilder (the engine that builds & runs student code) you can
+skip directly to the
+[org-code-javabuilder README](https://github.com/code-dot-org/javabuilder/blob/main/org-code-javabuilder/README.md).
 For developing the API Gateway communication layer lambdas or working on the deployment
 script, read further.
 
-## Prerequisites
+### Prerequisites
 You need to install Ruby 2.7.4 to build and/or run the Ruby lambda functions 
 (`javabuilder-authorizer` and `api-gateway-routes`). 
 [rbenv](https://github.com/rbenv/rbenv) is a useful tool for installing Ruby and managing
@@ -41,18 +46,48 @@ new Ruby version. You may need to also install
 [ruby-build](https://github.com/rbenv/ruby-build#readme) to get the latest Ruby versions.
 The `.ruby-version` file sets the local Ruby version for javabuilder to be 2.7.4.
 
-## Deploying Javabuilder
-For development purposes, you generally shouldn't need to deploy Javabuilder. See the 
-org-code-javabuilder 
-[README](https://github.com/code-dot-org/javabuilder/blob/main/org-code-javabuilder/README.md)
-for local testing instructions. Some cases that do need a dev deployment of Javabuilder:
+### Dev Deploy of Javabuilder
+For development purposes, you generally shouldn't need a dev deploy of Javabuilder. Some
+cases that do need a dev deploy of Javabuilder:
 * Editing the API Gateway Route Lambdas.
 * Editing the Javabuilder Authorizer Lambda.
 * Editing the Javabuilder Cloud Formation template or deploy script.
-* Editing the Lambda-specific portions of the build and run Lambda. These are all 
-  prefixed with `AWS` or `Lambda` in the org-code-javabuilder directory.
-
-
-To deploy Javabuilder to production or to a dev account, see the
+* Editing the AWS Lambda or AWS SQS-specific portions of the build and run Lambda. These
+  are all prefixed with `AWS` or `Lambda` in the org-code-javabuilder directory.
+  
+To deploy Javabuilder to a dev account, see the
 [Deploying Javabuilder](https://docs.google.com/document/d/1mMQK6HhniLsz9lynzhUcm7Tcw_2WVLBxADe0WzqL6rM/edit#)
 instruction doc.
+
+Once you have deployed Javabuilder, you can run a basic connection to it with
+```
+wscat -c wss://<host-name>/?Authorization=connectivityTest
+```
+**Developing with deployed Javabuilder**  
+If you need to test against a level's Java code, use the following steps:
+1. Log in to https://staging-studio.code.org
+1. Navigate to the level or project you'd like to test against
+1. Open the network tab on your browser developer tools
+1. Click "Run" in Javalab
+1. Look for the network request to
+   https://staging-studio.code.org/javabuilder/access_token?projectUrl=...
+   in the response, there will be a token. Copy the entire token, without quotes around
+   it.
+1. Open up Postman. Choose new-> WebSocket Request
+1. Put the url of your javabuilder instance in the server url section (such as
+   wss://javabuilder-myname.dev-code.org)
+1. Under Params add the key `Authorization` with the value of the token you copied earlier
+1. Under Headers add the key `Origin` with the value https://staging-studio.code.org
+1. Click connect
+
+You should now start seeing messages from Javabuilder! Your token will last for 15
+minutes. If you make changes to the code, you do not need to re-generate your token.
+
+**Developing with deployed Javabuilder and an adhoc environment**
+1. Deploy javabuilder with the instructions above
+1. In the code-dot-org repo, edit the `javabuilder_url` value in
+   [cdo.rb](https://github.com/code-dot-org/code-dot-org/blob/3219e5866689117e086d9891effe0fb39b9ae3f0/lib/cdo.rb#L131)
+   to point to your local dev deployment.
+1. Deploy the adhoc using the instructions in the
+   [How to Provision an adhoc Environment](https://docs.google.com/document/d/1nWeQEmEQF1B2l93JTQPyeRpLEFzCzY5NdgJ8kgprcDk/edit)
+   document.

--- a/README.md
+++ b/README.md
@@ -84,10 +84,13 @@ You should now start seeing messages from Javabuilder! Your token will last for 
 minutes. If you make changes to the code, you do not need to re-generate your token.
 
 **Developing with deployed Javabuilder and an adhoc environment**
-1. Deploy javabuilder with the instructions above
+1. Deploy Javabuilder with the instructions above
 1. In the code-dot-org repo, edit the `javabuilder_url` value in
    [cdo.rb](https://github.com/code-dot-org/code-dot-org/blob/3219e5866689117e086d9891effe0fb39b9ae3f0/lib/cdo.rb#L131)
    to point to your local dev deployment.
+1. In the code-dot-org repo, also edit the `upgrade_insecure_requests` list to include
+   the deployed Javabuilder hostname. 
+   [example](https://github.com/code-dot-org/code-dot-org/commit/945fa3ad38be6d85cb7c7aaeda5b3bf2e0fde60c#diff-19cc5be92c36ff06b63767f0ff922d2b9b7b9b8bebe4eaf38e0f331a14b0b528R53)
 1. Deploy the adhoc using the instructions in the
    [How to Provision an adhoc Environment](https://docs.google.com/document/d/1nWeQEmEQF1B2l93JTQPyeRpLEFzCzY5NdgJ8kgprcDk/edit)
    document.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,58 @@
-# java-ide
-In-browser Java IDE
+# Javabuilder
+
+This is the code that compiles and runs user code from the Java Lab app in code studio.
+Javabuilder is a serverless AWS application with three main parts:
+1. The WebSocket communication layer, handled by AWS API Gateway and AWS SQS
+1. The code execution layer, handled by AWS Lambda
+1. The data layer, handled by Code.org's Dashboard server
+
+For an in-depth description of how these three parts work together, see the
+[Code.org Javabuilder Service Infrastructure](https://docs.google.com/document/d/196aKj947BYZXZH3nGvzHprgWPOoy2Kw1x3sKgziUaSo/edit)
+doc.
+
+### Directory
+* [api-gateway-routes](https://github.com/code-dot-org/javabuilder/tree/main/api-gateway-routes)
+  contains the Lambda function that is executed by API Gateway when the connect,
+  disconnect, and default routes are invoked.
+* [javabuilder-authorizer](https://github.com/code-dot-org/javabuilder/tree/main/javabuilder-authorizer)
+  contains the Lambda function that is executed by API Gateway to authorize the user when
+  the connect route is invoked.
+* [org-code-javabuilder](https://github.com/code-dot-org/javabuilder/tree/main/org-code-javabuilder)
+  contains the Lambda function that builds and runs student code. It also contains the
+  local developent version of Javabuilder.
+* [javabuilder](https://github.com/code-dot-org/javabuilder) (the current directory)
+  contains the script and Cloud Formation template for deploying Javabuilder to
+  production.
+
+## Developing Javabuilder
+For developing core Javabuilder (the engine that builds & runs student code) you can skip
+directly to the
+[Java README](https://github.com/code-dot-org/javabuilder/blob/main/org-code-javabuilder/README.md).
+For developing the API Gateway communication layer lambdas or working on the deployment
+script, read further.
+
+## Prerequisites
+You need to install Ruby 2.7.4 to build and/or run the Ruby lambda functions 
+(`javabuilder-authorizer` and `api-gateway-routes`). 
+[rbenv](https://github.com/rbenv/rbenv) is a useful tool for installing Ruby and managing
+multiple versions. Follow the instructions 
+[here](https://github.com/rbenv/rbenv#installing-ruby-versions) to use rbenv to install a
+new Ruby version. You may need to also install 
+[ruby-build](https://github.com/rbenv/ruby-build#readme) to get the latest Ruby versions.
+The `.ruby-version` file sets the local Ruby version for javabuilder to be 2.7.4.
+
+## Deploying Javabuilder
+For development purposes, you generally shouldn't need to deploy Javabuilder. See the 
+org-code-javabuilder 
+[README](https://github.com/code-dot-org/javabuilder/blob/main/org-code-javabuilder/README.md)
+for local testing instructions. Some cases that do need a dev deployment of Javabuilder:
+* Editing the API Gateway Route Lambdas.
+* Editing the Javabuilder Authorizer Lambda.
+* Editing the Javabuilder Cloud Formation template or deploy script.
+* Editing the Lambda-specific portions of the build and run Lambda. These are all 
+  prefixed with `AWS` or `Lambda` in the org-code-javabuilder directory.
 
 
-# Prerequisites
-You need to install Ruby 2.7.4 to build and/or run the Ruby lambda functions (`javabuilder-authorizer` and `api-gateway-routes`).
-[rbenv](https://github.com/rbenv/rbenv) is a useful tool for installing Ruby 
-and managing multiple versions. Follow the instructions [here](https://github.com/rbenv/rbenv#installing-ruby-versions) to
-use rbenv to install a new Ruby version. You may need to also install [ruby-build](https://github.com/rbenv/ruby-build#readme) to get the latest Ruby
-versions. The `.ruby-version` file sets the local Ruby version for javabuilder to be 2.7.4.
+To deploy Javabuilder to production or to a dev account, see the
+[Deploying Javabuilder](https://docs.google.com/document/d/1mMQK6HhniLsz9lynzhUcm7Tcw_2WVLBxADe0WzqL6rM/edit#)
+instruction doc.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ doc.
   contains the script and Cloud Formation template for deploying Javabuilder to
   production.
 
+### Prerequisites
+You need to install Ruby 2.7.4 to build and/or run the Ruby lambda functions
+(`javabuilder-authorizer` and `api-gateway-routes`).
+[rbenv](https://github.com/rbenv/rbenv) is a useful tool for installing Ruby and managing
+multiple versions. Follow the instructions
+[here](https://github.com/rbenv/rbenv#installing-ruby-versions) to use rbenv to install a
+new Ruby version. You may need to also install
+[ruby-build](https://github.com/rbenv/ruby-build#readme) to get the latest Ruby versions.
+The `.ruby-version` file sets the local Ruby version for javabuilder to be 2.7.4.
+
 ## Deploying Production Javabuilder
 To deploy Javabuilder to production, see the
 [Deploying Javabuilder](https://docs.google.com/document/d/1mMQK6HhniLsz9lynzhUcm7Tcw_2WVLBxADe0WzqL6rM/edit#)
@@ -33,18 +43,8 @@ instruction doc.
 For developing "core" Javabuilder (the engine that builds & runs student code) you can
 skip directly to the
 [org-code-javabuilder README](https://github.com/code-dot-org/javabuilder/blob/main/org-code-javabuilder/README.md).
-For developing the API Gateway communication layer lambdas or working on the deployment
+For developing the API Gateway communication layer Lambdas or working on the deployment
 script, read further.
-
-### Prerequisites
-You need to install Ruby 2.7.4 to build and/or run the Ruby lambda functions 
-(`javabuilder-authorizer` and `api-gateway-routes`). 
-[rbenv](https://github.com/rbenv/rbenv) is a useful tool for installing Ruby and managing
-multiple versions. Follow the instructions 
-[here](https://github.com/rbenv/rbenv#installing-ruby-versions) to use rbenv to install a
-new Ruby version. You may need to also install 
-[ruby-build](https://github.com/rbenv/ruby-build#readme) to get the latest Ruby versions.
-The `.ruby-version` file sets the local Ruby version for javabuilder to be 2.7.4.
 
 ### Dev Deploy of Javabuilder
 For development purposes, you generally shouldn't need a dev deploy of Javabuilder. Some

--- a/api-gateway-routes/README.md
+++ b/api-gateway-routes/README.md
@@ -1,4 +1,5 @@
 # Javabuilder API Gateway Routes
 
-This lambda function defines the actions that happen when the Javabuilder API Gateway triggers the connect, disconnect, and default actions.
+This lambda function defines the actions that happen when the Javabuilder API Gateway 
+triggers the connect, disconnect, and default actions.
 

--- a/javabuilder-authorizer/README.md
+++ b/javabuilder-authorizer/README.md
@@ -2,8 +2,9 @@
 
 This lambda function is an 
 [API Gateway Authorizer](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-lambda-auth.html).
-It expects a JWT token to be sent in an Authorization header in the standard format `Authorization: Bearer <token>`.
+It expects a JWT token to be sent in an Authorization header in the standard format 
+`Authorization: Bearer <token>`.
 
-You must be running ruby version 2.7.4 for the upload to work properly. The lambda expects the gems to be in 
-`vendor\bundle\ruby\2.7.0\*`. You may be able to manually rename the `2.7.0` folder to workaround installing a different
-ruby version.
+You must be running ruby version 2.7.4 for the upload to work properly. The lambda 
+expects the gems to be in `vendor\bundle\ruby\2.7.0\*`. You may be able to manually
+rename the `2.7.0` folder to workaround installing a different ruby version.

--- a/org-code-javabuilder/README.md
+++ b/org-code-javabuilder/README.md
@@ -1,33 +1,138 @@
-# Javabuilder App
-### Local Development
-To run Javabuilder in isolation, run the `LocalMain` class from an IDE (IntelliJ is recommended).
-This will exercise the compile and run logic in isolation. Javabuilder will execute the
-program in src/main/resources/main.json. You can update which file is used from `LocalProjectFileManager`.
-Input and output will be directed to the terminal.
-Any non-Java file used or created by the program (for example `grid.txt` in `main_painter.json`) will be
-created in the `org-code-javabuilder` folder when running locally, so be aware you may want 
-to do some cleanup after running code that relies on text files (in our Lambda runtime the code 
-all runs from a temporary folder and handles this cleanup). 
+# Javabuilder build-and-run package
+This portion of Javabuilder contains the code that compiles and runs student code as well
+as the code for the `org.code` Java packages that are used in the Java Lab mini apps.
 
-### Developing with Dashboard
+### Directory
+* [lib](https://github.com/code-dot-org/javabuilder/tree/main/org-code-javabuilder/lib)
+  contains the "backend" code that compiles, builds, and runs student code. This is not
+  user-facing. It also handles the WebSocket layer that communicates between the client
+  and the running program. Also contained here are implementations of the communication
+  protocol and program initialization that are specific to local development and AWS
+  development. Local implementations are in the `dev.javabuilder` package while AWS
+  implementations are in the main `org.code.javabuilder` package and are prefixed with
+  `AWS` or `Lambda`
+* [media](https://github.com/code-dot-org/javabuilder/tree/main/org-code-javabuilder/media)
+  contains a package that can be imported by the user to edit sounds, colors, fonts, and
+  images.
+* [neighborhood](https://github.com/code-dot-org/javabuilder/tree/main/org-code-javabuilder/neighborhood)
+  contains a package that can be imported by the user to interact with the neighborhood
+  mini-app, a maze-like app created for AP CSA.
+* [protocol](https://github.com/code-dot-org/javabuilder/tree/main/org-code-javabuilder/protocol)
+  contains the communication protocol that handles messages between Java Lab (client) and
+  Javabuilder (server)
+* [theater](https://github.com/code-dot-org/javabuilder/tree/main/org-code-javabuilder/theater)
+  contains a package that can be imported by the user to interact with the theater 
+  mini-app, an image and sound editing app created for AP CSA and used in standalone Java
+  Lab projects.
+
+## Local Development
+### Setup your project
+1. Install a Java IDE - We recommend IntelliJ Community edition.
+    1. If given the option when installing, select Java 11 as the default
+1. If Java 11 was not installed as part of the IDE, install 
+   [OpenJDK 11](https://jdk.java.net/java-se-ri/11)
+1. Download the repo and build. Building is a one-time step that seeds the git commit
+   hooks.
+```
+git clone git@github.com:code-dot-org/javabuilder.git
+cd javabuilder/org-code-javabuilder
+./gradlew build
+```
+That's it! Now you can open the project in your IDE and start developing. Here are some
+other useful commands:
+
+**Launch the local Javabuilder WebSocket server**
+```
+./gradlew appRun
+```
+*Note: the Javabuilder server will be ready to use when you see
+`Press any key to stop the server.` It will never reach `100% EXECUTING`.*
+
+**Run all tests**
+```
+./gradlew test
+```
+
+**Run the linter and fix lint errors**
+```
+./gradlew goJF
+```
+
+### Developing with Dashboard (most common scenario)
 In order to run Java Lab (Code Studio client) with Javabuilder, use the WebSocketServer.
 This is a local replacement of AWS API Gateway. 
 
-Instructions (Note: this method is still in development)
-1. Launch the WebSocketServer: `gradle appRun`
-1. Launch dashboard using the instructions here: https://github.com/code-dot-org/code-dot-org/blob/staging/SETUP.md#overview 
-1. Navigate to any Java Lab level, for example: http://localhost-studio.code.org:3000/projects/javalab/new
+Instructions
+1. Launch the WebSocketServer using the instructions above. (run `./gradlew appRun`)
+1. Launch dashboard using the instructions here: 
+   https://github.com/code-dot-org/code-dot-org/blob/staging/SETUP.md#overview 
+1. Navigate to any Java Lab level, for example: 
+   http://localhost-studio.code.org:3000/projects/javalab/new
 1. Click the "Run" button
 
 Alternatively, you can test in "headless" mode
 1. Install wscat: `npm install -g wscat`
-1. Launch the WebSocketServer: `gradle appRun`
-1. In a terminal, connect to the server with wscat: `wscat -c ws://localhost:8080/javabuilder`
+1. Launch the WebSocketServer: `./gradlew appRun`
+1. In a terminal, connect to the server with wscat: 
+   `wscat -c ws://localhost:8080/javabuilder`
 
-### Developing with AWS (under construction)
-In order to test against the AWS services, you'll need to integrate your IDE with AWS SAM.
+Postman is a good wscat alternative. It is in beta, but has a gui and is more
+feature-rich.
 
-1. Set up AWS SAM: https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/setup-toolkit.html
-1. Connect the first time: https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/key-tasks.html#key-tasks-first-connect
-1. This is still in development. Check in with the CSA team to get the latest details on running with AWS.
-1. Open LambdaRequestHandler, set any configurations, and run the lambda.
+### Developing with AWS
+For development purposes, you generally shouldn't need to deploy Javabuilder. Some cases
+that do need a dev deployment of Javabuilder:
+* Editing the API Gateway Route Lambdas.
+* Editing the Javabuilder Authorizer Lambda.
+* Editing the Javabuilder Cloud Formation template or deploy script.
+* Editing the Lambda-specific portions of the build and run Lambda. These are all
+  prefixed with `AWS` or `Lambda` in the org-code-javabuilder directory.
+
+**Deploying Javabuilder**  
+To deploy a development version of Javabuilder, see the
+[Deploying Javabuilder](https://docs.google.com/document/d/1mMQK6HhniLsz9lynzhUcm7Tcw_2WVLBxADe0WzqL6rM/edit#)
+instruction doc.
+
+Once you have deployed Javabuilder, you can run a basic connection to it with
+```
+wscat -c wss://<host-name>/?Authorization=connectivityTest
+```
+**Developing with deployed Javabuilder**  
+If you need to test against a level's Java code, use the following steps:
+1. Log in to https://staging-studio.code.org 
+1. Navigate to the level or project you'd like to test against
+1. Open the network tab on your browser developer tools
+1. Click "Run" in Javalab
+1. Look for the network request to 
+   https://staging-studio.code.org/javabuilder/access_token?projectUrl=...
+   in the response, there will be a token. Copy the entire token, without quotes around
+   it.
+1. Open up Postman. Choose new-> WebSocket Request 
+1. Put the url of your javabuilder instance in the server url section (such as 
+   wss://javabuilder-myname.dev-code.org)
+1. Under Params add the key `Authorization` with the value of the token you copied earlier
+1. Under Headers add the key `Origin` with the value https://staging-studio.code.org
+1. Click connect
+
+You should now start seeing messages from Javabuilder! Your token will last for 15
+minutes. If you make changes to the code, you do not need to re-generate your token.
+
+**Developing with deployed Javabuilder and an adhoc environment**  
+1. Deploy javabuilder with the instructions above
+1. In the code-dot-org repo, edit the `javabuilder_url` value in 
+   [cdo.rb](https://github.com/code-dot-org/code-dot-org/blob/3219e5866689117e086d9891effe0fb39b9ae3f0/lib/cdo.rb#L131)
+   to point to your local dev deployment.
+1. Deploy the adhoc using the instructions in the 
+   [How to Provision an adhoc Environment](https://docs.google.com/document/d/1nWeQEmEQF1B2l93JTQPyeRpLEFzCzY5NdgJ8kgprcDk/edit)
+   document.
+
+### Developing in isolation
+To run Javabuilder in isolation, run the `LocalMain` class from you Java IDE. This will
+exercise the compile and run logic in isolation. Javabuilder will execute the program in
+src/main/resources/main.json. You can update which file is used from 
+`LocalProjectFileManager`. Input and output will be directed to the terminal. Any 
+non-Java file used or created by the program (for example `grid.txt` in 
+`main_painter.json`) will be created in the `org-code-javabuilder` folder when running
+locally, so be aware you may want to do some cleanup after running code that relies on
+text files (in our Lambda runtime the code all runs from a temporary folder and handles
+this cleanup).

--- a/org-code-javabuilder/README.md
+++ b/org-code-javabuilder/README.md
@@ -24,6 +24,10 @@ as the code for the `org.code` Java packages that are used in the Java Lab mini 
   contains a package that can be imported by the user to interact with the theater 
   mini-app, an image and sound editing app created for AP CSA and used in standalone Java
   Lab projects.
+* [playground](https://github.com/code-dot-org/javabuilder/tree/main/org-code-javabuilder/playground)
+  is a prototype built to explore the idea of click-interactivity in Javabuilder and AP
+  CSA. It contains a package that can be imported by the user to interact with the playground
+  mini-app. Playground is primarily used for board game style programs.
 
 ## Local Development
 ### Setup your project
@@ -38,14 +42,21 @@ git clone git@github.com:code-dot-org/javabuilder.git
 cd javabuilder/org-code-javabuilder
 ./gradlew build
 ```
-That's it! Now you can open the project in your IDE and start developing. Here are some
-other useful commands:
+That's it! Now you can open the project in your IDE and start developing. If you are
+using IntelliJ, import the project as a gradle project: File -> New -> Project from
+Existing Sources...
+
+It is not required, but you can also install gradle. If you do, you can use gradle
+directly rather than from the gradlew file. Instead of running `./gradlew build`, for
+example, you would run `gradle build`.
+
+Here are some other useful commands:
 
 **Launch the local Javabuilder WebSocket server**
 ```
 ./gradlew appRun
 ```
-*Note: the Javabuilder server will be ready to use when you see
+*Note: the Javabuilder server will be ready to use after a few seconds when you see
 `Press any key to stop the server.` It will never reach `100% EXECUTING`.*
 
 **Run all tests**
@@ -80,51 +91,9 @@ Postman is a good wscat alternative. It is in beta, but has a gui and is more
 feature-rich.
 
 ### Developing with AWS
-For development purposes, you generally shouldn't need to deploy Javabuilder. Some cases
-that do need a dev deployment of Javabuilder:
-* Editing the API Gateway Route Lambdas.
-* Editing the Javabuilder Authorizer Lambda.
-* Editing the Javabuilder Cloud Formation template or deploy script.
-* Editing the Lambda-specific portions of the build and run Lambda. These are all
-  prefixed with `AWS` or `Lambda` in the org-code-javabuilder directory.
-
-**Deploying Javabuilder**  
-To deploy a development version of Javabuilder, see the
-[Deploying Javabuilder](https://docs.google.com/document/d/1mMQK6HhniLsz9lynzhUcm7Tcw_2WVLBxADe0WzqL6rM/edit#)
-instruction doc.
-
-Once you have deployed Javabuilder, you can run a basic connection to it with
-```
-wscat -c wss://<host-name>/?Authorization=connectivityTest
-```
-**Developing with deployed Javabuilder**  
-If you need to test against a level's Java code, use the following steps:
-1. Log in to https://staging-studio.code.org 
-1. Navigate to the level or project you'd like to test against
-1. Open the network tab on your browser developer tools
-1. Click "Run" in Javalab
-1. Look for the network request to 
-   https://staging-studio.code.org/javabuilder/access_token?projectUrl=...
-   in the response, there will be a token. Copy the entire token, without quotes around
-   it.
-1. Open up Postman. Choose new-> WebSocket Request 
-1. Put the url of your javabuilder instance in the server url section (such as 
-   wss://javabuilder-myname.dev-code.org)
-1. Under Params add the key `Authorization` with the value of the token you copied earlier
-1. Under Headers add the key `Origin` with the value https://staging-studio.code.org
-1. Click connect
-
-You should now start seeing messages from Javabuilder! Your token will last for 15
-minutes. If you make changes to the code, you do not need to re-generate your token.
-
-**Developing with deployed Javabuilder and an adhoc environment**  
-1. Deploy javabuilder with the instructions above
-1. In the code-dot-org repo, edit the `javabuilder_url` value in 
-   [cdo.rb](https://github.com/code-dot-org/code-dot-org/blob/3219e5866689117e086d9891effe0fb39b9ae3f0/lib/cdo.rb#L131)
-   to point to your local dev deployment.
-1. Deploy the adhoc using the instructions in the 
-   [How to Provision an adhoc Environment](https://docs.google.com/document/d/1nWeQEmEQF1B2l93JTQPyeRpLEFzCzY5NdgJ8kgprcDk/edit)
-   document.
+For development purposes, you generally shouldn't need a dev deploy of Javabuilder. See
+the [repo-level README]() for instructions on when a dev deploy of Javabuilder is 
+required and how to carry out such a deployment.
 
 ### Developing in isolation
 To run Javabuilder in isolation, run the `LocalMain` class from you Java IDE. This will

--- a/org-code-javabuilder/README.md
+++ b/org-code-javabuilder/README.md
@@ -92,8 +92,10 @@ feature-rich.
 
 ### Developing with AWS
 For development purposes, you generally shouldn't need a dev deploy of Javabuilder. See
-the [repo-level README]() for instructions on when a dev deploy of Javabuilder is 
-required and how to carry out such a deployment.
+the 
+[repo-level README](https://github.com/code-dot-org/javabuilder/blob/main/README.md#dev-deploy-of-javabuilder)
+for instructions on when a dev deploy of Javabuilder is required and how to carry out
+such a deployment.
 
 ### Developing in isolation
 To run Javabuilder in isolation, run the `LocalMain` class from you Java IDE. This will

--- a/org-code-javabuilder/README.md
+++ b/org-code-javabuilder/README.md
@@ -90,6 +90,10 @@ Alternatively, you can test in "headless" mode
 Postman is a good wscat alternative. It is in beta, but has a gui and is more
 feature-rich.
 
+_Note: non-Java files used or created by the program (for example `grid.txt` in the
+Neighborhood) will be added to the root of the repo. In production, the runtime directory
+is changed to the tmp directory, so cleanup of these files is not necessary there._
+
 ### Developing with AWS
 For development purposes, you generally shouldn't need a dev deploy of Javabuilder. See
 the 


### PR DESCRIPTION
This is an update of the javabuilder readme files to account for the large number of changes that have happened to the Javabuilder repo over the last several months. 

Note to the reviewer, you can look at the "rich diff" of md files by clicking the document icon across from the file name.
![image](https://user-images.githubusercontent.com/8324574/133501013-56daa9d8-b036-40d8-a518-ca967efd1322.png)
