### PR TITLE
Playground: Set background image

### DIFF
--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
@@ -56,7 +56,7 @@ public class Board {
    */
   public void setBackgroundImage(String filename) throws FileNotFoundException {
     final HashMap<String, String> details = new HashMap<>();
-    details.put(ClientMessageDetailKeys.FILENAME.toString(), filename);
+    details.put(ClientMessageDetailKeys.FILENAME, filename);
 
     this.playgroundMessageHandler.sendMessage(
         new PlaygroundMessage(PlaygroundSignalKey.SET_BACKGROUND_IMAGE, details));

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
@@ -2,6 +2,7 @@ package org.code.playground;
 
 import java.io.FileNotFoundException;
 import java.util.HashMap;
+import org.code.protocol.ClientMessageDetailKeys;
 import org.code.protocol.GlobalProtocol;
 import org.code.protocol.InputHandler;
 import org.code.protocol.InputMessageType;
@@ -53,7 +54,13 @@ public class Board {
    * @param filename the name of the file from the asset manager to put in the background
    * @throws FileNotFoundException if the file cannot be found in the asset manager
    */
-  public void setBackgroundImage(String filename) throws FileNotFoundException {}
+  public void setBackgroundImage(String filename) throws FileNotFoundException {
+    final HashMap<String, String> details = new HashMap<>();
+    details.put(ClientMessageDetailKeys.FILENAME.toString(), filename);
+
+    this.playgroundMessageHandler.sendMessage(
+        new PlaygroundMessage(PlaygroundSignalKey.SET_BACKGROUND_IMAGE, details));
+  }
 
   /**
    * Adds a clickable image to the board.

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
@@ -45,10 +45,9 @@ class BoardTest {
     verify(playgroundMessageHandler).sendMessage(messageCaptor.capture());
     final PlaygroundMessage message = messageCaptor.getValue();
     assertEquals(PlaygroundSignalKey.SET_BACKGROUND_IMAGE.toString(), message.getValue());
-    assertTrue(message.getDetail().has(ClientMessageDetailKeys.FILENAME.toString()));
+    assertTrue(message.getDetail().has(ClientMessageDetailKeys.FILENAME));
     assertEquals(
-        backgroundFilename,
-        message.getDetail().getString(ClientMessageDetailKeys.FILENAME.toString()));
+        backgroundFilename, message.getDetail().getString(ClientMessageDetailKeys.FILENAME));
   }
 
   @Test

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
@@ -1,9 +1,10 @@
 package org.code.playground;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.io.FileNotFoundException;
+import org.code.protocol.ClientMessageDetailKeys;
 import org.code.protocol.InputHandler;
 import org.code.protocol.InputMessageType;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +34,21 @@ class BoardTest {
   @Test
   public void testGetHeightReturnsDefaultHeight() {
     assertEquals(400, unitUnderTest.getHeight());
+  }
+
+  @Test
+  public void testSetBackgroundImageSendsMessage() throws FileNotFoundException {
+    final String backgroundFilename = "background.png";
+
+    unitUnderTest.setBackgroundImage(backgroundFilename);
+
+    verify(playgroundMessageHandler).sendMessage(messageCaptor.capture());
+    final PlaygroundMessage message = messageCaptor.getValue();
+    assertEquals(PlaygroundSignalKey.SET_BACKGROUND_IMAGE.toString(), message.getValue());
+    assertTrue(message.getDetail().has(ClientMessageDetailKeys.FILENAME.toString()));
+    assertEquals(
+        backgroundFilename,
+        message.getDetail().getString(ClientMessageDetailKeys.FILENAME.toString()));
   }
 
   @Test

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
@@ -1,6 +1,6 @@
 package org.code.protocol;
 
 /** Expected keys in the optional detail object of {@link ClientMessage}s */
-public final class ClientMessageDetailKeys {
+public class ClientMessageDetailKeys {
   public static final String FILENAME = "filename";
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
@@ -1,16 +1,6 @@
 package org.code.protocol;
 
 /** Expected keys in the optional detail object of {@link ClientMessage}s */
-public enum ClientMessageDetailKeys {
-  FILENAME("filename");
-
-  private final String name;
-
-  ClientMessageDetailKeys(String name) {
-    this.name = name;
-  }
-
-  public String toString() {
-    return this.name;
-  }
+public final class ClientMessageDetailKeys {
+  public static final String FILENAME = "filename";
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
@@ -1,0 +1,16 @@
+package org.code.protocol;
+
+/** Expected keys in the optional detail object of {@link ClientMessage}s */
+public enum ClientMessageDetailKeys {
+  FILENAME("filename");
+
+  private final String name;
+
+  ClientMessageDetailKeys(String name) {
+    this.name = name;
+  }
+
+  public String toString() {
+    return this.name;
+  }
+}


### PR DESCRIPTION
Sends a SET_BACKGROUND_IMAGE message with the background image file name.

I also created an ~~enum~~ class for `ClientMessageDetailKeys` that would contain common keys we use in the detail object that gets sent with client messages. I'm curious for feedback on this - I added this because, as we'll be introducing a lot of these for Playground, I felt like it would be good for us to have all our keys in one place and standardize the naming a little bit so it's easier to reference. But I'm not sure if it's overkill, as a lot of the keys will still be app-specific (for example all the playground x, y, width, height, etc keys). Still though, this can at least house some common keys like `filename`, `url`, and `id` for example. Additionally, if we think it would be helpful, we can also subclass `ClientMessageDetailKeys` for app-specific keys (for example `PlaygroundClientMessageDetailKeys` which can contain enums for X, Y, WIDTH, HEIGHT, etc)

Spec: https://docs.google.com/document/d/1Moo2s5EXZRp5rMg1VW9jlOqs_GeMN5yjU8FJgoqOEMk/edit#heading=h.yth48qvin8gl
JIRA: https://codedotorg.atlassian.net/browse/CSA-838

Tested locally with All The Things Playground level & unit tests
