### PR TITLE
Javabuilder: add run tests option

### DIFF
--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -45,7 +45,8 @@ def on_connect(event, context)
     :options => authorizer["options"],
     :iss => authorizer["iss"],
     :channelId => authorizer["channel_id"],
-    :javabuilderSessionId => authorizer['sid']
+    :javabuilderSessionId => authorizer['sid'],
+    :executionType => authorizer['execution_type']
   }
   response = lambda_client.invoke({
     function_name: ENV['BUILD_AND_RUN_PROJECT_LAMBDA_ARN'] || 'javaBuilderExecuteCode:13',

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
@@ -26,6 +26,6 @@ public class LocalMain {
 
     // Create and invoke the code execution environment
     CodeBuilderWrapper codeBuilderWrapper = new CodeBuilderWrapper(fileLoader, outputAdapter);
-    codeBuilderWrapper.executeCodeBuilder();
+    codeBuilderWrapper.executeCodeBuilder(ExecutionType.RUN);
   }
 }

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -58,6 +58,15 @@ public class WebSocketServer {
       useNeighborhood = Boolean.parseBoolean(useNeighborhoodStr);
     }
 
+    final String executionTypeString =
+        queryInput.has("execution_type") ? queryInput.getString("execution_type") : null;
+    // TODO: in order to not break current behavior in Javalab, execution type defaults to 'RUN'.
+    // Once Javalab is sending the execution type parameter, remove this fallback
+    final ExecutionType executionType =
+        executionTypeString == null
+            ? ExecutionType.RUN
+            : ExecutionType.valueOf(executionTypeString);
+
     this.logger = Logger.getLogger(MAIN_LOGGER);
     this.logHandler = new LocalLogHandler(System.out, levelId, channelId);
     this.logger.addHandler(this.logHandler);
@@ -81,7 +90,7 @@ public class WebSocketServer {
             () -> {
               CodeBuilderWrapper codeBuilderWrapper =
                   new CodeBuilderWrapper(fileLoader, outputAdapter);
-              codeBuilderWrapper.executeCodeBuilder();
+              codeBuilderWrapper.executeCodeBuilder(executionType);
               try {
                 session.close();
                 logger.removeHandler(this.logHandler);

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilder.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilder.java
@@ -44,23 +44,14 @@ public class CodeBuilder implements AutoCloseable {
     codeCompiler.compileProgram();
   }
 
-  /**
-   * Replaces System.in and System.out with our custom implementation and executes the user's code.
-   */
+  /** Runs the main method of the student's code */
   public void runUserCode() throws InternalFacingException, JavabuilderException {
-    System.setOut(new OutputPrintStream(this.outputAdapter));
-    System.setIn(new InputRedirectionStream(this.inputHandler));
-    JavaRunner runner;
-    try {
-      runner =
-          new JavaRunner(
-              this.tempFolder.toURI().toURL(),
-              this.userProjectFiles.getJavaFiles(),
-              this.outputAdapter);
-    } catch (MalformedURLException e) {
-      throw new InternalServerError(InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION, e);
-    }
-    runner.runCode();
+    this.createJavaRunner().runMain();
+  }
+
+  /** Runs all tests in the student's code */
+  public void runUserTests() throws InternalFacingException, JavabuilderException {
+    this.createJavaRunner().runTests();
   }
 
   /**
@@ -80,6 +71,23 @@ public class CodeBuilder implements AutoCloseable {
       } catch (IOException e) {
         throw new InternalFacingException(e.toString(), e);
       }
+    }
+  }
+
+  /**
+   * Replaces System.in and System.out with our custom implementation and creates a runner for
+   * executing code
+   */
+  private JavaRunner createJavaRunner() throws InternalServerError {
+    System.setOut(new OutputPrintStream(this.outputAdapter));
+    System.setIn(new InputRedirectionStream(this.inputHandler));
+    try {
+      return new JavaRunner(
+          this.tempFolder.toURI().toURL(),
+          this.userProjectFiles.getJavaFiles(),
+          this.outputAdapter);
+    } catch (MalformedURLException e) {
+      throw new InternalServerError(InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION, e);
     }
   }
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilderWrapper.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilderWrapper.java
@@ -21,13 +21,18 @@ public class CodeBuilderWrapper {
     this.outputAdapter = outputAdapter;
   }
 
-  public void executeCodeBuilder() {
+  public void executeCodeBuilder(ExecutionType executionType) {
     try {
       UserProjectFiles userProjectFiles = fileLoader.loadFiles();
       try (CodeBuilder codeBuilder =
           new CodeBuilder(GlobalProtocol.getInstance(), userProjectFiles)) {
         codeBuilder.buildUserCode();
-        codeBuilder.runUserCode();
+
+        if (executionType == ExecutionType.RUN) {
+          codeBuilder.runUserCode();
+        } else if (executionType == ExecutionType.TEST) {
+          codeBuilder.runUserTests();
+        }
       }
     } catch (InternalServerError | InternalServerRuntimeError e) {
       // The error was caused by us (essentially an HTTP 5xx error). Log it so we can fix it.

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ExecutionType.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ExecutionType.java
@@ -1,0 +1,9 @@
+package org.code.javabuilder;
+
+/** Specifies in which manner the lambda should build and execute student code */
+public enum ExecutionType {
+  // Compile and run the main method
+  RUN,
+  // Compile and run tests
+  TEST
+}

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavaRunner.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavaRunner.java
@@ -30,7 +30,7 @@ public class JavaRunner {
    * @throws InternalFacingException When we hit an internal error after the user's code has
    *     finished executing.
    */
-  public void runCode() throws InternalFacingException, JavabuilderException {
+  public void runMain() throws InternalFacingException, JavabuilderException {
     // Include the user-facing api jars in the code we are loading so student code can access them.
     URL[] classLoaderUrls = Util.getAllJarURLs(this.executableLocation);
 
@@ -72,16 +72,19 @@ public class JavaRunner {
     }
   }
 
+  public void runTests() {
+    // TODO: Find and run tests
+  }
+
   /**
    * Finds the main method in the set of files in fileManager if it exists.
    *
    * @param urlClassLoader class loader pointing to location of compiled classes
    * @return the main method if it is found
-   * @throws InternalServerError if there is an issue loading a class
-   * @throws UserInitiatedException if there is more than one main method or no main method
+   * @throws UserInitiatedException if there is more than one main method or no main method, or if
+   *     the class definition is empty
    */
-  public Method findMainMethod(URLClassLoader urlClassLoader)
-      throws InternalServerError, UserInitiatedException {
+  private Method findMainMethod(URLClassLoader urlClassLoader) throws UserInitiatedException {
 
     Method mainMethod = null;
     for (JavaProjectFile file : this.javaFiles) {

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -56,6 +56,14 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
       useNeighborhood = Boolean.parseBoolean(useNeighborhoodStr);
     }
 
+    final String executionTypeString = lambdaInput.get("executionType");
+    // TODO: in order to not break current behavior in Javalab, execution type defaults to 'RUN'.
+    // Once Javalab is sending the execution type parameter, remove this fallback
+    final ExecutionType executionType =
+        executionTypeString == null
+            ? ExecutionType.RUN
+            : ExecutionType.valueOf(executionTypeString);
+
     Logger logger = Logger.getLogger(MAIN_LOGGER);
     logger.addHandler(
         new LambdaLogHandler(
@@ -120,7 +128,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
       // Load files to memory and create and invoke the code execution environment
       CodeBuilderWrapper codeBuilderWrapper =
           new CodeBuilderWrapper(userProjectFileLoader, outputAdapter);
-      codeBuilderWrapper.executeCodeBuilder();
+      codeBuilderWrapper.executeCodeBuilder(executionType);
     } finally {
       cleanUpResources(connectionId, api);
     }


### PR DESCRIPTION
Adds an option to run tests on Javabuilder (as opposed to running the main method, which is currently the default behavior). This is done by introducing an "execution type" parameter that is passed from Javalab to Javabuilder. Currently, the types include `RUN` and `TEST`, but my thinking was this can expanded to include other uses (such as `COMPILE_ONLY`) and give us more flexibility in how we want to handle requests. Currently invoking Javabuilder with `TEST` will do nothing (running tests no-ops); actually finding and running test code will be a separate change.

Additionally - if no execution type is provided, we will temporarily default to `RUN` to make sure Javalab doesn't break. There will be a separate change to Javalab for sending the parameter, after which there will be a follow-up task to remove the fallback.

JIRA: https://codedotorg.atlassian.net/browse/CSA-930
Related Javalab PR for passing the execution type parameter: https://github.com/code-dot-org/code-dot-org/pull/42938

Testing: locally with All The Things Level