### PR TITLE
Playground: throw runtime exception if a message is attempted after end()

### DIFF
--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
@@ -15,6 +15,7 @@ public class Board {
 
   private boolean firstRunStarted;
   private boolean isRunning;
+  private boolean hasEnded;
 
   private final HashMap<String, ClickableImage> clickableImages;
   private final HashMap<String, Item> items;
@@ -39,6 +40,7 @@ public class Board {
     this.items = new HashMap<>();
     this.clickableImages = new HashMap<>();
     this.nextItemIndex = 0;
+    this.hasEnded = false;
   }
 
   /**
@@ -210,6 +212,10 @@ public class Board {
     this.sendExitMessageAndEndRun();
   }
 
+  protected boolean hasEnded() {
+    return this.hasEnded;
+  }
+
   private void handleClickEvent(String id) {
     if (!this.clickableImages.containsKey(id)) {
       return;
@@ -237,6 +243,7 @@ public class Board {
     this.playgroundMessageHandler.sendMessage(
         new PlaygroundMessage(PlaygroundSignalKey.EXIT, new HashMap<>()));
     this.isRunning = false;
+    this.hasEnded = true;
   }
 
   private void confirmIsRunning() throws PlaygroundException {

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundExceptionKeys.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundExceptionKeys.java
@@ -2,5 +2,6 @@ package org.code.playground;
 
 public enum PlaygroundExceptionKeys {
   PLAYGROUND_RUNNING,
-  PLAYGROUND_NOT_RUNNING
+  PLAYGROUND_NOT_RUNNING,
+  INVALID_MESSAGE_PLAYGROUND_ENDED
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundMessageHandler.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundMessageHandler.java
@@ -25,8 +25,11 @@ class PlaygroundMessageHandler {
   }
 
   public void sendMessage(PlaygroundMessage message) {
-    // only send messages if playground has not ended.
-    if (!Playground.board.hasEnded()) {
+    // only send messages if playground has not ended. Otherwise throw a runtime exception.
+    if (Playground.board.hasEnded()) {
+      throw new PlaygroundRuntimeException(
+          PlaygroundExceptionKeys.INVALID_MESSAGE_PLAYGROUND_ENDED);
+    } else {
       this.outputAdapter.sendMessage(message);
     }
   }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundMessageHandler.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundMessageHandler.java
@@ -25,6 +25,9 @@ class PlaygroundMessageHandler {
   }
 
   public void sendMessage(PlaygroundMessage message) {
-    this.outputAdapter.sendMessage(message);
+    // only send messages if playground has not ended.
+    if (!Playground.board.hasEnded()) {
+      this.outputAdapter.sendMessage(message);
+    }
   }
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundRuntimeException.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundRuntimeException.java
@@ -1,0 +1,13 @@
+package org.code.playground;
+
+import org.code.protocol.JavabuilderRuntimeException;
+
+public class PlaygroundRuntimeException extends JavabuilderRuntimeException {
+  protected PlaygroundRuntimeException(PlaygroundExceptionKeys key) {
+    super(key);
+  }
+
+  protected PlaygroundRuntimeException(PlaygroundExceptionKeys key, Throwable cause) {
+    super(key, cause);
+  }
+}


### PR DESCRIPTION
We don't want to allow any messages to be sent from the playground after `board.end()` has been called. We previously handled this by ignoring these messages on the frontend. Instead, we want to throw a runtime exception on the backend if a message is attempted to be sent after the board has ended.