### PR TITLE
Create Playground Message Handler

### DIFF
--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundMessageHandler.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundMessageHandler.java
@@ -1,0 +1,30 @@
+package org.code.playground;
+
+import org.code.protocol.GlobalProtocol;
+import org.code.protocol.OutputAdapter;
+
+class PlaygroundMessageHandler {
+  private static PlaygroundMessageHandler instance;
+
+  static PlaygroundMessageHandler getInstance() {
+    if (instance == null) {
+      instance = new PlaygroundMessageHandler();
+    }
+    return PlaygroundMessageHandler.instance;
+  }
+
+  private final OutputAdapter outputAdapter;
+
+  private PlaygroundMessageHandler() {
+    this(GlobalProtocol.getInstance().getOutputAdapter());
+  }
+
+  // Visible for testing only
+  PlaygroundMessageHandler(OutputAdapter outputAdapter) {
+    this.outputAdapter = outputAdapter;
+  }
+
+  public void sendMessage(PlaygroundMessage message) {
+    this.outputAdapter.sendMessage(message);
+  }
+}

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/PlaygroundMessageHandlerTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/PlaygroundMessageHandlerTest.java
@@ -1,0 +1,31 @@
+package org.code.playground;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.HashMap;
+import org.code.protocol.OutputAdapter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PlaygroundMessageHandlerTest {
+
+  private OutputAdapter outputAdapter;
+  private PlaygroundMessageHandler unitUnderTest;
+
+  @BeforeEach
+  public void setUp() {
+    outputAdapter = mock(OutputAdapter.class);
+    unitUnderTest = new PlaygroundMessageHandler(outputAdapter);
+  }
+
+  @Test
+  public void testSendMessageCallsOutputAdapter() {
+    final PlaygroundMessage message =
+        new PlaygroundMessage(PlaygroundSignalKey.RUN, new HashMap<>());
+
+    unitUnderTest.sendMessage(message);
+
+    verify(outputAdapter).sendMessage(message);
+  }
+}


### PR DESCRIPTION
Creates a PlaygroundMessageHandler class that takes care of routing Playground messages. For now this is nothing more than a wrapper around `outputAdapter.sendMessage()` but it allows us to isolate message related logic to support other use cases (like message batching) down the road.

Spec: https://docs.google.com/document/d/1Moo2s5EXZRp5rMg1VW9jlOqs_GeMN5yjU8FJgoqOEMk/edit#bookmark=id.7kl6bmoljerq

JIRA: https://codedotorg.atlassian.net/browse/CSA-832

Testing: unit