### PR TITLE
Playground: Manage State & Throw Playground Exceptions

### DIFF
--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundException.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundException.java
@@ -3,7 +3,7 @@ package org.code.playground;
 import org.code.protocol.JavabuilderException;
 
 public class PlaygroundException extends JavabuilderException {
-  protected PlaygroundException(ExceptionKeys key) {
+  protected PlaygroundException(PlaygroundExceptionKeys key) {
     super(key);
   }
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundExceptionKeys.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundExceptionKeys.java
@@ -1,6 +1,6 @@
 package org.code.playground;
 
-public enum ExceptionKeys {
+public enum PlaygroundExceptionKeys {
   PLAYGROUND_RUNNING,
   PLAYGROUND_NOT_RUNNING
 }

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
@@ -1,0 +1,94 @@
+package org.code.playground;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import org.code.protocol.InputHandler;
+import org.code.protocol.InputMessageType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class BoardTest {
+
+  private PlaygroundMessageHandler playgroundMessageHandler;
+  private InputHandler inputHandler;
+  private ArgumentCaptor<PlaygroundMessage> messageCaptor;
+  private Board unitUnderTest;
+
+  @BeforeEach
+  public void setUp() {
+    playgroundMessageHandler = mock(PlaygroundMessageHandler.class);
+    messageCaptor = ArgumentCaptor.forClass(PlaygroundMessage.class);
+    inputHandler = mock(InputHandler.class);
+    unitUnderTest = new Board(playgroundMessageHandler, inputHandler);
+  }
+
+  @Test
+  public void testGetWidthReturnsDefaultWidth() {
+    assertEquals(400, unitUnderTest.getWidth());
+  }
+
+  @Test
+  public void testGetHeightReturnsDefaultHeight() {
+    assertEquals(400, unitUnderTest.getHeight());
+  }
+
+  @Test
+  public void testRunSendsMessageAndWaitsForInput() throws PlaygroundException {
+    // Need to make sure exit() is called so run() terminates
+    when(inputHandler.getNextMessageForType(InputMessageType.PLAYGROUND))
+        .thenAnswer(
+            invocation -> {
+              unitUnderTest.exit();
+              return "id";
+            });
+
+    unitUnderTest.run();
+
+    verify(playgroundMessageHandler, times(2)).sendMessage(messageCaptor.capture());
+    assertEquals(
+        PlaygroundSignalKey.RUN.toString(), messageCaptor.getAllValues().get(0).getValue());
+    verify(inputHandler).getNextMessageForType(InputMessageType.PLAYGROUND);
+  }
+
+  @Test
+  public void testRunThrowsExceptionIfCalledTwice() throws PlaygroundException {
+    // Need to make sure exit() is called so run() terminates
+    when(inputHandler.getNextMessageForType(InputMessageType.PLAYGROUND))
+        .thenAnswer(
+            invocation -> {
+              unitUnderTest.exit();
+              return "id";
+            });
+
+    unitUnderTest.run();
+    final PlaygroundException e =
+        assertThrows(PlaygroundException.class, () -> unitUnderTest.run());
+    assertEquals(PlaygroundExceptionKeys.PLAYGROUND_RUNNING.toString(), e.getMessage());
+  }
+
+  @Test
+  public void testExitSendsExitMessage() throws PlaygroundException {
+    // Ensure that exit() is called while running to avoid exception
+    when(inputHandler.getNextMessageForType(InputMessageType.PLAYGROUND))
+        .thenAnswer(
+            invocation -> {
+              unitUnderTest.exit();
+              return "id";
+            });
+    unitUnderTest.run();
+
+    verify(playgroundMessageHandler, times(2)).sendMessage(messageCaptor.capture());
+    assertEquals(
+        PlaygroundSignalKey.EXIT.toString(), messageCaptor.getAllValues().get(1).getValue());
+  }
+
+  @Test
+  public void testExitThrowsExceptionIfNotRunning() {
+    final PlaygroundException e =
+        assertThrows(PlaygroundException.class, () -> unitUnderTest.exit());
+    assertEquals(PlaygroundExceptionKeys.PLAYGROUND_NOT_RUNNING.toString(), e.getMessage());
+  }
+}


### PR DESCRIPTION
This sets up state management in run() and exit() and also throws exception for state violations. These two tasks were rolled into one PR since they're very closely related. Also renamed ExceptionKeys -> PlaygroundExceptionKeys for clarity.

Spec: https://docs.google.com/document/d/1Moo2s5EXZRp5rMg1VW9jlOqs_GeMN5yjU8FJgoqOEMk/edit#heading=h.9c6oh2x12o0m & https://docs.google.com/document/d/1Moo2s5EXZRp5rMg1VW9jlOqs_GeMN5yjU8FJgoqOEMk/edit#bookmark=id.vlxpt49puof4

JIRAs: https://codedotorg.atlassian.net/browse/CSA-836 & https://codedotorg.atlassian.net/browse/CSA-839

Testing: unit