### PR TITLE
Playground: Rename run() / exit() to start() / end()

### DIFF
--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
@@ -145,12 +145,12 @@ public class Board {
 
   /**
    * Starts the playground game, waiting for the user to click on images and executing the
-   * appropriate code. To end the game, call the exit() method. The run() method may only be called
+   * appropriate code. To end the game, call the end() method. The start() method may only be called
    * once per execution of a program.
    *
-   * @throws PlaygroundException if the run() method has already been called.
+   * @throws PlaygroundException if the start() method has already been called.
    */
-  public void run() throws PlaygroundException {
+  public void start() throws PlaygroundException {
     if (this.firstRunStarted) {
       throw new PlaygroundException(PlaygroundExceptionKeys.PLAYGROUND_RUNNING);
     }
@@ -175,17 +175,17 @@ public class Board {
    *
    * @param endingSound the name of a sound file in the asset manager to play at the end of the
    *     game.
-   * @throws PlaygroundException if the run() method has not been called.
+   * @throws PlaygroundException if the start() method has not been called.
    * @throws FileNotFoundException if the sound file cannot be found.
    */
-  public void exit(String endingSound) throws PlaygroundException, FileNotFoundException {}
+  public void end(String endingSound) throws PlaygroundException, FileNotFoundException {}
 
   /**
    * Ends the game and stops program execution.
    *
-   * @throws PlaygroundException if the run() method has not been called.
+   * @throws PlaygroundException if the start() method has not been called.
    */
-  public void exit() throws PlaygroundException {
+  public void end() throws PlaygroundException {
     if (!this.isRunning) {
       throw new PlaygroundException(PlaygroundExceptionKeys.PLAYGROUND_NOT_RUNNING);
     }

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
@@ -121,14 +121,14 @@ class BoardTest {
       throws PlaygroundException, FileNotFoundException {
     String filename = "test_file.wav";
 
-    // Ensure that exit() is called while running to avoid exception
+    // Ensure that end() is called while running to avoid exception
     when(inputHandler.getNextMessageForType(InputMessageType.PLAYGROUND))
         .thenAnswer(
             invocation -> {
-              unitUnderTest.exit(filename);
+              unitUnderTest.end(filename);
               return "id";
             });
-    unitUnderTest.run();
+    unitUnderTest.start();
 
     verify(playgroundMessageHandler, times(3)).sendMessage(messageCaptor.capture());
     assertEquals(

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
@@ -56,15 +56,15 @@ class BoardTest {
 
   @Test
   public void testRunSendsMessageAndWaitsForInput() throws PlaygroundException {
-    // Need to make sure exit() is called so run() terminates
+    // Need to make sure end() is called so start() terminates
     when(inputHandler.getNextMessageForType(InputMessageType.PLAYGROUND))
         .thenAnswer(
             invocation -> {
-              unitUnderTest.exit();
+              unitUnderTest.end();
               return "id";
             });
 
-    unitUnderTest.run();
+    unitUnderTest.start();
 
     verify(playgroundMessageHandler, times(2)).sendMessage(messageCaptor.capture());
     assertEquals(
@@ -74,30 +74,30 @@ class BoardTest {
 
   @Test
   public void testRunThrowsExceptionIfCalledTwice() throws PlaygroundException {
-    // Need to make sure exit() is called so run() terminates
+    // Need to make sure end() is called so start() terminates
     when(inputHandler.getNextMessageForType(InputMessageType.PLAYGROUND))
         .thenAnswer(
             invocation -> {
-              unitUnderTest.exit();
+              unitUnderTest.end();
               return "id";
             });
 
-    unitUnderTest.run();
+    unitUnderTest.start();
     final PlaygroundException e =
-        assertThrows(PlaygroundException.class, () -> unitUnderTest.run());
+        assertThrows(PlaygroundException.class, () -> unitUnderTest.start());
     assertEquals(PlaygroundExceptionKeys.PLAYGROUND_RUNNING.toString(), e.getMessage());
   }
 
   @Test
   public void testExitSendsExitMessage() throws PlaygroundException {
-    // Ensure that exit() is called while running to avoid exception
+    // Ensure that end() is called while running to avoid exception
     when(inputHandler.getNextMessageForType(InputMessageType.PLAYGROUND))
         .thenAnswer(
             invocation -> {
-              unitUnderTest.exit();
+              unitUnderTest.end();
               return "id";
             });
-    unitUnderTest.run();
+    unitUnderTest.start();
 
     verify(playgroundMessageHandler, times(2)).sendMessage(messageCaptor.capture());
     assertEquals(
@@ -107,7 +107,7 @@ class BoardTest {
   @Test
   public void testExitThrowsExceptionIfNotRunning() {
     final PlaygroundException e =
-        assertThrows(PlaygroundException.class, () -> unitUnderTest.exit());
+        assertThrows(PlaygroundException.class, () -> unitUnderTest.end());
     assertEquals(PlaygroundExceptionKeys.PLAYGROUND_NOT_RUNNING.toString(), e.getMessage());
   }
 


### PR DESCRIPTION
Renaming run/exit to start/end for clarity. See https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1632258762339500?thread_ts=1632253744.333100&cid=C01EF4GJ9GE for discussion.