### PR TITLE
Playground: fix text color behavior

### DIFF
--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
@@ -11,9 +11,7 @@ public class TextItem extends Item {
   private Font font;
   private FontStyle fontStyle;
   private double rotation;
-  private int colorRed;
-  private int colorGreen;
-  private int colorBlue;
+  private Color color;
 
   /**
    * Creates text item that can be placed the board.
@@ -38,7 +36,8 @@ public class TextItem extends Item {
       double rotation) {
     super(x, y, height);
     this.text = text;
-    this.setColorHelper(color);
+    // Copy to new color to store the values only, and not a reference to the original color object
+    this.color = new Color(color);
     this.font = font;
     this.fontStyle = fontStyle;
     this.rotation = rotation;
@@ -84,7 +83,8 @@ public class TextItem extends Item {
    * @param color the text color
    */
   public void setColor(Color color) {
-    this.setColorHelper(color);
+    // Copy to new color to store the values only, and not a reference to the original color object
+    this.color = new Color(color);
     HashMap<String, String> colorDetails = new HashMap<>();
     this.addColorToDetails(colorDetails);
     this.sendChangeMessage(colorDetails);
@@ -97,8 +97,9 @@ public class TextItem extends Item {
    * @param colorRed the amount of red (ranging from 0 to 255) in the color of the text.
    */
   public void setRed(int colorRed) {
-    this.colorRed = Math.max(Math.min(colorRed, 255), 0);
-    this.sendChangeMessage(ClientMessageDetailKeys.COLOR_RED, Integer.toString(this.colorRed));
+    this.color = new Color(colorRed, this.color.getGreen(), this.color.getBlue());
+    this.sendChangeMessage(
+        ClientMessageDetailKeys.COLOR_RED, Integer.toString(this.color.getRed()));
   }
 
   /**
@@ -108,8 +109,9 @@ public class TextItem extends Item {
    * @param colorGreen the amount of green (ranging from 0 to 255) in the color of the text.
    */
   public void setGreen(int colorGreen) {
-    this.colorGreen = Math.max(Math.min(colorGreen, 255), 0);
-    this.sendChangeMessage(ClientMessageDetailKeys.COLOR_GREEN, Integer.toString(this.colorGreen));
+    this.color = new Color(this.color.getRed(), colorGreen, this.color.getBlue());
+    this.sendChangeMessage(
+        ClientMessageDetailKeys.COLOR_GREEN, Integer.toString(this.color.getGreen()));
   }
 
   /**
@@ -119,8 +121,9 @@ public class TextItem extends Item {
    * @param colorBlue the amount of blue (ranging from 0 to 255) in the color of the text.
    */
   public void setBlue(int colorBlue) {
-    this.colorBlue = Math.max(Math.min(colorBlue, 255), 0);
-    this.sendChangeMessage(ClientMessageDetailKeys.COLOR_BLUE, Integer.toString(this.colorBlue));
+    this.color = new Color(this.color.getRed(), this.color.getGreen(), colorBlue);
+    this.sendChangeMessage(
+        ClientMessageDetailKeys.COLOR_BLUE, Integer.toString(this.color.getBlue()));
   }
 
   /**
@@ -129,7 +132,9 @@ public class TextItem extends Item {
    * @return the text color for the item
    */
   public Color getColor() {
-    return new Color(this.colorRed, this.colorGreen, this.colorBlue);
+    // TODO: wrapping this.color in a new Color object will not be necessary once Color is
+    // immutable.
+    return new Color(this.color);
   }
 
   /**
@@ -200,16 +205,9 @@ public class TextItem extends Item {
     return details;
   }
 
-  private void setColorHelper(Color color) {
-    // we lock the color rgb values to what is currently set in color
-    this.colorRed = color.getRed();
-    this.colorBlue = color.getBlue();
-    this.colorGreen = color.getGreen();
-  }
-
   private void addColorToDetails(HashMap<String, String> details) {
-    details.put(ClientMessageDetailKeys.COLOR_RED, Integer.toString(this.colorRed));
-    details.put(ClientMessageDetailKeys.COLOR_GREEN, Integer.toString(this.colorGreen));
-    details.put(ClientMessageDetailKeys.COLOR_BLUE, Integer.toString(this.colorBlue));
+    details.put(ClientMessageDetailKeys.COLOR_RED, Integer.toString(this.color.getRed()));
+    details.put(ClientMessageDetailKeys.COLOR_GREEN, Integer.toString(this.color.getGreen()));
+    details.put(ClientMessageDetailKeys.COLOR_BLUE, Integer.toString(this.color.getBlue()));
   }
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
@@ -8,7 +8,6 @@ import org.code.protocol.ClientMessageDetailKeys;
 
 public class TextItem extends Item {
   private String text;
-  private Color color;
   private Font font;
   private FontStyle fontStyle;
   private double rotation;
@@ -92,12 +91,45 @@ public class TextItem extends Item {
   }
 
   /**
+   * Set the amount of red (ranging from 0 to 255). Values below 0 will be ignored and set to 0, and
+   * values above 255 will be ignored and set to 255.
+   *
+   * @param colorRed the amount of red (ranging from 0 to 255) in the color of the text.
+   */
+  public void setRed(int colorRed) {
+    this.colorRed = Math.max(Math.min(colorRed, 255), 0);
+    this.sendChangeMessage(ClientMessageDetailKeys.COLOR_RED, Integer.toString(this.colorRed));
+  }
+
+  /**
+   * Set the amount of green (ranging from 0 to 255). Values below 0 will be ignored and set to 0,
+   * and values above 255 will be ignored and set to 255.
+   *
+   * @param colorGreen the amount of green (ranging from 0 to 255) in the color of the text.
+   */
+  public void setGreen(int colorGreen) {
+    this.colorGreen = Math.max(Math.min(colorGreen, 255), 0);
+    this.sendChangeMessage(ClientMessageDetailKeys.COLOR_GREEN, Integer.toString(this.colorGreen));
+  }
+
+  /**
+   * Set the amount of blue (ranging from 0 to 255). Values below 0 will be ignored and set to 0,
+   * and values above 255 will be ignored and set to 255.
+   *
+   * @param colorBlue the amount of blue (ranging from 0 to 255) in the color of the text.
+   */
+  public void setBlue(int colorBlue) {
+    this.colorBlue = Math.max(Math.min(colorBlue, 255), 0);
+    this.sendChangeMessage(ClientMessageDetailKeys.COLOR_BLUE, Integer.toString(this.colorBlue));
+  }
+
+  /**
    * Get the text color for the item.
    *
    * @return the text color for the item
    */
   public Color getColor() {
-    return this.color;
+    return new Color(this.colorRed, this.colorGreen, this.colorBlue);
   }
 
   /**
@@ -169,7 +201,6 @@ public class TextItem extends Item {
   }
 
   private void setColorHelper(Color color) {
-    this.color = color;
     // we lock the color rgb values to what is currently set in color
     this.colorRed = color.getRed();
     this.colorBlue = color.getBlue();

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
@@ -48,28 +48,52 @@ public class TextItemTest {
     TextItem textItem = new TextItem("text", 0, 0, Color.BLUE, Font.SANS, FontStyle.BOLD, 10, 0);
 
     String newText = "new text";
-    Color newColor = Color.GREEN;
     Font newFont = Font.SERIF;
     FontStyle newFontStyle = FontStyle.ITALIC;
     double newRotation = 15;
+
+    textItem.setText(newText);
+    textItem.setFont(newFont);
+    textItem.setFontStyle(newFontStyle);
+    textItem.setRotation(newRotation);
+
+    verify(playgroundMessageHandler, times(4)).sendMessage(messageCaptor.capture());
+    List<PlaygroundMessage> messages = messageCaptor.getAllValues();
+    assertEquals(PlaygroundSignalKey.CHANGE_ITEM.toString(), messages.get(0).getValue());
+    assertEquals(newText, messages.get(0).getDetail().get(ClientMessageDetailKeys.TEXT));
+    assertEquals(newFont.toString(), messages.get(1).getDetail().get(ClientMessageDetailKeys.FONT));
+    assertEquals(
+        newFontStyle.toString(),
+        messages.get(2).getDetail().get(ClientMessageDetailKeys.FONT_STYLE));
+    assertEquals(
+        Double.toString(newRotation),
+        messages.get(3).getDetail().get(ClientMessageDetailKeys.ROTATION));
+  }
+
+  @Test
+  public void testColorSettersSendMessages() {
+    TextItem textItem = new TextItem("text", 0, 0, Color.BLUE, Font.SANS, FontStyle.BOLD, 10, 0);
+
+    Color newColor = Color.GREEN;
+
     int colorRed = 50;
     int colorGreen = 100;
     int colorBlue = 150;
 
-    textItem.setText(newText);
+    int outOfBoundsColorRed = 300;
+    int outOfBoundsColorBlue = -100;
+
     textItem.setColor(newColor);
-    textItem.setFont(newFont);
-    textItem.setFontStyle(newFontStyle);
-    textItem.setRotation(newRotation);
     textItem.setRed(colorRed);
     textItem.setGreen(colorGreen);
     textItem.setBlue(colorBlue);
+    textItem.setRed(outOfBoundsColorRed);
+    textItem.setBlue(outOfBoundsColorBlue);
 
-    verify(playgroundMessageHandler, times(8)).sendMessage(messageCaptor.capture());
+    verify(playgroundMessageHandler, times(6)).sendMessage(messageCaptor.capture());
     List<PlaygroundMessage> messages = messageCaptor.getAllValues();
-    assertEquals(PlaygroundSignalKey.CHANGE_ITEM.toString(), messages.get(0).getValue());
-    assertEquals(newText, messages.get(0).getDetail().get(ClientMessageDetailKeys.TEXT));
-    JSONObject colorDetails = messages.get(1).getDetail();
+
+    JSONObject colorDetails = messages.get(0).getDetail();
     assertEquals(
         Integer.toString(newColor.getRed()), colorDetails.get(ClientMessageDetailKeys.COLOR_RED));
     assertEquals(
@@ -77,22 +101,21 @@ public class TextItemTest {
     assertEquals(
         Integer.toString(newColor.getGreen()),
         colorDetails.get(ClientMessageDetailKeys.COLOR_GREEN));
-    assertEquals(newFont.toString(), messages.get(2).getDetail().get(ClientMessageDetailKeys.FONT));
-    assertEquals(
-        newFontStyle.toString(),
-        messages.get(3).getDetail().get(ClientMessageDetailKeys.FONT_STYLE));
-    assertEquals(
-        Double.toString(newRotation),
-        messages.get(4).getDetail().get(ClientMessageDetailKeys.ROTATION));
+
     assertEquals(
         Integer.toString(colorRed),
-        messages.get(5).getDetail().get(ClientMessageDetailKeys.COLOR_RED));
+        messages.get(1).getDetail().get(ClientMessageDetailKeys.COLOR_RED));
     assertEquals(
         Integer.toString(colorGreen),
-        messages.get(6).getDetail().get(ClientMessageDetailKeys.COLOR_GREEN));
+        messages.get(2).getDetail().get(ClientMessageDetailKeys.COLOR_GREEN));
     assertEquals(
         Integer.toString(colorBlue),
-        messages.get(7).getDetail().get(ClientMessageDetailKeys.COLOR_BLUE));
+        messages.get(3).getDetail().get(ClientMessageDetailKeys.COLOR_BLUE));
+
+    assertEquals(
+        Integer.toString(255), messages.get(4).getDetail().get(ClientMessageDetailKeys.COLOR_RED));
+    assertEquals(
+        Integer.toString(0), messages.get(5).getDetail().get(ClientMessageDetailKeys.COLOR_BLUE));
   }
 
   @Test

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
@@ -1,6 +1,7 @@
 package org.code.playground;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.mockito.Mockito.*;
 
 import java.util.List;
@@ -51,14 +52,20 @@ public class TextItemTest {
     Font newFont = Font.SERIF;
     FontStyle newFontStyle = FontStyle.ITALIC;
     double newRotation = 15;
+    int colorRed = 50;
+    int colorGreen = 100;
+    int colorBlue = 150;
 
     textItem.setText(newText);
     textItem.setColor(newColor);
     textItem.setFont(newFont);
     textItem.setFontStyle(newFontStyle);
     textItem.setRotation(newRotation);
+    textItem.setRed(colorRed);
+    textItem.setGreen(colorGreen);
+    textItem.setBlue(colorBlue);
 
-    verify(playgroundMessageHandler, times(5)).sendMessage(messageCaptor.capture());
+    verify(playgroundMessageHandler, times(8)).sendMessage(messageCaptor.capture());
     List<PlaygroundMessage> messages = messageCaptor.getAllValues();
     assertEquals(PlaygroundSignalKey.CHANGE_ITEM.toString(), messages.get(0).getValue());
     assertEquals(newText, messages.get(0).getDetail().get(ClientMessageDetailKeys.TEXT));
@@ -77,5 +84,35 @@ public class TextItemTest {
     assertEquals(
         Double.toString(newRotation),
         messages.get(4).getDetail().get(ClientMessageDetailKeys.ROTATION));
+    assertEquals(
+        Integer.toString(colorRed),
+        messages.get(5).getDetail().get(ClientMessageDetailKeys.COLOR_RED));
+    assertEquals(
+        Integer.toString(colorGreen),
+        messages.get(6).getDetail().get(ClientMessageDetailKeys.COLOR_GREEN));
+    assertEquals(
+        Integer.toString(colorBlue),
+        messages.get(7).getDetail().get(ClientMessageDetailKeys.COLOR_BLUE));
+  }
+
+  @Test
+  public void testGetColorReturnsCopyOfColor() {
+    final Color color = Color.AQUA;
+    final TextItem textItem = new TextItem("text", 0, 0, color, Font.SANS, 0, 0);
+
+    // Should be a different instance but have the same values
+    assertNotSame(color, textItem.getColor());
+    assertEquals(color.getRed(), textItem.getColor().getRed());
+    assertEquals(color.getGreen(), textItem.getColor().getGreen());
+    assertEquals(color.getBlue(), textItem.getColor().getBlue());
+
+    final Color newColor = Color.BEIGE;
+    textItem.setColor(newColor);
+
+    // Should be a different instance but have the same values
+    assertNotSame(newColor, textItem.getColor());
+    assertEquals(newColor.getRed(), textItem.getColor().getRed());
+    assertEquals(newColor.getGreen(), textItem.getColor().getGreen());
+    assertEquals(newColor.getBlue(), textItem.getColor().getBlue());
   }
 }


### PR DESCRIPTION
~~Updates TextItem to not store color directly and only maintain individual the RGB values (along with the respective setters).~~ Edit: after looking at this a little more, I changed this so TextItem stores a color object, but it is always copied into a new object when color is supplied via the constructor or setColor. This is done so that Color can still own how it deals with the individual RGB values internally (for example, the logic for sanitizing values to be [0, 255]). The setters also create a new color object based off of the supplied value and the other two existing values.

This comes from discussion around how color should behave across Playground and Theater - we eventually want color to be immutable, so we should only be able to update TextItem color via `setColor` or `setRed/Green/Blue`. `getColor` now returns a new color object constructed from the stored RGB values.

Slack thread for context: https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1632255167336300

JIRA: https://codedotorg.atlassian.net/browse/CSA-856

Tested locally by verifying websocket messages & unit