### PR TITLE
Javabuilder should throw a translatable UserInitiatedException if a file name is invalid

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilder.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilder.java
@@ -84,7 +84,7 @@ public class CodeBuilder implements AutoCloseable {
   }
 
   /** Save any non-source code files to storage */
-  private void saveProjectAssets() throws InternalServerError {
+  private void saveProjectAssets() throws InternalServerError, UserInitiatedException {
     // Save all text files to current folder.
     List<TextProjectFile> textProjectFiles = this.userProjectFiles.getTextFiles();
     for (TextProjectFile projectFile : textProjectFiles) {
@@ -92,6 +92,10 @@ public class CodeBuilder implements AutoCloseable {
       try {
         Files.writeString(Path.of(filePath), projectFile.getFileContents());
       } catch (IOException e) {
+        if (filePath.isBlank()) {
+          // If the file name is empty, indicate to the user that the file name is invalid
+          throw new UserInitiatedException(UserInitiatedExceptionKey.MISSING_PROJECT_FILE_NAME, e);
+        }
         throw new InternalServerError(InternalErrorKey.INTERNAL_COMPILER_EXCEPTION, e);
       }
     }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserInitiatedExceptionKey.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserInitiatedExceptionKey.java
@@ -19,5 +19,9 @@ public enum UserInitiatedExceptionKey {
   // The user tried to run a file without a class definition
   CLASS_NOT_FOUND,
   // The user's code threw a FileNotFoundException
-  FILE_NOT_FOUND
+  FILE_NOT_FOUND,
+  // The user's project has a Java file with an invalid file name
+  INVALID_JAVA_FILE_NAME,
+  // The user's project has a non-Java project file with a blank file name
+  MISSING_PROJECT_FILE_NAME
 }

--- a/org-code-javabuilder/media/src/test/java/org/code/media/ImageTest.java
+++ b/org-code-javabuilder/media/src/test/java/org/code/media/ImageTest.java
@@ -130,6 +130,6 @@ public class ImageTest {
             () -> {
               Image.getImageAssetFromFile(imageFileName);
             });
-    assertEquals(exception.getMessage(), ("Could not find file " + imageFileName));
+    assertEquals(exception.getMessage(), (imageFileName));
   }
 }


### PR DESCRIPTION
Makes Javabuilder throw a UserInitiatedException if either a Java file or non-Java project file is invalid. Java files cannot contain spaces or special characters, while non-Java files cannot be blank.

Note: we do have validation in Javalab to prevent files from being created with empty file names in the name file dialog, so the non-Java file check here is just a server-side fallback check.

Also includes a small unrelated fix to a failing unit test.

JIRA: https://codedotorg.atlassian.net/browse/CSA-806
Related Javalab PR: https://github.com/code-dot-org/code-dot-org/pull/42674

Tested locally.