### PR TITLE
Make color immutable

### DIFF
--- a/org-code-javabuilder/media/src/main/java/org/code/media/Color.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/Color.java
@@ -4,10 +4,22 @@ import java.util.Map;
 
 public class Color {
 
-  private int red;
-  private int green;
-  private int blue;
-  private int alpha;
+  private final int red;
+  private final int green;
+  private final int blue;
+  private final int alpha;
+
+  public static Color copyWithRed(Color color, int redValue) {
+    return new Color(redValue, color.getGreen(), color.getBlue());
+  }
+
+  public static Color copyWithGreen(Color color, int greenValue) {
+    return new Color(color.getRed(), greenValue, color.getBlue());
+  }
+
+  public static Color copyWithBlue(Color color, int blueValue) {
+    return new Color(color.getRed(), color.getGreen(), blueValue);
+  }
 
   /**
    * Creates a color from a string representation.
@@ -24,7 +36,7 @@ public class Color {
     this.red = colorToCopy.getRed();
     this.green = colorToCopy.getGreen();
     this.blue = colorToCopy.getBlue();
-    this.setFullOpacity();
+    this.alpha = 255;
   }
 
   /**
@@ -36,10 +48,7 @@ public class Color {
    * @param blue the blue value from 0 - 255
    */
   public Color(int red, int green, int blue) {
-    this.red = this.sanitizeValue(red);
-    this.green = this.sanitizeValue(green);
-    this.blue = this.sanitizeValue(blue);
-    this.setFullOpacity();
+    this(red, green, blue, 255);
   }
 
   /**
@@ -107,42 +116,6 @@ public class Color {
   }
 
   /**
-   * Sets the amount of red (ranging from 0 to 255). Values below 0 will be ignored and set to 0,
-   * and values above 255 will be ignored and set to 255.
-   *
-   * @param value the amount of red (ranging from 0 to 255) in the color of the pixel.
-   */
-  public void setRed(int value) {
-    this.red = this.sanitizeValue(value);
-    // for now, setting the color implies we want full opacity
-    this.setFullOpacity();
-  }
-
-  /**
-   * Sets the amount of green (ranging from 0 to 255). Values below 0 will be ignored and set to 0,
-   * and values above 255 will be ignored and set to 255.
-   *
-   * @param value the amount of green (ranging from 0 to 255) in the color of the pixel.
-   */
-  public void setGreen(int value) {
-    this.green = this.sanitizeValue(value);
-    // for now, setting the color implies we want full opacity
-    this.setFullOpacity();
-  }
-
-  /**
-   * Sets the amount of blue (ranging from 0 to 255). Values below 0 will be ignored and set to 0, *
-   * and values above 255 will be ignored and set to 255.
-   *
-   * @param value the amount of blue (ranging from 0 to 255) in the color of the pixel.
-   */
-  public void setBlue(int value) {
-    this.blue = this.sanitizeValue(value);
-    // for now, setting the color implies we want full opacity
-    this.setFullOpacity();
-  }
-
-  /**
    * @return the combined RGB integer value consisting of the alpha component in bits 24-31, the red
    *     component in bits 16-23, the green component in bits 8-15, and the blue component in bits
    *     0-7.
@@ -165,10 +138,6 @@ public class Color {
       return 255;
     }
     return value;
-  }
-
-  private void setFullOpacity() {
-    this.alpha = 255;
   }
 
   public static java.awt.Color convertToAWTColor(Color c) {
@@ -225,6 +194,7 @@ public class Color {
           Map.entry("ORANGE", ORANGE),
           Map.entry("GOLD", GOLD),
           Map.entry("BROWN", BROWN),
+          Map.entry("CHOCOLATE", CHOCOLATE),
           Map.entry("TAN", TAN),
           Map.entry("TURQUOISE", TURQUOISE),
           Map.entry("INDIGO", INDIGO),

--- a/org-code-javabuilder/media/src/main/java/org/code/media/Color.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/Color.java
@@ -3,6 +3,8 @@ package org.code.media;
 import java.util.Map;
 
 public class Color {
+  private static final int MAX_VALUE = 255;
+  private static final int MIN_VALUE = 0;
 
   private final int red;
   private final int green;
@@ -36,7 +38,7 @@ public class Color {
     this.red = colorToCopy.getRed();
     this.green = colorToCopy.getGreen();
     this.blue = colorToCopy.getBlue();
-    this.alpha = 255;
+    this.alpha = MAX_VALUE;
   }
 
   /**
@@ -48,7 +50,7 @@ public class Color {
    * @param blue the blue value from 0 - 255
    */
   public Color(int red, int green, int blue) {
-    this(red, green, blue, 255);
+    this(red, green, blue, MAX_VALUE);
   }
 
   /**
@@ -131,13 +133,10 @@ public class Color {
    * @return value if it was in the expected range, or a valid value based on the reset logic.
    */
   private int sanitizeValue(int value) {
-    if (value < 0) {
-      return 0;
+    if (value < MIN_VALUE) {
+      return MIN_VALUE;
     }
-    if (value > 255) {
-      return 255;
-    }
-    return value;
+    return Math.min(value, MAX_VALUE);
   }
 
   public static java.awt.Color convertToAWTColor(Color c) {

--- a/org-code-javabuilder/media/src/main/java/org/code/media/Pixel.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/Pixel.java
@@ -103,7 +103,7 @@ public class Pixel {
    * @param value the amount of red (ranging from 0 to 255) in the color of the pixel.
    */
   public void setRed(int value) {
-    this.color.setRed(value);
+    this.color = Color.copyWithRed(this.color, value);
   }
 
   /**
@@ -113,7 +113,7 @@ public class Pixel {
    * @param value the amount of green (ranging from 0 to 255) in the color of the pixel.
    */
   public void setGreen(int value) {
-    this.color.setGreen(value);
+    this.color = Color.copyWithGreen(this.color, value);
   }
 
   /**
@@ -122,6 +122,6 @@ public class Pixel {
    * @param value the amount of blue (ranging from 0 to 255) in the color of the pixel.
    */
   public void setBlue(int value) {
-    this.color.setBlue(value);
+    this.color = Color.copyWithBlue(this.color, value);
   }
 }

--- a/org-code-javabuilder/media/src/test/java/org/code/media/ColorTest.java
+++ b/org-code-javabuilder/media/src/test/java/org/code/media/ColorTest.java
@@ -1,6 +1,7 @@
 package org.code.media;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +18,9 @@ public class ColorTest {
     final int green = 150;
     final int blue = 200;
     final int newRed = 50;
-    final Color copied = Color.copyWithRed(new Color(red, green, blue), newRed);
+    final Color original = new Color(red, green, blue);
+    final Color copied = Color.copyWithRed(original, newRed);
+    assertNotSame(copied, original);
     assertEquals(newRed, copied.getRed());
     assertEquals(green, copied.getGreen());
     assertEquals(blue, copied.getBlue());
@@ -29,7 +32,9 @@ public class ColorTest {
     final int green = 150;
     final int blue = 200;
     final int newGreen = 50;
-    final Color copied = Color.copyWithGreen(new Color(red, green, blue), newGreen);
+    final Color original = new Color(red, green, blue);
+    final Color copied = Color.copyWithGreen(original, newGreen);
+    assertNotSame(copied, original);
     assertEquals(red, copied.getRed());
     assertEquals(newGreen, copied.getGreen());
     assertEquals(blue, copied.getBlue());
@@ -41,7 +46,9 @@ public class ColorTest {
     final int green = 150;
     final int blue = 200;
     final int newBlue = 50;
-    final Color copied = Color.copyWithBlue(new Color(red, green, blue), newBlue);
+    final Color original = new Color(red, green, blue);
+    final Color copied = Color.copyWithBlue(original, newBlue);
+    assertNotSame(copied, original);
     assertEquals(red, copied.getRed());
     assertEquals(green, copied.getGreen());
     assertEquals(newBlue, copied.getBlue());

--- a/org-code-javabuilder/media/src/test/java/org/code/media/ColorTest.java
+++ b/org-code-javabuilder/media/src/test/java/org/code/media/ColorTest.java
@@ -12,11 +12,38 @@ public class ColorTest {
   }
 
   @Test
-  public void resettingColorSetsAlpha() {
-    Color c = new Color(0, 0, 0, 0);
-    assertEquals(0, c.getAlpha());
-    c.setBlue(255);
-    // now alpha should be 255 (max opacity), since we set the blue value on the color
-    assertEquals(255, c.getAlpha());
+  public void testCopyWithRedCreatesCopyWithNewRedValue() {
+    final int red = 100;
+    final int green = 150;
+    final int blue = 200;
+    final int newRed = 50;
+    final Color copied = Color.copyWithRed(new Color(red, green, blue), newRed);
+    assertEquals(newRed, copied.getRed());
+    assertEquals(green, copied.getGreen());
+    assertEquals(blue, copied.getBlue());
+  }
+
+  @Test
+  public void testCopyWithGreenCreatesCopyWithNewGreenValue() {
+    final int red = 100;
+    final int green = 150;
+    final int blue = 200;
+    final int newGreen = 50;
+    final Color copied = Color.copyWithGreen(new Color(red, green, blue), newGreen);
+    assertEquals(red, copied.getRed());
+    assertEquals(newGreen, copied.getGreen());
+    assertEquals(blue, copied.getBlue());
+  }
+
+  @Test
+  public void testCopyWithBlueCreatesCopyWithNewBlueValue() {
+    final int red = 100;
+    final int green = 150;
+    final int blue = 200;
+    final int newBlue = 50;
+    final Color copied = Color.copyWithBlue(new Color(red, green, blue), newBlue);
+    assertEquals(red, copied.getRed());
+    assertEquals(green, copied.getGreen());
+    assertEquals(newBlue, copied.getBlue());
   }
 }

--- a/org-code-javabuilder/media/src/test/java/org/code/media/ImageTest.java
+++ b/org-code-javabuilder/media/src/test/java/org/code/media/ImageTest.java
@@ -53,14 +53,6 @@ public class ImageTest {
   }
 
   @Test
-  public void canModifyColorAndItModifiesPixel() {
-    Image test = new Image(500, 300);
-    Color c = test.getPixel(50, 200).getColor();
-    c.setBlue(50);
-    assertEquals(50, test.getPixel(50, 200).getBlue());
-  }
-
-  @Test
   public void canCreateBufferedImage() {
     Image test = new Image(500, 300);
     // set one pixel to a specific color

--- a/org-code-javabuilder/media/src/test/java/org/code/media/PixelTest.java
+++ b/org-code-javabuilder/media/src/test/java/org/code/media/PixelTest.java
@@ -1,0 +1,39 @@
+package org.code.media;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PixelTest {
+
+  private Image image;
+
+  @BeforeEach
+  public void setUp() {
+    image = mock(Image.class);
+  }
+
+  @Test
+  public void testColorSettersUpdateColor() {
+    final Color original = new Color(50, 150, 250);
+    final Pixel pixel = new Pixel(image, 0, 0, original);
+
+    final int newValue = 123;
+    pixel.setRed(newValue);
+    assertEquals(newValue, pixel.getRed());
+
+    pixel.setGreen(newValue);
+    assertEquals(newValue, pixel.getGreen());
+
+    pixel.setBlue(newValue);
+    assertEquals(newValue, pixel.getBlue());
+
+    final Color newColor = new Color(123, 234, 111);
+    pixel.setColor(newColor);
+    assertEquals(newColor.getRed(), pixel.getRed());
+    assertEquals(newColor.getGreen(), pixel.getGreen());
+    assertEquals(newColor.getBlue(), pixel.getBlue());
+  }
+}

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
@@ -97,7 +97,7 @@ public class TextItem extends Item {
    * @param colorRed the amount of red (ranging from 0 to 255) in the color of the text.
    */
   public void setRed(int colorRed) {
-    this.color = new Color(colorRed, this.color.getGreen(), this.color.getBlue());
+    this.color = Color.copyWithRed(this.color, colorRed);
     this.sendChangeMessage(
         ClientMessageDetailKeys.COLOR_RED, Integer.toString(this.color.getRed()));
   }
@@ -109,7 +109,7 @@ public class TextItem extends Item {
    * @param colorGreen the amount of green (ranging from 0 to 255) in the color of the text.
    */
   public void setGreen(int colorGreen) {
-    this.color = new Color(this.color.getRed(), colorGreen, this.color.getBlue());
+    this.color = Color.copyWithGreen(this.color, colorGreen);
     this.sendChangeMessage(
         ClientMessageDetailKeys.COLOR_GREEN, Integer.toString(this.color.getGreen()));
   }
@@ -121,7 +121,7 @@ public class TextItem extends Item {
    * @param colorBlue the amount of blue (ranging from 0 to 255) in the color of the text.
    */
   public void setBlue(int colorBlue) {
-    this.color = new Color(this.color.getRed(), this.color.getGreen(), colorBlue);
+    this.color = Color.copyWithBlue(this.color, colorBlue);
     this.sendChangeMessage(
         ClientMessageDetailKeys.COLOR_BLUE, Integer.toString(this.color.getBlue()));
   }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/TextItem.java
@@ -36,8 +36,7 @@ public class TextItem extends Item {
       double rotation) {
     super(x, y, height);
     this.text = text;
-    // Copy to new color to store the values only, and not a reference to the original color object
-    this.color = new Color(color);
+    this.color = color;
     this.font = font;
     this.fontStyle = fontStyle;
     this.rotation = rotation;
@@ -83,8 +82,7 @@ public class TextItem extends Item {
    * @param color the text color
    */
   public void setColor(Color color) {
-    // Copy to new color to store the values only, and not a reference to the original color object
-    this.color = new Color(color);
+    this.color = color;
     HashMap<String, String> colorDetails = new HashMap<>();
     this.addColorToDetails(colorDetails);
     this.sendChangeMessage(colorDetails);
@@ -132,9 +130,7 @@ public class TextItem extends Item {
    * @return the text color for the item
    */
   public Color getColor() {
-    // TODO: wrapping this.color in a new Color object will not be necessary once Color is
-    // immutable.
-    return new Color(this.color);
+    return this.color;
   }
 
   /**

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
@@ -1,7 +1,6 @@
 package org.code.playground;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.List;
@@ -119,12 +118,11 @@ public class TextItemTest {
   }
 
   @Test
-  public void testGetColorReturnsCopyOfColor() {
+  public void testGetColorReturnsColor() {
     final Color color = Color.AQUA;
     final TextItem textItem = new TextItem("text", 0, 0, color, Font.SANS, 0, 0);
 
-    // Should be a different instance but have the same values
-    assertNotSame(color, textItem.getColor());
+    assertSame(color, textItem.getColor());
     assertEquals(color.getRed(), textItem.getColor().getRed());
     assertEquals(color.getGreen(), textItem.getColor().getGreen());
     assertEquals(color.getBlue(), textItem.getColor().getBlue());
@@ -132,8 +130,7 @@ public class TextItemTest {
     final Color newColor = Color.BEIGE;
     textItem.setColor(newColor);
 
-    // Should be a different instance but have the same values
-    assertNotSame(newColor, textItem.getColor());
+    assertSame(newColor, textItem.getColor());
     assertEquals(newColor.getRed(), textItem.getColor().getRed());
     assertEquals(newColor.getGreen(), textItem.getColor().getGreen());
     assertEquals(newColor.getBlue(), textItem.getColor().getBlue());


### PR DESCRIPTION
Makes `Color` immutable. This more closely aligns with the Java Color class and makes behavior consistent between Playground and Theater.

JIRA: https://codedotorg.atlassian.net/browse/CSA-865

Testing: local & unit