### PR TITLE
Allow FileNotFoundExceptions to be translatable

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavaRunner.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavaRunner.java
@@ -1,5 +1,6 @@
 package org.code.javabuilder;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -56,6 +57,11 @@ public class JavaRunner {
       }
       if (e.getCause() instanceof JavabuilderRuntimeException) {
         throw (JavabuilderRuntimeException) e.getCause();
+      }
+      // FileNotFoundExceptions may be thrown from student code, so we treat them as a
+      // specific case of a UserInitiatedException
+      if (e.getCause() instanceof FileNotFoundException) {
+        throw new UserInitiatedException(UserInitiatedExceptionKey.FILE_NOT_FOUND, e.getCause());
       }
       throw new UserInitiatedException(UserInitiatedExceptionKey.RUNTIME_ERROR, e);
     }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserInitiatedExceptionKey.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserInitiatedExceptionKey.java
@@ -17,5 +17,7 @@ public enum UserInitiatedExceptionKey {
   // The user is writing to file too many times
   TOO_MANY_WRITES,
   // The user tried to run a file without a class definition
-  CLASS_NOT_FOUND
+  CLASS_NOT_FOUND,
+  // The user's code threw a FileNotFoundException
+  FILE_NOT_FOUND
 }

--- a/org-code-javabuilder/media/src/main/java/org/code/media/AudioUtils.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/AudioUtils.java
@@ -179,7 +179,7 @@ class AudioUtils {
               AudioSystem.getAudioInputStream(audioFileUrl));
       return AudioUtils.readSamplesFromInputStream(audioInputStream);
     } catch (IOException e) {
-      throw new FileNotFoundException("Could not find file: " + filename);
+      throw new FileNotFoundException(filename);
     } catch (UnsupportedAudioFileException e) {
       throw new SoundException(SoundExceptionKeys.INVALID_AUDIO_FILE_FORMAT);
     }
@@ -199,7 +199,7 @@ class AudioUtils {
           AudioUtils.convertStreamToDefaultAudioFormat(
               AudioSystem.getAudioInputStream(new File(filepath))));
     } catch (IOException e) {
-      throw new FileNotFoundException("Could not find file: " + filepath);
+      throw new FileNotFoundException(filepath);
     } catch (UnsupportedAudioFileException e) {
       throw new SoundException(SoundExceptionKeys.INVALID_AUDIO_FILE_FORMAT);
     }

--- a/org-code-javabuilder/media/src/main/java/org/code/media/Image.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/Image.java
@@ -165,7 +165,7 @@ public class Image {
       }
       return image;
     } catch (IOException e) {
-      throw new FileNotFoundException("Could not find file " + filename);
+      throw new FileNotFoundException(filename);
     }
   }
 

--- a/org-code-javabuilder/media/src/test/java/org/code/media/AudioUtilsTest.java
+++ b/org-code-javabuilder/media/src/test/java/org/code/media/AudioUtilsTest.java
@@ -71,7 +71,7 @@ class AudioUtilsTest {
             () -> {
               AudioUtils.readSamplesFromAssetFile(TEST_FILE_NAME);
             });
-    assertTrue(exception.getMessage().contains("Could not find file: " + TEST_FILE_NAME));
+    assertTrue(exception.getMessage().contains(TEST_FILE_NAME));
   }
 
   @Test

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/AssetFileHelper.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/AssetFileHelper.java
@@ -47,7 +47,7 @@ public class AssetFileHelper {
 
     if (!this.starterAssetFilenames.contains(filename)
         && !this.userAssetFilenames.contains(filename)) {
-      throw new FileNotFoundException("Could not find file: " + filename);
+      throw new FileNotFoundException(filename);
     }
   }
 

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
@@ -17,4 +17,9 @@ public class ClientMessageDetailKeys {
   public static final String FONT = "font";
   public static final String FONT_STYLE = "fontStyle";
   public static final String ROTATION = "rotation";
+
+  // Exception specific
+  public static final String CONNECTION_ID = "connectionId";
+  public static final String CAUSE = "cause";
+  public static final String CAUSE_MESSAGE = "causeMessage";
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderException.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderException.java
@@ -21,9 +21,12 @@ public abstract class JavabuilderException extends Exception
 
   public JavabuilderThrowableMessage getExceptionMessage() {
     HashMap<String, String> detail = new HashMap<>();
-    detail.put("connectionId", Properties.getConnectionId());
+    detail.put(ClientMessageDetailKeys.CONNECTION_ID, Properties.getConnectionId());
     if (this.getCause() != null) {
-      detail.put("cause", this.getLoggingString());
+      detail.put(ClientMessageDetailKeys.CAUSE, this.getLoggingString());
+      if (this.getCause().getMessage() != null) {
+        detail.put(ClientMessageDetailKeys.CAUSE_MESSAGE, this.getCause().getMessage());
+      }
     }
 
     return new JavabuilderThrowableMessage(this.key, detail);

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderRuntimeException.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderRuntimeException.java
@@ -21,9 +21,12 @@ public abstract class JavabuilderRuntimeException extends RuntimeException
 
   public JavabuilderThrowableMessage getExceptionMessage() {
     HashMap<String, String> detail = new HashMap<>();
-    detail.put("connectionId", Properties.getConnectionId());
+    detail.put(ClientMessageDetailKeys.CONNECTION_ID, Properties.getConnectionId());
     if (this.getCause() != null) {
-      detail.put("cause", this.getLoggingString());
+      detail.put(ClientMessageDetailKeys.CAUSE, this.getLoggingString());
+      if (this.getCause().getMessage() != null) {
+        detail.put(ClientMessageDetailKeys.CAUSE_MESSAGE, this.getCause().getMessage());
+      }
     }
 
     return new JavabuilderThrowableMessage(this.key, detail);


### PR DESCRIPTION
Wraps FileNotFoundExceptions in UserInitiatedExceptions with a specific FILE_NOT_FOUND key so it can be translated on the client. Also adds the underlying exception's message to JavabuilderException messages that are sent to Javalab so Javalab can display the filename that caused the exception.

Javalab PR: https://github.com/code-dot-org/code-dot-org/pull/42650

JIRA: https://codedotorg.atlassian.net/browse/CSA-553

Tested locally.