### PR TITLE
Playground: implement add and remove item handlers

### DIFF
--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
@@ -1,10 +1,14 @@
 package org.code.playground;
 
 import java.io.FileNotFoundException;
+import java.util.HashMap;
 
 public class ImageItem extends Item {
   private int width;
   private String filename;
+
+  private final String FILENAME_KEY = "filename";
+  private final String WIDTH_KEY = "width";
 
   /**
    * Creates an item that can be displayed in the Playground. An item consists of an image,
@@ -60,5 +64,13 @@ public class ImageItem extends Item {
    */
   public int getWidth() {
     return this.width;
+  }
+
+  @Override
+  protected HashMap<String, String> getDetails() {
+    HashMap<String, String> details = super.getDetails();
+    details.put(FILENAME_KEY, this.getFilename());
+    details.put(WIDTH_KEY, Integer.toString(this.getWidth()));
+    return details;
   }
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
@@ -1,12 +1,18 @@
 package org.code.playground;
 
+import java.util.HashMap;
 import java.util.UUID;
 
 public abstract class Item {
   private int xLocation;
   private int yLocation;
   private int height;
-  private String id;
+  private final String id;
+
+  private final String HEIGHT_KEY = "height";
+  private final String X_KEY = "x";
+  private final String Y_KEY = "y";
+  private final String ID_KEY = "id";
 
   Item(int x, int y, int height) {
     this.xLocation = x;
@@ -71,5 +77,20 @@ public abstract class Item {
 
   protected String getId() {
     return this.id;
+  }
+
+  protected HashMap<String, String> getDetails() {
+    HashMap<String, String> details = new HashMap<>();
+    details.put(HEIGHT_KEY, Integer.toString(this.getHeight()));
+    details.put(X_KEY, Integer.toString(this.getX()));
+    details.put(Y_KEY, Integer.toString(this.getY()));
+    details.put(ID_KEY, this.getId());
+    return details;
+  }
+
+  protected HashMap<String, String> getRemoveDetails() {
+    HashMap<String, String> details = new HashMap<>();
+    details.put(ID_KEY, this.getId());
+    return details;
   }
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
@@ -1,14 +1,18 @@
 package org.code.playground;
 
+import java.util.UUID;
+
 public abstract class Item {
   private int xLocation;
   private int yLocation;
   private int height;
+  private String id;
 
   Item(int x, int y, int height) {
     this.xLocation = x;
     this.yLocation = y;
     this.height = height;
+    this.id = UUID.randomUUID().toString();
   }
 
   /**
@@ -63,5 +67,9 @@ public abstract class Item {
    */
   public int getHeight() {
     return this.height;
+  }
+
+  protected String getId() {
+    return this.id;
   }
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
@@ -1,5 +1,6 @@
 package org.code.playground;
 
+import java.util.HashMap;
 import org.code.media.Color;
 import org.code.media.Font;
 import org.code.media.FontStyle;
@@ -10,6 +11,17 @@ public class TextItem extends Item {
   private Font font;
   private FontStyle fontStyle;
   private double rotation;
+  private int colorRed;
+  private int colorGreen;
+  private int colorBlue;
+
+  private final String TEXT_KEY = "text";
+  private final String COLOR_RED_KEY = "colorRed";
+  private final String COLOR_BLUE_KEY = "colorBlue";
+  private final String COLOR_GREEN_KEY = "colorGreen";
+  private final String FONT_KEY = "font";
+  private final String FONT_STYLE_KEY = "fontStyle";
+  private final String ROTATION_KEY = "rotation";
 
   /**
    * Creates text item that can be placed the board.
@@ -34,7 +46,7 @@ public class TextItem extends Item {
       double rotation) {
     super(x, y, height);
     this.text = text;
-    this.color = color;
+    this.setColor(color);
     this.font = font;
     this.fontStyle = fontStyle;
     this.rotation = rotation;
@@ -80,6 +92,10 @@ public class TextItem extends Item {
    */
   public void setColor(Color color) {
     this.color = color;
+    // we lock the color rgb values to what is currently set in color
+    this.colorRed = color.getRed();
+    this.colorBlue = color.getBlue();
+    this.colorGreen = color.getGreen();
   }
 
   /**
@@ -143,5 +159,18 @@ public class TextItem extends Item {
    */
   public double getRotation() {
     return this.rotation;
+  }
+
+  @Override
+  protected HashMap<String, String> getDetails() {
+    HashMap<String, String> details = super.getDetails();
+    details.put(TEXT_KEY, this.getText());
+    details.put(COLOR_RED_KEY, Integer.toString(this.colorRed));
+    details.put(COLOR_GREEN_KEY, Integer.toString(this.colorGreen));
+    details.put(COLOR_BLUE_KEY, Integer.toString(this.colorBlue));
+    details.put(FONT_KEY, this.getFont().toString());
+    details.put(FONT_STYLE_KEY, this.getFontStyle().toString());
+    details.put(ROTATION_KEY, Double.toString(this.getRotation()));
+    return details;
   }
 }

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
@@ -4,6 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
+import java.io.FileNotFoundException;
+import java.util.List;
+import org.code.media.Color;
+import org.code.media.Font;
+import org.code.media.FontStyle;
 import org.code.protocol.InputHandler;
 import org.code.protocol.InputMessageType;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,5 +95,71 @@ class BoardTest {
     final PlaygroundException e =
         assertThrows(PlaygroundException.class, () -> unitUnderTest.exit());
     assertEquals(PlaygroundExceptionKeys.PLAYGROUND_NOT_RUNNING.toString(), e.getMessage());
+  }
+
+  @Test
+  public void testAddClickableImageSendsMessage() throws FileNotFoundException {
+    ClickableImage testImage = new ClickableImageHelper("test", 0, 0, 10, 10);
+    unitUnderTest.addClickableImage(testImage);
+
+    verify(playgroundMessageHandler, times(1)).sendMessage(messageCaptor.capture());
+    PlaygroundMessage message = messageCaptor.getAllValues().get(0);
+    assertEquals(PlaygroundSignalKey.ADD_CLICKABLE_ITEM.toString(), message.getValue());
+  }
+
+  @Test
+  public void testAddClickableImageDoesNotAddDuplicate() throws FileNotFoundException {
+    ClickableImage testImage = new ClickableImageHelper("test", 0, 0, 10, 10);
+    unitUnderTest.addClickableImage(testImage);
+    unitUnderTest.addClickableImage(testImage);
+
+    verify(playgroundMessageHandler, times(1)).sendMessage(messageCaptor.capture());
+    List<PlaygroundMessage> messages = messageCaptor.getAllValues();
+    assertEquals(PlaygroundSignalKey.ADD_CLICKABLE_ITEM.toString(), messages.get(0).getValue());
+  }
+
+  @Test
+  public void testAddItemIncrementsIndex() throws FileNotFoundException {
+    ClickableImage testClickableImage = new ClickableImageHelper("test", 0, 0, 10, 10);
+    ImageItem testImage = new ImageItem("test", 0, 0, 10, 15);
+    unitUnderTest.addClickableImage(testClickableImage);
+    unitUnderTest.addImageItem(testImage);
+
+    verify(playgroundMessageHandler, times(2)).sendMessage(messageCaptor.capture());
+    List<PlaygroundMessage> messages = messageCaptor.getAllValues();
+    assertEquals("0", messages.get(0).getDetail().get("index"));
+    assertEquals("1", messages.get(1).getDetail().get("index"));
+  }
+
+  @Test
+  public void testRemoveItemDoesNotRemoveDuplicate() {
+    TextItem testTextItem =
+        new TextItem("text", 0, 0, Color.AQUA, Font.SANS, FontStyle.BOLD, 10, 0);
+    unitUnderTest.addTextItem(testTextItem);
+    unitUnderTest.removeItem(testTextItem);
+    unitUnderTest.removeItem(testTextItem);
+
+    // should have sent one add and one remove message
+    verify(playgroundMessageHandler, times(2)).sendMessage(messageCaptor.capture());
+    List<PlaygroundMessage> messages = messageCaptor.getAllValues();
+    assertEquals(PlaygroundSignalKey.ADD_TEXT_ITEM.toString(), messages.get(0).getValue());
+    assertEquals(PlaygroundSignalKey.REMOVE_ITEM.toString(), messages.get(1).getValue());
+  }
+
+  @Test
+  public void testCanRemoveAllItemTypes() throws FileNotFoundException {
+    ClickableImage testClickableImage = new ClickableImageHelper("test", 0, 0, 10, 10);
+    ImageItem testImage = new ImageItem("test", 0, 0, 10, 15);
+    TextItem testTextItem =
+        new TextItem("text", 0, 0, Color.AQUA, Font.SANS, FontStyle.BOLD, 10, 0);
+    unitUnderTest.addClickableImage(testClickableImage);
+    unitUnderTest.addTextItem(testTextItem);
+    unitUnderTest.addImageItem(testImage);
+    unitUnderTest.removeItem(testClickableImage);
+    unitUnderTest.removeItem(testTextItem);
+    unitUnderTest.removeItem(testImage);
+
+    // should have sent 3 add and 3 remove messages
+    verify(playgroundMessageHandler, times(6)).sendMessage(messageCaptor.capture());
   }
 }

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
@@ -155,7 +155,7 @@ class BoardTest {
     unitUnderTest.addClickableImage(testClickableImage);
     unitUnderTest.addTextItem(testTextItem);
     unitUnderTest.addImageItem(testImage);
-    unitUnderTest.removeItem(testClickableImage);
+    unitUnderTest.removeClickableImage(testClickableImage);
     unitUnderTest.removeItem(testTextItem);
     unitUnderTest.removeItem(testImage);
 

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/ClickableImageHelper.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/ClickableImageHelper.java
@@ -1,0 +1,27 @@
+package org.code.playground;
+
+import java.io.FileNotFoundException;
+
+public class ClickableImageHelper extends ClickableImage {
+  /**
+   * Creates an item that can be displayed in the Playground and respond to click events. An item
+   * consists of an image, referenced by the name of the image file in the asset manager. The image
+   * for the item will be scaled to fit the width and height provided, which may distort the image.
+   *
+   * @param filename the file name of the image for this item in the asset manager
+   * @param x the distance, in pixels, from the left side of the board
+   * @param y the distance, in pixels, from the top of the board
+   * @param width the width of the item, in pixels
+   * @param height the height of the item, in pixels
+   * @throws FileNotFoundException if the file specified is not the in the asset manager
+   */
+  public ClickableImageHelper(String filename, int x, int y, int width, int height)
+      throws FileNotFoundException {
+    super(filename, x, y, width, height);
+  }
+
+  @Override
+  public void onClick() {
+    // do nothing
+  }
+}


### PR DESCRIPTION
Implement the add and remove handlers for all Item types (`ClickableImage`, `ImageItem`, `TextItem`). This includes a change to the api to remove the `addItem` method and replace it with `addImageItem` and `addTextItem`.

## Links
- [jira](https://codedotorg.atlassian.net/browse/CSA-834)