### PR TITLE
Don't wrap JavabuilderExceptions if they are thrown in student code

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilder.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilder.java
@@ -47,8 +47,7 @@ public class CodeBuilder implements AutoCloseable {
   /**
    * Replaces System.in and System.out with our custom implementation and executes the user's code.
    */
-  public void runUserCode()
-      throws InternalServerError, InternalFacingException, UserInitiatedException {
+  public void runUserCode() throws InternalFacingException, JavabuilderException {
     System.setOut(new OutputPrintStream(this.outputAdapter));
     System.setIn(new InputRedirectionStream(this.inputHandler));
     JavaRunner runner;


### PR DESCRIPTION
We currently have logic to surface `JavabuilderRuntimeException`s if they are thrown from student code, but do not handle `JavabuilderException`s in the same way. This adds the same logic for handling `JavabuilderException`s so that the original underlying exceptions are thrown and can be translated correctly in Javalab.

Tested locally against All The Things Playground level