### PR TITLE
Playground: Clean up message send logic

### DIFF
--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
@@ -92,6 +92,7 @@ public class Board {
     this.clickableImages.put(image.getId(), image);
     this.playgroundMessageHandler.sendMessage(
         new PlaygroundMessage(PlaygroundSignalKey.ADD_CLICKABLE_ITEM, details));
+    image.turnOnChangeMessages();
   }
 
   /**
@@ -107,6 +108,7 @@ public class Board {
     HashMap<String, String> details = image.getRemoveDetails();
     this.playgroundMessageHandler.sendMessage(
         new PlaygroundMessage(PlaygroundSignalKey.REMOVE_ITEM, details));
+    image.turnOffChangeMessages();
   }
 
   /**
@@ -142,6 +144,7 @@ public class Board {
     HashMap<String, String> details = item.getRemoveDetails();
     this.playgroundMessageHandler.sendMessage(
         new PlaygroundMessage(PlaygroundSignalKey.REMOVE_ITEM, details));
+    item.turnOffChangeMessages();
   }
 
   /**
@@ -232,6 +235,7 @@ public class Board {
     HashMap<String, String> itemDetails = item.getDetails();
     this.addIndexToDetails(itemDetails);
     this.playgroundMessageHandler.sendMessage(new PlaygroundMessage(signalKey, itemDetails));
+    item.turnOnChangeMessages();
   }
 
   private void addIndexToDetails(HashMap<String, String> details) {
@@ -244,6 +248,7 @@ public class Board {
         new PlaygroundMessage(PlaygroundSignalKey.EXIT, new HashMap<>()));
     this.isRunning = false;
     this.hasEnded = true;
+    this.playgroundMessageHandler.disableMessages();
   }
 
   private void confirmIsRunning() throws PlaygroundException {

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
@@ -95,20 +95,14 @@ public abstract class Item {
   }
 
   protected void sendChangeMessage(String key, String value) {
-    if (this.shouldSendMessages) {
-      HashMap<String, String> details = this.getIdDetails();
-      details.put(key, value);
-      this.playgroundMessageHandler.sendMessage(
-          new PlaygroundMessage(PlaygroundSignalKey.CHANGE_ITEM, details));
-    }
+    HashMap<String, String> details = this.getIdDetails();
+    details.put(key, value);
+    this.sendChangeMessageHelper(details);
   }
 
   protected void sendChangeMessage(HashMap<String, String> changeDetails) {
-    if (this.shouldSendMessages) {
-      changeDetails.put(ClientMessageDetailKeys.ID, this.getId());
-      this.playgroundMessageHandler.sendMessage(
-          new PlaygroundMessage(PlaygroundSignalKey.CHANGE_ITEM, changeDetails));
-    }
+    changeDetails.put(ClientMessageDetailKeys.ID, this.getId());
+    this.sendChangeMessageHelper(changeDetails);
   }
 
   protected void turnOnChangeMessages() {
@@ -123,5 +117,12 @@ public abstract class Item {
     HashMap<String, String> idDetails = new HashMap<>();
     idDetails.put(ClientMessageDetailKeys.ID, this.getId());
     return idDetails;
+  }
+
+  private void sendChangeMessageHelper(HashMap<String, String> changeDetails) {
+    if (this.shouldSendMessages) {
+      this.playgroundMessageHandler.sendMessage(
+          new PlaygroundMessage(PlaygroundSignalKey.CHANGE_ITEM, changeDetails));
+    }
   }
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Item.java
@@ -10,6 +10,7 @@ public abstract class Item {
   private int height;
   private final String id;
   private final PlaygroundMessageHandler playgroundMessageHandler;
+  private boolean shouldSendMessages;
 
   Item(int x, int y, int height) {
     this.xLocation = x;
@@ -17,6 +18,7 @@ public abstract class Item {
     this.height = height;
     this.id = UUID.randomUUID().toString();
     this.playgroundMessageHandler = PlaygroundMessageHandler.getInstance();
+    this.shouldSendMessages = false;
   }
 
   /**
@@ -93,16 +95,28 @@ public abstract class Item {
   }
 
   protected void sendChangeMessage(String key, String value) {
-    HashMap<String, String> details = this.getIdDetails();
-    details.put(key, value);
-    this.playgroundMessageHandler.sendMessage(
-        new PlaygroundMessage(PlaygroundSignalKey.CHANGE_ITEM, details));
+    if (this.shouldSendMessages) {
+      HashMap<String, String> details = this.getIdDetails();
+      details.put(key, value);
+      this.playgroundMessageHandler.sendMessage(
+          new PlaygroundMessage(PlaygroundSignalKey.CHANGE_ITEM, details));
+    }
   }
 
   protected void sendChangeMessage(HashMap<String, String> changeDetails) {
-    changeDetails.put(ClientMessageDetailKeys.ID, this.getId());
-    this.playgroundMessageHandler.sendMessage(
-        new PlaygroundMessage(PlaygroundSignalKey.CHANGE_ITEM, changeDetails));
+    if (this.shouldSendMessages) {
+      changeDetails.put(ClientMessageDetailKeys.ID, this.getId());
+      this.playgroundMessageHandler.sendMessage(
+          new PlaygroundMessage(PlaygroundSignalKey.CHANGE_ITEM, changeDetails));
+    }
+  }
+
+  protected void turnOnChangeMessages() {
+    this.shouldSendMessages = true;
+  }
+
+  protected void turnOffChangeMessages() {
+    this.shouldSendMessages = false;
   }
 
   private HashMap<String, String> getIdDetails() {

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundExceptionKeys.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundExceptionKeys.java
@@ -3,5 +3,5 @@ package org.code.playground;
 public enum PlaygroundExceptionKeys {
   PLAYGROUND_RUNNING,
   PLAYGROUND_NOT_RUNNING,
-  INVALID_MESSAGE_PLAYGROUND_ENDED
+  INVALID_MESSAGE
 }

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundMessageHandler.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundMessageHandler.java
@@ -5,6 +5,7 @@ import org.code.protocol.OutputAdapter;
 
 class PlaygroundMessageHandler {
   private static PlaygroundMessageHandler instance;
+  private boolean messagesEnabled;
 
   static PlaygroundMessageHandler getInstance() {
     if (instance == null) {
@@ -21,16 +22,24 @@ class PlaygroundMessageHandler {
 
   // Visible for testing only
   PlaygroundMessageHandler(OutputAdapter outputAdapter) {
+    this.messagesEnabled = true;
     this.outputAdapter = outputAdapter;
   }
 
   public void sendMessage(PlaygroundMessage message) {
     // only send messages if playground has not ended. Otherwise throw a runtime exception.
-    if (Playground.board.hasEnded()) {
-      throw new PlaygroundRuntimeException(
-          PlaygroundExceptionKeys.INVALID_MESSAGE_PLAYGROUND_ENDED);
+    if (!this.messagesEnabled) {
+      throw new PlaygroundRuntimeException(PlaygroundExceptionKeys.INVALID_MESSAGE);
     } else {
       this.outputAdapter.sendMessage(message);
     }
+  }
+
+  protected void enableMessages() {
+    this.messagesEnabled = true;
+  }
+
+  protected void disableMessages() {
+    this.messagesEnabled = false;
   }
 }

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/ImageItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/ImageItemTest.java
@@ -42,7 +42,7 @@ public class ImageItemTest {
   }
 
   @Test
-  public void settersSendChangeMessages() throws FileNotFoundException {
+  public void settersSendChangeMessagesIfTheyAreOn() throws FileNotFoundException {
     ImageItem imageItem = new ImageItem("test", 0, 0, 10, 10, assetFileHelper);
     imageItem.turnOnChangeMessages();
 
@@ -57,6 +57,21 @@ public class ImageItemTest {
     assertEquals(newFilename, messages.get(0).getDetail().get(ClientMessageDetailKeys.FILENAME));
     assertEquals(
         Integer.toString(newWidth), messages.get(1).getDetail().get(ClientMessageDetailKeys.WIDTH));
+  }
+
+  @Test
+  public void settersDoNotSendChangeMessagesByDefault() throws FileNotFoundException {
+    ImageItem imageItem = new ImageItem("test", 0, 0, 10, 10, assetFileHelper);
+    String newFilename = "new_filename";
+    int newWidth = 100;
+
+    // change messages are off by default, no messages should be sent but values should change
+    imageItem.setFilename(newFilename);
+    imageItem.setWidth(newWidth);
+
+    verify(playgroundMessageHandler, times(0)).sendMessage(messageCaptor.capture());
+    assertEquals(newWidth, imageItem.getWidth());
+    assertEquals(newFilename, imageItem.getFilename());
   }
 
   @Test

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/ImageItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/ImageItemTest.java
@@ -44,6 +44,7 @@ public class ImageItemTest {
   @Test
   public void settersSendChangeMessages() throws FileNotFoundException {
     ImageItem imageItem = new ImageItem("test", 0, 0, 10, 10, assetFileHelper);
+    imageItem.turnOnChangeMessages();
 
     String newFilename = "new_filename";
     int newWidth = 100;

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/ItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/ItemTest.java
@@ -40,7 +40,7 @@ public class ItemTest {
   }
 
   @Test
-  public void settersSendChangeMessages() {
+  public void settersSendChangeMessagesIfTheyAreOn() {
     Item item = new ItemHelper(0, 0, 15);
     item.turnOnChangeMessages();
 
@@ -61,5 +61,22 @@ public class ItemTest {
     assertEquals(
         Integer.toString(newHeight),
         messages.get(2).getDetail().get(ClientMessageDetailKeys.HEIGHT));
+  }
+
+  @Test
+  public void settersDoNotSendChangeMessagesByDefault() {
+    Item item = new ItemHelper(0, 0, 15);
+
+    int newX = 5;
+    int newY = 10;
+    int newHeight = 100;
+    item.setX(newX);
+    item.setY(newY);
+    item.setHeight(newHeight);
+
+    verify(playgroundMessageHandler, times(0)).sendMessage(messageCaptor.capture());
+    assertEquals(newHeight, item.getHeight());
+    assertEquals(newX, item.getX());
+    assertEquals(newY, item.getY());
   }
 }

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/ItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/ItemTest.java
@@ -42,6 +42,7 @@ public class ItemTest {
   @Test
   public void settersSendChangeMessages() {
     Item item = new ItemHelper(0, 0, 15);
+    item.turnOnChangeMessages();
 
     int newX = 5;
     int newY = 10;

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
@@ -44,7 +44,7 @@ public class TextItemTest {
   }
 
   @Test
-  public void settersSendChangeMessages() {
+  public void settersSendChangeMessagesIfTheyAreOn() {
     TextItem textItem = new TextItem("text", 0, 0, Color.BLUE, Font.SANS, FontStyle.BOLD, 10, 0);
     textItem.turnOnChangeMessages();
 
@@ -72,7 +72,7 @@ public class TextItemTest {
   }
 
   @Test
-  public void testColorSettersSendMessages() {
+  public void testColorSettersSendMessagesIfTheyAreOn() {
     TextItem textItem = new TextItem("text", 0, 0, Color.BLUE, Font.SANS, FontStyle.BOLD, 10, 0);
     textItem.turnOnChangeMessages();
 

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
@@ -46,6 +46,7 @@ public class TextItemTest {
   @Test
   public void settersSendChangeMessages() {
     TextItem textItem = new TextItem("text", 0, 0, Color.BLUE, Font.SANS, FontStyle.BOLD, 10, 0);
+    textItem.turnOnChangeMessages();
 
     String newText = "new text";
     Font newFont = Font.SERIF;
@@ -73,6 +74,7 @@ public class TextItemTest {
   @Test
   public void testColorSettersSendMessages() {
     TextItem textItem = new TextItem("text", 0, 0, Color.BLUE, Font.SANS, FontStyle.BOLD, 10, 0);
+    textItem.turnOnChangeMessages();
 
     Color newColor = Color.GREEN;
 


### PR DESCRIPTION
Fix up the logic for sending playground messages in preparation for batching messages. The changes here make it so that items have methods to turn on/off change messages, which will be called when an item is added/removed from the board. By default items won't send change messages, so any initial changes won't send irrelevant messages to javalab. I also updated the message handler to have enable/disable message methods, so that board can turn off messages when `exit` is called. Currently we don't have a reason to turn messages back on, but I left the method there in case it's required in the future.

I renamed the exception message we throw when a message is sent after the board exits to align better with the new model. There will be a frontend change incoming to use this new message.