### PR TITLE
Theater images should rotate around the top left corner rather than center

### DIFF
--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -425,10 +425,10 @@ public class Stage {
       double widthScale = (double) width / image.getWidth();
       double heightScale = (double) height / image.getHeight();
       // create a transform that moves the location of the image to (x,y), rotates around
-      // the center of the image and scales the image to width and height
+      // the top left corner of the image and scales the image to width and height
       // Note: order of transforms is important, do not reorder these calls
       transform.translate(x, y);
-      transform.rotate(Math.toRadians(degrees), width / 2, height / 2);
+      transform.rotate(Math.toRadians(degrees), 0, 0);
       transform.scale(widthScale, heightScale);
       this.graphics.drawImage(image, transform, null);
     } else {


### PR DESCRIPTION
Just need to update the transform anchor to the top left corner (0, 0) rather than the center.

JIRA: https://codedotorg.atlassian.net/browse/CSA-866

Tested locally on All The Things theater level

New rotation (around top left corner):

https://user-images.githubusercontent.com/85528507/136087553-5d56d9b9-97ed-452c-a27f-62d4f1d886ef.mov

Original rotation (around center):

https://user-images.githubusercontent.com/85528507/136087587-dae0a312-3fc2-4fb6-9358-50535af705dd.mov



