### PR TITLE
Make Item abstract class instead of interface

### DIFF
--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
@@ -16,7 +16,9 @@ public class ImageItem extends Item {
    * @throws FileNotFoundException if the file specified is not the in the asset manager
    */
   public ImageItem(String filename, int x, int y, int width, int height)
-      throws FileNotFoundException {}
+      throws FileNotFoundException {
+    super(x, y, height);
+  }
 
   /**
    * Retrieve the filename for this item.
@@ -30,7 +32,7 @@ public class ImageItem extends Item {
   /**
    * Sets the filename for this item.
    *
-   * @param filename the filename in the asset manager for the image to associat with this item
+   * @param filename the filename in the asset manager for the image to associate with this item
    * @throws FileNotFoundException if the file specified is not the in the asset manager
    */
   public void setFilename(String filename) throws FileNotFoundException {}

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
@@ -2,7 +2,7 @@ package org.code.playground;
 
 import java.io.FileNotFoundException;
 
-public class ImageItem implements Item {
+public class ImageItem extends Item {
   /**
    * Creates an item that can be displayed in the Playground. An item consists of an image,
    * referenced by the name of the image file in the asset manager. The image for the item will be
@@ -36,38 +36,6 @@ public class ImageItem implements Item {
   public void setFilename(String filename) throws FileNotFoundException {}
 
   /**
-   * Set the X position for the item.
-   *
-   * @param x the distance, in pixels, from the left side of the board
-   */
-  public void setX(int x) {}
-
-  /**
-   * Get the X position for the item.
-   *
-   * @return the distance, in pixels, from the left side of the board
-   */
-  public int getX() {
-    return -1;
-  }
-
-  /**
-   * Set the Y position for the item.
-   *
-   * @param y the distance, in pixels, from the top of the board
-   */
-  public void setY(int y) {}
-
-  /**
-   * Get the Y position for the item.
-   *
-   * @return the distance, in pixels, from the top of the board
-   */
-  public int getY() {
-    return -1;
-  }
-
-  /**
    * Set the width for the item.
    *
    * @param width the width of the item, in pixels
@@ -80,22 +48,6 @@ public class ImageItem implements Item {
    * @return the width of the item, in pixels
    */
   public int getWidth() {
-    return -1;
-  }
-
-  /**
-   * Set the height for the item.
-   *
-   * @param height the height of the item, in pixels
-   */
-  public void setHeight(int height) {}
-
-  /**
-   * Get the height for the item.
-   *
-   * @return the height of the item, in pixels
-   */
-  public int getHeight() {
     return -1;
   }
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
@@ -1,6 +1,6 @@
 package org.code.playground;
 
-abstract class Item {
+public abstract class Item {
   /**
    * Set the X position for the item.
    *

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
@@ -1,31 +1,51 @@
 package org.code.playground;
 
-interface Item {
+public abstract class Item {
   /**
    * Set the X position for the item.
    *
    * @param x the distance, in pixels, from the left side of the board
    */
-  public void setX(int x);
+  public void setX(int x) {}
 
   /**
    * Get the X position for the item.
    *
    * @return the distance, in pixels, from the left side of the board
    */
-  public int getX();
+  public int getX() {
+    return -1;
+  }
 
   /**
    * Set the Y position for the item.
    *
    * @param y the distance, in pixels, from the top of the board
    */
-  public void setY(int y);
+  public void setY(int y) {}
 
   /**
    * Get the Y position for the item.
    *
    * @return the distance, in pixels, from the top of the board
    */
-  public int getY();
+  public int getY() {
+    return -1;
+  }
+
+  /**
+   * Set the height for the item.
+   *
+   * @param height the height of the item, in pixels
+   */
+  public void setHeight(int height) {}
+
+  /**
+   * Get the height for the item.
+   *
+   * @return the height of the item, in pixels
+   */
+  public int getHeight() {
+    return -1;
+  }
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
@@ -1,6 +1,6 @@
 package org.code.playground;
 
-public abstract class Item {
+abstract class Item {
   /**
    * Set the X position for the item.
    *

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
@@ -1,6 +1,8 @@
 package org.code.playground;
 
 public abstract class Item {
+  Item(int x, int y, int height) {}
+
   /**
    * Set the X position for the item.
    *

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
@@ -4,7 +4,7 @@ import org.code.media.Color;
 import org.code.media.Font;
 import org.code.media.FontStyle;
 
-public class TextItem implements Item {
+public class TextItem extends Item {
   /**
    * Creates text item that can be placed the board.
    *
@@ -118,53 +118,5 @@ public class TextItem implements Item {
    */
   public double getRotation() {
     return -1.0;
-  }
-
-  /**
-   * Set the X position for the item.
-   *
-   * @param x the distance, in pixels, from the left side of the board
-   */
-  public void setX(int x) {}
-
-  /**
-   * Get the X position for the item.
-   *
-   * @return the distance, in pixels, from the left side of the board
-   */
-  public int getX() {
-    return -1;
-  }
-
-  /**
-   * Set the Y position for the item.
-   *
-   * @param y the distance, in pixels, from the top of the board
-   */
-  public void setY(int y) {}
-
-  /**
-   * Get the Y position for the item.
-   *
-   * @return the distance, in pixels, from the top of the board
-   */
-  public int getY() {
-    return -1;
-  }
-
-  /**
-   * Set the height for the text.
-   *
-   * @param height the height of the text, in pixels
-   */
-  public void setHeight(int height) {}
-
-  /**
-   * Get the height for the text.
-   *
-   * @return the height of the text, in pixels
-   */
-  public int getHeight() {
-    return -1;
   }
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
@@ -25,7 +25,9 @@ public class TextItem extends Item {
       Font font,
       FontStyle fontStyle,
       int height,
-      double rotation) {}
+      double rotation) {
+    super(x, y, height);
+  }
 
   /**
    * Creates text item that can be placed the board in a normal font style.
@@ -38,7 +40,9 @@ public class TextItem extends Item {
    * @param height the height of the text in pixels
    * @param rotation the rotation or tilt of the text, in degrees.
    */
-  public TextItem(String text, int x, int y, Color color, Font font, int height, double rotation) {}
+  public TextItem(String text, int x, int y, Color color, Font font, int height, double rotation) {
+    super(x, y, height);
+  }
 
   /**
    * Set the text content for the item.


### PR DESCRIPTION
Simplify Item and sub-classes by making Item an abstract class instead of an interface. Suggested/discussed in the [Playground dev doc](https://docs.google.com/document/d/1Moo2s5EXZRp5rMg1VW9jlOqs_GeMN5yjU8FJgoqOEMk/edit#).

## Testing story

Confirmed that my script to execute all methods ran as it did when I merged the original no-op PR ([see test code there if interested](https://github.com/code-dot-org/javabuilder/pull/109)).