### PR TITLE
Playground: fast-click prevention

### DIFF
--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
@@ -173,8 +173,7 @@ public class Board {
       throw new PlaygroundException(PlaygroundExceptionKeys.PLAYGROUND_RUNNING);
     }
 
-    this.playgroundMessageHandler.sendMessage(
-        new PlaygroundMessage(PlaygroundSignalKey.RUN, new HashMap<>()));
+    this.playgroundMessageHandler.sendMessage(new PlaygroundMessage(PlaygroundSignalKey.RUN));
 
     this.firstRunStarted = true;
     this.isRunning = true;
@@ -184,6 +183,11 @@ public class Board {
       final String message = this.inputHandler.getNextMessageForType(InputMessageType.PLAYGROUND);
       if (message != null) {
         this.handleClickEvent(message);
+      }
+      if (this.isRunning) {
+        // Only need to send update complete if the game is still running
+        this.playgroundMessageHandler.sendMessage(
+            new PlaygroundMessage(PlaygroundSignalKey.UPDATE_COMPLETE));
       }
     }
   }
@@ -240,8 +244,7 @@ public class Board {
   }
 
   private void sendExitMessageAndEndRun() {
-    this.playgroundMessageHandler.sendMessage(
-        new PlaygroundMessage(PlaygroundSignalKey.EXIT, new HashMap<>()));
+    this.playgroundMessageHandler.sendMessage(new PlaygroundMessage(PlaygroundSignalKey.EXIT));
     this.isRunning = false;
     this.hasEnded = true;
   }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundMessage.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundMessage.java
@@ -8,4 +8,8 @@ public class PlaygroundMessage extends ClientMessage {
   PlaygroundMessage(PlaygroundSignalKey key, HashMap<String, String> detail) {
     super(ClientMessageType.PLAYGROUND, key.toString(), detail);
   }
+
+  PlaygroundMessage(PlaygroundSignalKey key) {
+    super(ClientMessageType.PLAYGROUND, key.toString());
+  }
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundSignalKey.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundSignalKey.java
@@ -18,5 +18,7 @@ public enum PlaygroundSignalKey {
   // Play a sound
   PLAY_SOUND,
   // Set the background image of the Playground
-  SET_BACKGROUND_IMAGE
+  SET_BACKGROUND_IMAGE,
+  // Indicate that the current update cycle has completed
+  UPDATE_COMPLETE
 }

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
@@ -105,7 +105,7 @@ class BoardTest {
   }
 
   @Test
-  public void testRunSendsMessageAndWaitsForInput() throws PlaygroundException {
+  public void testStartSendsMessageAndWaitsForInput() throws PlaygroundException {
     // Need to make sure end() is called so start() terminates
     when(inputHandler.getNextMessageForType(InputMessageType.PLAYGROUND))
         .thenAnswer(
@@ -123,7 +123,7 @@ class BoardTest {
   }
 
   @Test
-  public void testRunThrowsExceptionIfCalledTwice() throws PlaygroundException {
+  public void testStartThrowsExceptionIfCalledTwice() throws PlaygroundException {
     // Need to make sure end() is called so start() terminates
     when(inputHandler.getNextMessageForType(InputMessageType.PLAYGROUND))
         .thenAnswer(
@@ -139,7 +139,32 @@ class BoardTest {
   }
 
   @Test
-  public void testExitSendsExitMessage() throws PlaygroundException {
+  public void testStartSendsUpdateCompleteIfGameNotEnded() throws PlaygroundException {
+    // Simulate three messages with end only being called on the last
+    when(inputHandler.getNextMessageForType(InputMessageType.PLAYGROUND))
+        .thenReturn("id")
+        .thenReturn("id")
+        .thenAnswer(
+            invocation -> {
+              unitUnderTest.end();
+              return "id";
+            });
+
+    unitUnderTest.start();
+
+    verify(playgroundMessageHandler, times(4)).sendMessage(messageCaptor.capture());
+
+    // UPDATE_COMPLETE should only be sent after the first two messages, not the last
+    assertEquals(
+        PlaygroundSignalKey.UPDATE_COMPLETE.toString(),
+        messageCaptor.getAllValues().get(1).getValue());
+    assertEquals(
+        PlaygroundSignalKey.UPDATE_COMPLETE.toString(),
+        messageCaptor.getAllValues().get(2).getValue());
+  }
+
+  @Test
+  public void testEndSendsExitMessage() throws PlaygroundException {
     // Ensure that end() is called while running to avoid exception
     when(inputHandler.getNextMessageForType(InputMessageType.PLAYGROUND))
         .thenAnswer(
@@ -155,7 +180,7 @@ class BoardTest {
   }
 
   @Test
-  public void testExitWithSoundSendsPlaySoundAndExitMessages()
+  public void testEndWithSoundSendsPlaySoundAndExitMessages()
       throws PlaygroundException, FileNotFoundException {
     String filename = "test_file.wav";
 
@@ -179,7 +204,7 @@ class BoardTest {
   }
 
   @Test
-  public void testExitWithSoundThrowsExceptionIfFileNotFound()
+  public void testEndWithSoundThrowsExceptionIfFileNotFound()
       throws PlaygroundException, FileNotFoundException {
     final FileNotFoundException expected = new FileNotFoundException();
     doThrow(expected).when(assetFileHelper).verifyAssetFilename(anyString());
@@ -201,7 +226,7 @@ class BoardTest {
   }
 
   @Test
-  public void testExitThrowsExceptionIfNotRunning() {
+  public void testEndThrowsExceptionIfNotRunning() {
     final PlaygroundException e =
         assertThrows(PlaygroundException.class, () -> unitUnderTest.end());
     assertEquals(PlaygroundExceptionKeys.PLAYGROUND_NOT_RUNNING.toString(), e.getMessage());

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/PlaygroundMessageHandlerTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/PlaygroundMessageHandlerTest.java
@@ -3,7 +3,6 @@ package org.code.playground;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import java.util.HashMap;
 import org.code.protocol.OutputAdapter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,8 +20,7 @@ class PlaygroundMessageHandlerTest {
 
   @Test
   public void testSendMessageCallsOutputAdapter() {
-    final PlaygroundMessage message =
-        new PlaygroundMessage(PlaygroundSignalKey.RUN, new HashMap<>());
+    final PlaygroundMessage message = new PlaygroundMessage(PlaygroundSignalKey.RUN);
 
     unitUnderTest.sendMessage(message);
 


### PR DESCRIPTION
Javabuilder-side support for adding fast-click prevention. Javabuilder sends an UPDATE_COMPLETE message after processing the current set of updates so that Javalab can listen and accordingly re-enable click events. Also includes some minor cleanups to related classes/tests.

Related Javalab PR for adding fast-click prevention: https://github.com/code-dot-org/code-dot-org/pull/42816
JIRA: https://codedotorg.atlassian.net/browse/CSA-841

Testing: locally & unit