### PR TITLE
Send message on playSound

### DIFF
--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
@@ -143,7 +143,7 @@ public class Board {
    */
   public void playSound(String filename) throws FileNotFoundException {
     HashMap<String, String> details = new HashMap<>();
-    details.put("filename", filename);
+    details.put(ClientMessageDetailKeys.FILENAME, filename);
 
     PlaygroundMessage playSoundMessage =
         new PlaygroundMessage(PlaygroundSignalKey.PLAY_SOUND, details);

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
@@ -179,8 +179,9 @@ public class Board {
    * @throws FileNotFoundException if the sound file cannot be found.
    */
   public void exit(String endingSound) throws PlaygroundException, FileNotFoundException {
+    this.confirmIsRunning();
     this.playSound(endingSound);
-    this.exit();
+    this.sendExitMessageAndEndRun();
   }
 
   /**
@@ -189,13 +190,8 @@ public class Board {
    * @throws PlaygroundException if the run() method has not been called.
    */
   public void exit() throws PlaygroundException {
-    if (!this.isRunning) {
-      throw new PlaygroundException(PlaygroundExceptionKeys.PLAYGROUND_NOT_RUNNING);
-    }
-
-    this.playgroundMessageHandler.sendMessage(
-        new PlaygroundMessage(PlaygroundSignalKey.EXIT, new HashMap<>()));
-    this.isRunning = false;
+    this.confirmIsRunning();
+    this.sendExitMessageAndEndRun();
   }
 
   private void handleClickEvent(String id) {
@@ -215,5 +211,17 @@ public class Board {
   private void addIndexToDetails(HashMap<String, String> details) {
     details.put("index", Integer.toString(this.nextItemIndex));
     this.nextItemIndex++;
+  }
+
+  private void sendExitMessageAndEndRun() {
+    this.playgroundMessageHandler.sendMessage(
+        new PlaygroundMessage(PlaygroundSignalKey.EXIT, new HashMap<>()));
+    this.isRunning = false;
+  }
+
+  private void confirmIsRunning() throws PlaygroundException {
+    if (!this.isRunning) {
+      throw new PlaygroundException(PlaygroundExceptionKeys.PLAYGROUND_NOT_RUNNING);
+    }
   }
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
@@ -89,7 +89,14 @@ public class Board {
    * @param filename the name of the sound file from the asset manager to play
    * @throws FileNotFoundException when the sound file cannot be found.
    */
-  public void playSound(String filename) throws FileNotFoundException {}
+  public void playSound(String filename) throws FileNotFoundException {
+    HashMap<String, String> details = new HashMap<>();
+    details.put("filename", filename);
+
+    PlaygroundMessage playSoundMessage =
+        new PlaygroundMessage(PlaygroundSignalKey.PLAY_SOUND, details);
+    this.playgroundMessageHandler.sendMessage(playSoundMessage);
+  }
 
   /**
    * Starts the playground game, waiting for the user to click on images and executing the
@@ -126,7 +133,10 @@ public class Board {
    * @throws PlaygroundException if the run() method has not been called.
    * @throws FileNotFoundException if the sound file cannot be found.
    */
-  public void exit(String endingSound) throws PlaygroundException, FileNotFoundException {}
+  public void exit(String endingSound) throws PlaygroundException, FileNotFoundException {
+    this.playSound(endingSound);
+    this.exit();
+  }
 
   /**
    * Ends the game and stops program execution.

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
@@ -48,7 +48,9 @@ class BoardTest {
     verify(playgroundMessageHandler).sendMessage(messageCaptor.capture());
     assertEquals(
         PlaygroundSignalKey.PLAY_SOUND.toString(), messageCaptor.getAllValues().get(0).getValue());
-    assertEquals(filename, messageCaptor.getAllValues().get(0).getDetail().get("filename"));
+    assertEquals(
+        filename,
+        messageCaptor.getAllValues().get(0).getDetail().get(ClientMessageDetailKeys.FILENAME));
   }
 
   public void testSetBackgroundImageSendsMessage() throws FileNotFoundException {
@@ -131,7 +133,9 @@ class BoardTest {
     verify(playgroundMessageHandler, times(3)).sendMessage(messageCaptor.capture());
     assertEquals(
         PlaygroundSignalKey.PLAY_SOUND.toString(), messageCaptor.getAllValues().get(1).getValue());
-    assertEquals(filename, messageCaptor.getAllValues().get(1).getDetail().get("filename"));
+    assertEquals(
+        filename,
+        messageCaptor.getAllValues().get(1).getDetail().get(ClientMessageDetailKeys.FILENAME));
     assertEquals(
         PlaygroundSignalKey.EXIT.toString(), messageCaptor.getAllValues().get(2).getValue());
   }


### PR DESCRIPTION
Sends a message to Javalab to play a sound when `playSound` is called. Also implements the exit method where students can play a particular sound on exit from their program.

## Testing story

Added unit tests, and confirmed that I got the appropriate message if I called board.playSound('filename') directly (should this be allowed? I think so per [this slack conversation](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1632255162336100?thread_ts=1632253744.333100&cid=C01EF4GJ9GE))
