### PR TITLE
Unify clean up and exit

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilderWrapper.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilderWrapper.java
@@ -61,6 +61,9 @@ public class CodeBuilderWrapper {
 
       // Additionally, these may have affected the user. For now, let's tell them about it.
       outputAdapter.sendMessage(error.getExceptionMessage());
+    } finally {
+      GlobalProtocol.getInstance().cleanUpResources();
+      this.outputAdapter.sendMessage(new StatusMessage(StatusMessageKey.EXITED));
     }
   }
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavaRunner.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavaRunner.java
@@ -46,10 +46,8 @@ public class JavaRunner {
       mainMethod.invoke(null, new Object[] {null});
     } catch (IllegalAccessException e) {
       // TODO: this error message may not be not very friendly
-      this.outputAdapter.sendMessage(new StatusMessage(StatusMessageKey.EXITED));
       throw new UserInitiatedException(UserInitiatedExceptionKey.ILLEGAL_METHOD_ACCESS, e);
     } catch (InvocationTargetException e) {
-      this.outputAdapter.sendMessage(new StatusMessage(StatusMessageKey.EXITED));
       // If the invocation exception is wrapping another JavabuilderException or
       // JavabuilderRuntimeException, we don't need to wrap it in a UserInitiatedException
       if (e.getCause() instanceof JavabuilderException) {
@@ -66,7 +64,6 @@ public class JavaRunner {
       throw new UserInitiatedException(UserInitiatedExceptionKey.RUNTIME_ERROR, e);
     }
     try {
-      this.outputAdapter.sendMessage(new StatusMessage(StatusMessageKey.EXITED));
       urlClassLoader.close();
     } catch (IOException e) {
       // The user code has finished running. We don't want to confuse them at this point with an

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundMessageHandler.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundMessageHandler.java
@@ -1,9 +1,10 @@
 package org.code.playground;
 
 import org.code.protocol.GlobalProtocol;
+import org.code.protocol.MessageHandler;
 import org.code.protocol.OutputAdapter;
 
-class PlaygroundMessageHandler {
+class PlaygroundMessageHandler implements MessageHandler {
   private static PlaygroundMessageHandler instance;
   private boolean messagesEnabled;
 
@@ -18,6 +19,7 @@ class PlaygroundMessageHandler {
 
   private PlaygroundMessageHandler() {
     this(GlobalProtocol.getInstance().getOutputAdapter());
+    GlobalProtocol.getInstance().registerMessageHandler(this);
   }
 
   // Visible for testing only
@@ -35,11 +37,18 @@ class PlaygroundMessageHandler {
     }
   }
 
-  protected void enableMessages() {
+  @Override
+  public void exit() {
+    // TODO: Once batching is added, send any remaining messages here
+  }
+
+  @Override
+  public void enableMessages() {
     this.messagesEnabled = true;
   }
 
-  protected void disableMessages() {
+  @Override
+  public void disableMessages() {
     this.messagesEnabled = false;
   }
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
@@ -1,5 +1,8 @@
 package org.code.protocol;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * This sets up the protocols that are used across jars in Javabuilder. It allows the input and
  * output adapters to be set at the entrypoint of the system (i.e. LambdaRequestHandler, LocalMain,
@@ -16,6 +19,7 @@ public class GlobalProtocol {
   private final String dashboardHostname;
   private final String channelId;
   private final AssetFileHelper assetFileHelper;
+  private Set<MessageHandler> messageHandlers;
 
   private GlobalProtocol(
       OutputAdapter outputAdapter,
@@ -30,6 +34,7 @@ public class GlobalProtocol {
     this.channelId = channelId;
     this.fileWriter = fileWriter;
     this.assetFileHelper = assetFileHelper;
+    this.messageHandlers = new HashSet<>();
   }
 
   public static void create(
@@ -79,5 +84,16 @@ public class GlobalProtocol {
 
   public String generateSourcesUrl() {
     return String.format("%s/v3/sources/%s", this.dashboardHostname, this.channelId);
+  }
+
+  public void registerMessageHandler(MessageHandler handler) {
+    this.messageHandlers.add(handler);
+  }
+
+  // Clean up resources that require explicit clean up before exiting
+  public void cleanUpResources() {
+    for (MessageHandler handler : this.messageHandlers) {
+      handler.exit();
+    }
   }
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/MessageHandler.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/MessageHandler.java
@@ -1,0 +1,9 @@
+package org.code.protocol;
+
+public interface MessageHandler {
+  void exit();
+
+  void enableMessages();
+
+  void disableMessages();
+}


### PR DESCRIPTION
This PR fixes a small bug and prepares us for playground message batching. It includes the following changes:
- instead of sending an `EXIT` message before throwing an exception or exiting safely, instead add a `finally` block in `executeCodeBuilder` that sends an exit message in all cases (this is the backend part of the fix for an issue where we would see 2 exit messages in javalab if there was an exception)
- Add a new interface `MessageHandler` which `PlaygroundMessageHandler` implements, and register the `MessageHandler` with `GlobalProtocol`. Then, in the new `finally` block in `CodeBuilderWrapper`, call clean up the message handler(s). This will enable us to send any pending messages on exit for our new batch message strategy. We also can implement other message handlers with their own exit methods in the future if need be.