### PR TITLE
Playground: Throw FileNotFoundExceptions

### DIFF
--- a/org-code-javabuilder/playground/build.gradle
+++ b/org-code-javabuilder/playground/build.gradle
@@ -17,7 +17,7 @@ java {
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     // https://mvnrepository.com/artifact/org.mockito/mockito-core
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.9.0'
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
     // https://mvnrepository.com/artifact/org.json/json
     implementation group: 'org.json', name: 'json', version: '20210307'

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
@@ -2,10 +2,7 @@ package org.code.playground;
 
 import java.io.FileNotFoundException;
 import java.util.HashMap;
-import org.code.protocol.ClientMessageDetailKeys;
-import org.code.protocol.GlobalProtocol;
-import org.code.protocol.InputHandler;
-import org.code.protocol.InputMessageType;
+import org.code.protocol.*;
 
 public class Board {
 
@@ -14,6 +11,7 @@ public class Board {
 
   private final PlaygroundMessageHandler playgroundMessageHandler;
   private final InputHandler inputHandler;
+  private final AssetFileHelper assetFileHelper;
 
   private boolean firstRunStarted;
   private boolean isRunning;
@@ -23,12 +21,19 @@ public class Board {
   private int nextItemIndex;
 
   protected Board() {
-    this(PlaygroundMessageHandler.getInstance(), GlobalProtocol.getInstance().getInputHandler());
+    this(
+        PlaygroundMessageHandler.getInstance(),
+        GlobalProtocol.getInstance().getInputHandler(),
+        GlobalProtocol.getInstance().getAssetFileHelper());
   }
 
-  Board(PlaygroundMessageHandler playgroundMessageHandler, InputHandler inputHandler) {
+  Board(
+      PlaygroundMessageHandler playgroundMessageHandler,
+      InputHandler inputHandler,
+      AssetFileHelper assetFileHelper) {
     this.playgroundMessageHandler = playgroundMessageHandler;
     this.inputHandler = inputHandler;
+    this.assetFileHelper = assetFileHelper;
     this.firstRunStarted = false;
     this.isRunning = false;
     this.items = new HashMap<>();
@@ -62,6 +67,8 @@ public class Board {
    * @throws FileNotFoundException if the file cannot be found in the asset manager
    */
   public void setBackgroundImage(String filename) throws FileNotFoundException {
+    this.assetFileHelper.verifyAssetFilename(filename);
+
     final HashMap<String, String> details = new HashMap<>();
     details.put(ClientMessageDetailKeys.FILENAME, filename);
 
@@ -142,6 +149,8 @@ public class Board {
    * @throws FileNotFoundException when the sound file cannot be found.
    */
   public void playSound(String filename) throws FileNotFoundException {
+    this.assetFileHelper.verifyAssetFilename(filename);
+
     HashMap<String, String> details = new HashMap<>();
     details.put(ClientMessageDetailKeys.FILENAME, filename);
 

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
@@ -2,8 +2,12 @@ package org.code.playground;
 
 import java.io.FileNotFoundException;
 import java.util.HashMap;
+import org.code.protocol.AssetFileHelper;
+import org.code.protocol.GlobalProtocol;
 
 public class ImageItem extends Item {
+  private final AssetFileHelper assetFileHelper;
+
   private int width;
   private String filename;
 
@@ -24,7 +28,17 @@ public class ImageItem extends Item {
    */
   public ImageItem(String filename, int x, int y, int width, int height)
       throws FileNotFoundException {
+    this(filename, x, y, width, height, GlobalProtocol.getInstance().getAssetFileHelper());
+  }
+
+  // Visible for testing only
+  ImageItem(String filename, int x, int y, int width, int height, AssetFileHelper assetFileHelper)
+      throws FileNotFoundException {
     super(x, y, height);
+
+    this.assetFileHelper = assetFileHelper;
+    this.assetFileHelper.verifyAssetFilename(filename);
+
     this.width = width;
     this.filename = filename;
   }
@@ -45,6 +59,7 @@ public class ImageItem extends Item {
    * @throws FileNotFoundException if the file specified is not the in the asset manager
    */
   public void setFilename(String filename) throws FileNotFoundException {
+    this.assetFileHelper.verifyAssetFilename(filename);
     this.filename = filename;
   }
 

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
@@ -3,8 +3,8 @@ package org.code.playground;
 import java.io.FileNotFoundException;
 import java.util.HashMap;
 import org.code.protocol.AssetFileHelper;
-import org.code.protocol.GlobalProtocol;
 import org.code.protocol.ClientMessageDetailKeys;
+import org.code.protocol.GlobalProtocol;
 
 public class ImageItem extends Item {
   private final AssetFileHelper assetFileHelper;

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
@@ -15,7 +15,7 @@ public class GlobalProtocol {
   private final JavabuilderFileWriter fileWriter;
   private final String dashboardHostname;
   private final String channelId;
-  private final AssetUrlGenerator assetUrlGenerator;
+  private final AssetFileHelper assetFileHelper;
 
   private GlobalProtocol(
       OutputAdapter outputAdapter,
@@ -23,13 +23,13 @@ public class GlobalProtocol {
       String dashboardHostname,
       String channelId,
       JavabuilderFileWriter fileWriter,
-      AssetUrlGenerator assetUrlGenerator) {
+      AssetFileHelper assetFileHelper) {
     this.outputAdapter = outputAdapter;
     this.inputHandler = inputHandler;
     this.dashboardHostname = dashboardHostname;
     this.channelId = channelId;
     this.fileWriter = fileWriter;
-    this.assetUrlGenerator = assetUrlGenerator;
+    this.assetFileHelper = assetFileHelper;
   }
 
   public static void create(
@@ -46,7 +46,7 @@ public class GlobalProtocol {
             dashboardHostname,
             channelId,
             fileWriter,
-            new AssetUrlGenerator(dashboardHostname, channelId, levelId));
+            new AssetFileHelper(dashboardHostname, channelId, levelId));
   }
 
   public static GlobalProtocol getInstance() {
@@ -70,7 +70,11 @@ public class GlobalProtocol {
   }
 
   public String generateAssetUrl(String filename) {
-    return this.assetUrlGenerator.generateAssetUrl(filename);
+    return this.assetFileHelper.generateAssetUrl(filename);
+  }
+
+  public AssetFileHelper getAssetFileHelper() {
+    return this.assetFileHelper;
   }
 
   public String generateSourcesUrl() {

--- a/org-code-javabuilder/protocol/src/test/java/org/code/protocol/AssetFileHelperTest.java
+++ b/org-code-javabuilder/protocol/src/test/java/org/code/protocol/AssetFileHelperTest.java
@@ -4,18 +4,20 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class AssetUrlGeneratorTest {
+class AssetFileHelperTest {
   private static final String STARTER_ASSET_FILE = "file1.png";
   private static final String STARTER_ASSET_DATA =
       new JSONObject(
@@ -27,13 +29,20 @@ class AssetUrlGeneratorTest {
                   "otherKey",
                   "otherValue"))
           .toString();
+  private static final String USER_ASSET_FILE = "userFile1.png";
+  private static final String USER_ASSET_DATA =
+      new JSONArray(
+              List.of(
+                  Map.of("filename", USER_ASSET_FILE, "otherKey", "otherValue"),
+                  Map.of("otherKey", "otherValue")))
+          .toString();
   private static final String DASHBOARD_URL = "https://localhost-studio.code.org";
   private static final String CHANNEL_ID = "channelId";
   private static final String LEVEL_ID = "levelId";
 
   private HttpClient httpClient;
   private HttpResponse<String> httpResponse;
-  private AssetUrlGenerator unitUnderTest;
+  private AssetFileHelper unitUnderTest;
 
   @BeforeEach
   public void setUp() throws InterruptedException, IOException {
@@ -43,9 +52,10 @@ class AssetUrlGeneratorTest {
     when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
         .thenReturn(httpResponse);
     when(httpResponse.statusCode()).thenReturn(200);
-    when(httpResponse.body()).thenReturn(STARTER_ASSET_DATA);
+    // Return starter assets for first request and user assets for second request
+    when(httpResponse.body()).thenReturn(STARTER_ASSET_DATA, USER_ASSET_DATA);
 
-    unitUnderTest = new AssetUrlGenerator(DASHBOARD_URL, CHANNEL_ID, LEVEL_ID, httpClient);
+    unitUnderTest = new AssetFileHelper(DASHBOARD_URL, CHANNEL_ID, LEVEL_ID, httpClient);
   }
 
   @Test
@@ -113,9 +123,50 @@ class AssetUrlGeneratorTest {
     verify(httpClient, never()).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
 
     unitUnderTest.generateAssetUrl("file1.wav");
-    verify(httpClient, times(1)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+    verify(httpClient, times(2)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
 
+    // Should not call httpClient.send() again
     unitUnderTest.generateAssetUrl("file2.wav");
-    verify(httpClient, times(1)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+    verify(httpClient, times(2)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+  }
+
+  @Test
+  public void testVerifyAssetFilenameLoadsFilenamesIfNotLoaded()
+      throws IOException, InterruptedException {
+    unitUnderTest.verifyAssetFilename(USER_ASSET_FILE);
+
+    verify(httpClient, times(2)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+  }
+
+  @Test
+  public void testVerifyAssetFilenameDoesNotLoadFilenamesIfAlreadyLoaded()
+      throws IOException, InterruptedException {
+    verify(httpClient, never()).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+
+    unitUnderTest.verifyAssetFilename(USER_ASSET_FILE);
+    verify(httpClient, times(2)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+
+    // Should not call httpClient.send() again
+    unitUnderTest.verifyAssetFilename(USER_ASSET_FILE);
+    verify(httpClient, times(2)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+  }
+
+  @Test
+  public void testVerifyAssetFilenameThrowsExceptionIfFileNotInProject() {
+    final String filename = "otherFile.jpg";
+    final FileNotFoundException e =
+        assertThrows(
+            FileNotFoundException.class, () -> unitUnderTest.verifyAssetFilename(filename));
+    assertTrue(e.getMessage().contains(filename));
+  }
+
+  @Test
+  public void testVerifyAssetFilenameDoesNotThrowIfFileIsStarterAsset() {
+    assertDoesNotThrow(() -> unitUnderTest.verifyAssetFilename(STARTER_ASSET_FILE));
+  }
+
+  @Test
+  public void testVerifyAssetFilenameDoesNotThrowIfFileIsUserAsset() {
+    assertDoesNotThrow(() -> unitUnderTest.verifyAssetFilename(USER_ASSET_FILE));
   }
 }

--- a/org-code-javabuilder/protocol/src/test/java/org/code/protocol/AssetFileHelperTest.java
+++ b/org-code-javabuilder/protocol/src/test/java/org/code/protocol/AssetFileHelperTest.java
@@ -169,4 +169,18 @@ class AssetFileHelperTest {
   public void testVerifyAssetFilenameDoesNotThrowIfFileIsUserAsset() {
     assertDoesNotThrow(() -> unitUnderTest.verifyAssetFilename(USER_ASSET_FILE));
   }
+
+  @Test
+  public void testVerifyAssetFilenameThrowsExceptionIfFileListsAreEmpty() {
+    final String emptyStarterAssets = new JSONObject().toString();
+    final String emptyUserAssets = new JSONArray().toString();
+
+    when(httpResponse.body()).thenReturn(emptyStarterAssets, emptyUserAssets);
+
+    // Should not throw any JSON exceptions
+    final FileNotFoundException e =
+        assertThrows(
+            FileNotFoundException.class, () -> unitUnderTest.verifyAssetFilename(USER_ASSET_FILE));
+    assertTrue(e.getMessage().contains(USER_ASSET_FILE));
+  }
 }


### PR DESCRIPTION
Adds functionality to load all the file names in a student's project and check if a given file is part of the project, so we can verify and throw FileNotFoundExceptions in Javabuilder. Some of this work was already being done by AssetUrlGenerator, so I've added this functionality to that class, which I also renamed AssetFileHelper to avoid confusion.

Note: this has some overlap (specifically in the tests) with https://github.com/code-dot-org/javabuilder/pull/120 - I'll update this PR once that is merged.

Also note: on the client, FileNotFoundExceptions currently show up as UserInitiatedExceptions which are translated as generic runtime exceptions. We have an existing tech debt task to handle and translate FileNotFoundExceptions on the client which will make this more user-friendly (https://codedotorg.atlassian.net/browse/CSA-553)

JIRA: https://codedotorg.atlassian.net/browse/CSA-840
Spec: https://docs.google.com/document/d/1Moo2s5EXZRp5rMg1VW9jlOqs_GeMN5yjU8FJgoqOEMk/edit#bookmark=id.dl49xj5tnbcf

Testing: local all the things playground & unit