### PR TITLE
Playground: handle updates

### DIFF
--- a/org-code-javabuilder/playground/build.gradle
+++ b/org-code-javabuilder/playground/build.gradle
@@ -17,7 +17,7 @@ java {
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     // https://mvnrepository.com/artifact/org.mockito/mockito-core
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.9.0'
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
     // https://mvnrepository.com/artifact/org.json/json
     implementation group: 'org.json', name: 'json', version: '20210307'

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
@@ -200,6 +200,7 @@ public class Board {
       return;
     }
     ClickableImage image = this.clickableImages.get(id);
+    image.onClick();
   }
 
   private void addItemHelper(Item item, PlaygroundSignalKey signalKey) {

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
@@ -189,7 +189,10 @@ public class Board {
   }
 
   private void handleClickEvent(String id) {
-    // TODO: Handle updates
+    if (!this.clickableImages.containsKey(id)) {
+      return;
+    }
+    ClickableImage image = this.clickableImages.get(id);
   }
 
   private void addItemHelper(Item item, PlaygroundSignalKey signalKey) {

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
@@ -46,6 +46,7 @@ public class ImageItem extends Item {
    */
   public void setFilename(String filename) throws FileNotFoundException {
     this.filename = filename;
+    this.sendChangeMessage(FILENAME_KEY, filename);
   }
 
   /**
@@ -55,6 +56,7 @@ public class ImageItem extends Item {
    */
   public void setWidth(int width) {
     this.width = width;
+    this.sendChangeMessage(WIDTH_KEY, Integer.toString(width));
   }
 
   /**

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
@@ -2,13 +2,11 @@ package org.code.playground;
 
 import java.io.FileNotFoundException;
 import java.util.HashMap;
+import org.code.protocol.ClientMessageDetailKeys;
 
 public class ImageItem extends Item {
   private int width;
   private String filename;
-
-  private final String FILENAME_KEY = "filename";
-  private final String WIDTH_KEY = "width";
 
   /**
    * Creates an item that can be displayed in the Playground. An item consists of an image,
@@ -46,7 +44,7 @@ public class ImageItem extends Item {
    */
   public void setFilename(String filename) throws FileNotFoundException {
     this.filename = filename;
-    this.sendChangeMessage(FILENAME_KEY, filename);
+    this.sendChangeMessage(ClientMessageDetailKeys.FILENAME, filename);
   }
 
   /**
@@ -56,7 +54,7 @@ public class ImageItem extends Item {
    */
   public void setWidth(int width) {
     this.width = width;
-    this.sendChangeMessage(WIDTH_KEY, Integer.toString(width));
+    this.sendChangeMessage(ClientMessageDetailKeys.WIDTH, Integer.toString(width));
   }
 
   /**
@@ -71,8 +69,8 @@ public class ImageItem extends Item {
   @Override
   protected HashMap<String, String> getDetails() {
     HashMap<String, String> details = super.getDetails();
-    details.put(FILENAME_KEY, this.getFilename());
-    details.put(WIDTH_KEY, Integer.toString(this.getWidth()));
+    details.put(ClientMessageDetailKeys.FILENAME, this.getFilename());
+    details.put(ClientMessageDetailKeys.WIDTH, Integer.toString(this.getWidth()));
     return details;
   }
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
@@ -8,6 +8,7 @@ public abstract class Item {
   private int yLocation;
   private int height;
   private final String id;
+  private final PlaygroundMessageHandler playgroundMessageHandler;
 
   private final String HEIGHT_KEY = "height";
   private final String X_KEY = "x";
@@ -19,6 +20,7 @@ public abstract class Item {
     this.yLocation = y;
     this.height = height;
     this.id = UUID.randomUUID().toString();
+    this.playgroundMessageHandler = PlaygroundMessageHandler.getInstance();
   }
 
   /**
@@ -28,6 +30,7 @@ public abstract class Item {
    */
   public void setX(int x) {
     this.xLocation = x;
+    this.sendChangeMessage(X_KEY, Integer.toString(x));
   }
 
   /**
@@ -46,6 +49,7 @@ public abstract class Item {
    */
   public void setY(int y) {
     this.yLocation = y;
+    this.sendChangeMessage(Y_KEY, Integer.toString(y));
   }
 
   /**
@@ -64,6 +68,7 @@ public abstract class Item {
    */
   public void setHeight(int height) {
     this.height = height;
+    this.sendChangeMessage(HEIGHT_KEY, Integer.toString(height));
   }
 
   /**
@@ -80,17 +85,34 @@ public abstract class Item {
   }
 
   protected HashMap<String, String> getDetails() {
-    HashMap<String, String> details = new HashMap<>();
+    HashMap<String, String> details = this.getIdDetails();
     details.put(HEIGHT_KEY, Integer.toString(this.getHeight()));
     details.put(X_KEY, Integer.toString(this.getX()));
     details.put(Y_KEY, Integer.toString(this.getY()));
-    details.put(ID_KEY, this.getId());
     return details;
   }
 
   protected HashMap<String, String> getRemoveDetails() {
-    HashMap<String, String> details = new HashMap<>();
-    details.put(ID_KEY, this.getId());
+    HashMap<String, String> details = this.getIdDetails();
     return details;
+  }
+
+  protected void sendChangeMessage(String key, String value) {
+    HashMap<String, String> details = this.getIdDetails();
+    details.put(key, value);
+    this.playgroundMessageHandler.sendMessage(
+        new PlaygroundMessage(PlaygroundSignalKey.CHANGE_ITEM, details));
+  }
+
+  protected void sendChangeMessage(HashMap<String, String> changeDetails) {
+    changeDetails.put(ID_KEY, this.getId());
+    this.playgroundMessageHandler.sendMessage(
+        new PlaygroundMessage(PlaygroundSignalKey.CHANGE_ITEM, changeDetails));
+  }
+
+  private HashMap<String, String> getIdDetails() {
+    HashMap<String, String> idDetails = new HashMap<>();
+    idDetails.put(ID_KEY, this.getId());
+    return idDetails;
   }
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
@@ -2,6 +2,7 @@ package org.code.playground;
 
 import java.util.HashMap;
 import java.util.UUID;
+import org.code.protocol.ClientMessageDetailKeys;
 
 public abstract class Item {
   private int xLocation;
@@ -9,11 +10,6 @@ public abstract class Item {
   private int height;
   private final String id;
   private final PlaygroundMessageHandler playgroundMessageHandler;
-
-  private final String HEIGHT_KEY = "height";
-  private final String X_KEY = "x";
-  private final String Y_KEY = "y";
-  private final String ID_KEY = "id";
 
   Item(int x, int y, int height) {
     this.xLocation = x;
@@ -30,7 +26,7 @@ public abstract class Item {
    */
   public void setX(int x) {
     this.xLocation = x;
-    this.sendChangeMessage(X_KEY, Integer.toString(x));
+    this.sendChangeMessage(ClientMessageDetailKeys.X, Integer.toString(x));
   }
 
   /**
@@ -49,7 +45,7 @@ public abstract class Item {
    */
   public void setY(int y) {
     this.yLocation = y;
-    this.sendChangeMessage(Y_KEY, Integer.toString(y));
+    this.sendChangeMessage(ClientMessageDetailKeys.Y, Integer.toString(y));
   }
 
   /**
@@ -68,7 +64,7 @@ public abstract class Item {
    */
   public void setHeight(int height) {
     this.height = height;
-    this.sendChangeMessage(HEIGHT_KEY, Integer.toString(height));
+    this.sendChangeMessage(ClientMessageDetailKeys.HEIGHT, Integer.toString(height));
   }
 
   /**
@@ -86,9 +82,9 @@ public abstract class Item {
 
   protected HashMap<String, String> getDetails() {
     HashMap<String, String> details = this.getIdDetails();
-    details.put(HEIGHT_KEY, Integer.toString(this.getHeight()));
-    details.put(X_KEY, Integer.toString(this.getX()));
-    details.put(Y_KEY, Integer.toString(this.getY()));
+    details.put(ClientMessageDetailKeys.HEIGHT, Integer.toString(this.getHeight()));
+    details.put(ClientMessageDetailKeys.X, Integer.toString(this.getX()));
+    details.put(ClientMessageDetailKeys.Y, Integer.toString(this.getY()));
     return details;
   }
 
@@ -105,14 +101,14 @@ public abstract class Item {
   }
 
   protected void sendChangeMessage(HashMap<String, String> changeDetails) {
-    changeDetails.put(ID_KEY, this.getId());
+    changeDetails.put(ClientMessageDetailKeys.ID, this.getId());
     this.playgroundMessageHandler.sendMessage(
         new PlaygroundMessage(PlaygroundSignalKey.CHANGE_ITEM, changeDetails));
   }
 
   private HashMap<String, String> getIdDetails() {
     HashMap<String, String> idDetails = new HashMap<>();
-    idDetails.put(ID_KEY, this.getId());
+    idDetails.put(ClientMessageDetailKeys.ID, this.getId());
     return idDetails;
   }
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
@@ -89,8 +89,7 @@ public abstract class Item {
   }
 
   protected HashMap<String, String> getRemoveDetails() {
-    HashMap<String, String> details = this.getIdDetails();
-    return details;
+    return this.getIdDetails();
   }
 
   protected void sendChangeMessage(String key, String value) {

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
@@ -46,7 +46,7 @@ public class TextItem extends Item {
       double rotation) {
     super(x, y, height);
     this.text = text;
-    this.setColor(color);
+    this.setColorHelper(color);
     this.font = font;
     this.fontStyle = fontStyle;
     this.rotation = rotation;
@@ -92,11 +92,10 @@ public class TextItem extends Item {
    * @param color the text color
    */
   public void setColor(Color color) {
-    this.color = color;
-    // we lock the color rgb values to what is currently set in color
-    this.colorRed = color.getRed();
-    this.colorBlue = color.getBlue();
-    this.colorGreen = color.getGreen();
+    this.setColorHelper(color);
+    HashMap<String, String> colorDetails = new HashMap<>();
+    this.addColorToDetails(colorDetails);
+    this.sendChangeMessage(colorDetails);
   }
 
   /**
@@ -115,6 +114,7 @@ public class TextItem extends Item {
    */
   public void setFont(Font font) {
     this.font = font;
+    this.sendChangeMessage(FONT_KEY, font.toString());
   }
 
   /**
@@ -133,6 +133,7 @@ public class TextItem extends Item {
    */
   public void setFontStyle(FontStyle fontStyle) {
     this.fontStyle = fontStyle;
+    this.sendChangeMessage(FONT_STYLE_KEY, fontStyle.toString());
   }
 
   /**
@@ -151,6 +152,7 @@ public class TextItem extends Item {
    */
   public void setRotation(double rotation) {
     this.rotation = rotation;
+    this.sendChangeMessage(ROTATION_KEY, Double.toString(rotation));
   }
 
   /**
@@ -166,14 +168,24 @@ public class TextItem extends Item {
   protected HashMap<String, String> getDetails() {
     HashMap<String, String> details = super.getDetails();
     details.put(TEXT_KEY, this.getText());
-    details.put(COLOR_RED_KEY, Integer.toString(this.colorRed));
-    details.put(COLOR_GREEN_KEY, Integer.toString(this.colorGreen));
-    details.put(COLOR_BLUE_KEY, Integer.toString(this.colorBlue));
+    this.addColorToDetails(details);
     details.put(FONT_KEY, this.getFont().toString());
     details.put(FONT_STYLE_KEY, this.getFontStyle().toString());
     details.put(ROTATION_KEY, Double.toString(this.getRotation()));
     return details;
   }
 
-  private void setColorHelper(Color color) {}
+  private void setColorHelper(Color color) {
+    this.color = color;
+    // we lock the color rgb values to what is currently set in color
+    this.colorRed = color.getRed();
+    this.colorBlue = color.getBlue();
+    this.colorGreen = color.getGreen();
+  }
+
+  private void addColorToDetails(HashMap<String, String> details) {
+    details.put(COLOR_RED_KEY, Integer.toString(this.colorRed));
+    details.put(COLOR_GREEN_KEY, Integer.toString(this.colorGreen));
+    details.put(COLOR_BLUE_KEY, Integer.toString(this.colorBlue));
+  }
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import org.code.media.Color;
 import org.code.media.Font;
 import org.code.media.FontStyle;
+import org.code.protocol.ClientMessageDetailKeys;
 
 public class TextItem extends Item {
   private String text;
@@ -14,14 +15,6 @@ public class TextItem extends Item {
   private int colorRed;
   private int colorGreen;
   private int colorBlue;
-
-  private final String TEXT_KEY = "text";
-  private final String COLOR_RED_KEY = "colorRed";
-  private final String COLOR_BLUE_KEY = "colorBlue";
-  private final String COLOR_GREEN_KEY = "colorGreen";
-  private final String FONT_KEY = "font";
-  private final String FONT_STYLE_KEY = "fontStyle";
-  private final String ROTATION_KEY = "rotation";
 
   /**
    * Creates text item that can be placed the board.
@@ -74,7 +67,7 @@ public class TextItem extends Item {
    */
   public void setText(String text) {
     this.text = text;
-    this.sendChangeMessage(TEXT_KEY, text);
+    this.sendChangeMessage(ClientMessageDetailKeys.TEXT, text);
   }
 
   /**
@@ -114,7 +107,7 @@ public class TextItem extends Item {
    */
   public void setFont(Font font) {
     this.font = font;
-    this.sendChangeMessage(FONT_KEY, font.toString());
+    this.sendChangeMessage(ClientMessageDetailKeys.FONT, font.toString());
   }
 
   /**
@@ -133,7 +126,7 @@ public class TextItem extends Item {
    */
   public void setFontStyle(FontStyle fontStyle) {
     this.fontStyle = fontStyle;
-    this.sendChangeMessage(FONT_STYLE_KEY, fontStyle.toString());
+    this.sendChangeMessage(ClientMessageDetailKeys.FONT_STYLE, fontStyle.toString());
   }
 
   /**
@@ -152,7 +145,7 @@ public class TextItem extends Item {
    */
   public void setRotation(double rotation) {
     this.rotation = rotation;
-    this.sendChangeMessage(ROTATION_KEY, Double.toString(rotation));
+    this.sendChangeMessage(ClientMessageDetailKeys.ROTATION, Double.toString(rotation));
   }
 
   /**
@@ -167,11 +160,11 @@ public class TextItem extends Item {
   @Override
   protected HashMap<String, String> getDetails() {
     HashMap<String, String> details = super.getDetails();
-    details.put(TEXT_KEY, this.getText());
+    details.put(ClientMessageDetailKeys.TEXT, this.getText());
     this.addColorToDetails(details);
-    details.put(FONT_KEY, this.getFont().toString());
-    details.put(FONT_STYLE_KEY, this.getFontStyle().toString());
-    details.put(ROTATION_KEY, Double.toString(this.getRotation()));
+    details.put(ClientMessageDetailKeys.FONT, this.getFont().toString());
+    details.put(ClientMessageDetailKeys.FONT_STYLE, this.getFontStyle().toString());
+    details.put(ClientMessageDetailKeys.ROTATION, Double.toString(this.getRotation()));
     return details;
   }
 
@@ -184,8 +177,8 @@ public class TextItem extends Item {
   }
 
   private void addColorToDetails(HashMap<String, String> details) {
-    details.put(COLOR_RED_KEY, Integer.toString(this.colorRed));
-    details.put(COLOR_GREEN_KEY, Integer.toString(this.colorGreen));
-    details.put(COLOR_BLUE_KEY, Integer.toString(this.colorBlue));
+    details.put(ClientMessageDetailKeys.COLOR_RED, Integer.toString(this.colorRed));
+    details.put(ClientMessageDetailKeys.COLOR_GREEN, Integer.toString(this.colorGreen));
+    details.put(ClientMessageDetailKeys.COLOR_BLUE, Integer.toString(this.colorBlue));
   }
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
@@ -74,6 +74,7 @@ public class TextItem extends Item {
    */
   public void setText(String text) {
     this.text = text;
+    this.sendChangeMessage(TEXT_KEY, text);
   }
 
   /**
@@ -173,4 +174,6 @@ public class TextItem extends Item {
     details.put(ROTATION_KEY, Double.toString(this.getRotation()));
     return details;
   }
+
+  private void setColorHelper(Color color) {}
 }

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
@@ -9,8 +9,7 @@ import java.util.List;
 import org.code.media.Color;
 import org.code.media.Font;
 import org.code.media.FontStyle;
-import org.code.protocol.InputHandler;
-import org.code.protocol.InputMessageType;
+import org.code.protocol.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -28,6 +27,13 @@ class BoardTest {
     messageCaptor = ArgumentCaptor.forClass(PlaygroundMessage.class);
     inputHandler = mock(InputHandler.class);
     unitUnderTest = new Board(playgroundMessageHandler, inputHandler);
+    GlobalProtocol.create(
+        mock(OutputAdapter.class),
+        mock(InputAdapter.class),
+        "",
+        "",
+        "",
+        mock(JavabuilderFileWriter.class));
   }
 
   @Test

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/ClickableImageHelper.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/ClickableImageHelper.java
@@ -2,6 +2,7 @@ package org.code.playground;
 
 import java.io.FileNotFoundException;
 
+// a basic implementation of ClickableImage to use for testing
 public class ClickableImageHelper extends ClickableImage {
   /**
    * Creates an item that can be displayed in the Playground and respond to click events. An item

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/ImageItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/ImageItemTest.java
@@ -42,13 +42,17 @@ public class ImageItemTest {
   @Test
   public void settersSendChangeMessages() throws FileNotFoundException {
     ImageItem imageItem = new ImageItem("test", 0, 0, 10, 10);
-    imageItem.setFilename("new_filename");
-    imageItem.setWidth(100);
+
+    String newFilename = "new_filename";
+    int newWidth = 100;
+    imageItem.setFilename(newFilename);
+    imageItem.setWidth(newWidth);
 
     verify(playgroundMessageHandler, times(2)).sendMessage(messageCaptor.capture());
     List<PlaygroundMessage> messages = messageCaptor.getAllValues();
     assertEquals(PlaygroundSignalKey.CHANGE_ITEM.toString(), messages.get(0).getValue());
-    assertEquals("new_filename", messages.get(0).getDetail().get("filename"));
-    assertEquals("100", messages.get(1).getDetail().get("width"));
+    assertEquals(newFilename, messages.get(0).getDetail().get(ClientMessageDetailKeys.FILENAME));
+    assertEquals(
+        Integer.toString(newWidth), messages.get(1).getDetail().get(ClientMessageDetailKeys.WIDTH));
   }
 }

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/ImageItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/ImageItemTest.java
@@ -1,0 +1,54 @@
+package org.code.playground;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.io.FileNotFoundException;
+import java.util.List;
+import org.code.protocol.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+public class ImageItemTest {
+  private PlaygroundMessageHandler playgroundMessageHandler;
+  private ArgumentCaptor<PlaygroundMessage> messageCaptor;
+  private MockedStatic<PlaygroundMessageHandler> messageHandlerMockedStatic;
+
+  @BeforeEach
+  public void setUp() {
+    playgroundMessageHandler = mock(PlaygroundMessageHandler.class);
+    messageCaptor = ArgumentCaptor.forClass(PlaygroundMessage.class);
+    GlobalProtocol.create(
+        mock(OutputAdapter.class),
+        mock(InputAdapter.class),
+        "",
+        "",
+        "",
+        mock(JavabuilderFileWriter.class));
+    messageHandlerMockedStatic = mockStatic(PlaygroundMessageHandler.class);
+    messageHandlerMockedStatic
+        .when(PlaygroundMessageHandler::getInstance)
+        .thenReturn(playgroundMessageHandler);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    messageHandlerMockedStatic.close();
+  }
+
+  @Test
+  public void settersSendChangeMessages() throws FileNotFoundException {
+    ImageItem imageItem = new ImageItem("test", 0, 0, 10, 10);
+    imageItem.setFilename("new_filename");
+    imageItem.setWidth(100);
+
+    verify(playgroundMessageHandler, times(2)).sendMessage(messageCaptor.capture());
+    List<PlaygroundMessage> messages = messageCaptor.getAllValues();
+    assertEquals(PlaygroundSignalKey.CHANGE_ITEM.toString(), messages.get(0).getValue());
+    assertEquals("new_filename", messages.get(0).getDetail().get("filename"));
+    assertEquals("100", messages.get(1).getDetail().get("width"));
+  }
+}

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/ItemHelper.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/ItemHelper.java
@@ -1,0 +1,8 @@
+package org.code.playground;
+
+// a clean implementation of Item to use for testing basic Item functionality
+public class ItemHelper extends Item {
+  ItemHelper(int x, int y, int height) {
+    super(x, y, height);
+  }
+}

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/ItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/ItemTest.java
@@ -1,0 +1,60 @@
+package org.code.playground;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import org.code.protocol.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+public class ItemTest {
+  private PlaygroundMessageHandler playgroundMessageHandler;
+  private ArgumentCaptor<PlaygroundMessage> messageCaptor;
+  private MockedStatic<PlaygroundMessageHandler> messageHandlerMockedStatic;
+
+  @BeforeEach
+  public void setUp() {
+    playgroundMessageHandler = mock(PlaygroundMessageHandler.class);
+    messageCaptor = ArgumentCaptor.forClass(PlaygroundMessage.class);
+    GlobalProtocol.create(
+        mock(OutputAdapter.class),
+        mock(InputAdapter.class),
+        "",
+        "",
+        "",
+        mock(JavabuilderFileWriter.class));
+
+    messageHandlerMockedStatic = mockStatic(PlaygroundMessageHandler.class);
+    messageHandlerMockedStatic
+        .when(PlaygroundMessageHandler::getInstance)
+        .thenReturn(playgroundMessageHandler);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    messageHandlerMockedStatic.close();
+  }
+
+  @Test
+  public void settersSendChangeMessages() {
+    Item item = new ItemHelper(0, 0, 15);
+
+    int newX = 5;
+    int newY = 10;
+    int newHeight = 100;
+    item.setX(newX);
+    item.setY(newY);
+    item.setHeight(newHeight);
+
+    verify(playgroundMessageHandler, times(3)).sendMessage(messageCaptor.capture());
+    List<PlaygroundMessage> messages = messageCaptor.getAllValues();
+    assertEquals(PlaygroundSignalKey.CHANGE_ITEM.toString(), messages.get(0).getValue());
+    assertEquals(Integer.toString(newX), messages.get(0).getDetail().get("x"));
+    assertEquals(Integer.toString(newY), messages.get(1).getDetail().get("y"));
+    assertEquals(Integer.toString(newHeight), messages.get(2).getDetail().get("height"));
+  }
+}

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/ItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/ItemTest.java
@@ -53,8 +53,12 @@ public class ItemTest {
     verify(playgroundMessageHandler, times(3)).sendMessage(messageCaptor.capture());
     List<PlaygroundMessage> messages = messageCaptor.getAllValues();
     assertEquals(PlaygroundSignalKey.CHANGE_ITEM.toString(), messages.get(0).getValue());
-    assertEquals(Integer.toString(newX), messages.get(0).getDetail().get("x"));
-    assertEquals(Integer.toString(newY), messages.get(1).getDetail().get("y"));
-    assertEquals(Integer.toString(newHeight), messages.get(2).getDetail().get("height"));
+    assertEquals(
+        Integer.toString(newX), messages.get(0).getDetail().get(ClientMessageDetailKeys.X));
+    assertEquals(
+        Integer.toString(newY), messages.get(1).getDetail().get(ClientMessageDetailKeys.Y));
+    assertEquals(
+        Integer.toString(newHeight),
+        messages.get(2).getDetail().get(ClientMessageDetailKeys.HEIGHT));
   }
 }

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
@@ -1,0 +1,71 @@
+package org.code.playground;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import org.code.media.Color;
+import org.code.media.Font;
+import org.code.media.FontStyle;
+import org.code.protocol.GlobalProtocol;
+import org.code.protocol.InputAdapter;
+import org.code.protocol.JavabuilderFileWriter;
+import org.code.protocol.OutputAdapter;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+public class TextItemTest {
+  private PlaygroundMessageHandler playgroundMessageHandler;
+  private ArgumentCaptor<PlaygroundMessage> messageCaptor;
+  private MockedStatic<PlaygroundMessageHandler> messageHandlerMockedStatic;
+
+  @BeforeEach
+  public void setUp() {
+    playgroundMessageHandler = mock(PlaygroundMessageHandler.class);
+    messageCaptor = ArgumentCaptor.forClass(PlaygroundMessage.class);
+    GlobalProtocol.create(
+        mock(OutputAdapter.class),
+        mock(InputAdapter.class),
+        "",
+        "",
+        "",
+        mock(JavabuilderFileWriter.class));
+    messageHandlerMockedStatic = mockStatic(PlaygroundMessageHandler.class);
+    messageHandlerMockedStatic
+        .when(PlaygroundMessageHandler::getInstance)
+        .thenReturn(playgroundMessageHandler);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    messageHandlerMockedStatic.close();
+  }
+
+  @Test
+  public void settersSendChangeMessages() {
+    TextItem textItem = new TextItem("text", 0, 0, Color.BLUE, Font.SANS, FontStyle.BOLD, 10, 0);
+
+    String newText = "new text";
+    Color newColor = Color.GREEN;
+    Font newFont = Font.SERIF;
+    FontStyle newFontStyle = FontStyle.ITALIC;
+    double newRotation = 15;
+
+    textItem.setText(newText);
+    textItem.setColor(newColor);
+    textItem.setFont(newFont);
+    textItem.setFontStyle(newFontStyle);
+    textItem.setRotation(newRotation);
+
+    verify(playgroundMessageHandler, times(5)).sendMessage(messageCaptor.capture());
+    List<PlaygroundMessage> messages = messageCaptor.getAllValues();
+    assertEquals(PlaygroundSignalKey.CHANGE_ITEM.toString(), messages.get(0).getValue());
+    assertEquals(newText, messages.get(0).getDetail().get("text"));
+    JSONObject colorDetails = messages.get(1).getDetail();
+    assertEquals(Integer.toString(newColor.getRed()), colorDetails.get("colorRed"));
+  }
+}

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
@@ -7,10 +7,7 @@ import java.util.List;
 import org.code.media.Color;
 import org.code.media.Font;
 import org.code.media.FontStyle;
-import org.code.protocol.GlobalProtocol;
-import org.code.protocol.InputAdapter;
-import org.code.protocol.JavabuilderFileWriter;
-import org.code.protocol.OutputAdapter;
+import org.code.protocol.*;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,8 +61,21 @@ public class TextItemTest {
     verify(playgroundMessageHandler, times(5)).sendMessage(messageCaptor.capture());
     List<PlaygroundMessage> messages = messageCaptor.getAllValues();
     assertEquals(PlaygroundSignalKey.CHANGE_ITEM.toString(), messages.get(0).getValue());
-    assertEquals(newText, messages.get(0).getDetail().get("text"));
+    assertEquals(newText, messages.get(0).getDetail().get(ClientMessageDetailKeys.TEXT));
     JSONObject colorDetails = messages.get(1).getDetail();
-    assertEquals(Integer.toString(newColor.getRed()), colorDetails.get("colorRed"));
+    assertEquals(
+        Integer.toString(newColor.getRed()), colorDetails.get(ClientMessageDetailKeys.COLOR_RED));
+    assertEquals(
+        Integer.toString(newColor.getBlue()), colorDetails.get(ClientMessageDetailKeys.COLOR_BLUE));
+    assertEquals(
+        Integer.toString(newColor.getGreen()),
+        colorDetails.get(ClientMessageDetailKeys.COLOR_GREEN));
+    assertEquals(newFont.toString(), messages.get(2).getDetail().get(ClientMessageDetailKeys.FONT));
+    assertEquals(
+        newFontStyle.toString(),
+        messages.get(3).getDetail().get(ClientMessageDetailKeys.FONT_STYLE));
+    assertEquals(
+        Double.toString(newRotation),
+        messages.get(4).getDetail().get(ClientMessageDetailKeys.ROTATION));
   }
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
@@ -3,4 +3,18 @@ package org.code.protocol;
 /** Expected keys in the optional detail object of {@link ClientMessage}s */
 public class ClientMessageDetailKeys {
   public static final String FILENAME = "filename";
+  public static final String HEIGHT = "height";
+  public static final String WIDTH = "width";
+  public static final String X = "x";
+  public static final String Y = "y";
+  public static final String ID = "id";
+
+  // Playground specific
+  public static final String TEXT = "text";
+  public static final String COLOR_RED = "colorRed";
+  public static final String COLOR_BLUE = "colorBlue";
+  public static final String COLOR_GREEN = "colorGreen";
+  public static final String FONT = "font";
+  public static final String FONT_STYLE = "fontStyle";
+  public static final String ROTATION = "rotation";
 }


### PR DESCRIPTION
Handle `Item` and all `Item` subclass updates by sending an output message whenever a setter is called. This will enable the frontend to receive update information and update the game appropriately. Also actually call `ClickableImage` click events when they occur.

I also refactored out the constants created in [this PR](https://github.com/code-dot-org/javabuilder/pull/115) into the new `ClientMessageDetailKeys` class.

## Links
- [jira](https://codedotorg.atlassian.net/browse/CSA-835)

## Testing Story
This isn't testable beyond some basic unit tests right now because we would need to test with 2-way communication to verify the click events are working. I added unit tests to verify the setters send the expected messages. It would be good to find a way to do this 2-way communication in our unit tests, but it is out of scope for now. 