### PR TITLE
Prompter: send message when getImage is called

### DIFF
--- a/org-code-javabuilder/playground/build.gradle
+++ b/org-code-javabuilder/playground/build.gradle
@@ -16,7 +16,7 @@ java {
 
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    // https://mvnrepository.com/artifact/org.mockito/mockito-core
+    // https://mvnrepository.com/artifact/org.mockito/mockito-inline
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
     // https://mvnrepository.com/artifact/org.json/json

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
@@ -19,6 +19,9 @@ public class ClientMessageDetailKeys {
   public static final String ROTATION = "rotation";
   public static final String UPDATES = "updates";
 
+  // Theater specific
+  public static final String PROMPT = "prompt";
+
   // Exception specific
   public static final String CONNECTION_ID = "connectionId";
   public static final String CAUSE = "cause";

--- a/org-code-javabuilder/theater/build.gradle
+++ b/org-code-javabuilder/theater/build.gradle
@@ -24,8 +24,8 @@ java {
 
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    // https://mvnrepository.com/artifact/org.mockito/mockito-core
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.9.0'
+    // https://mvnrepository.com/artifact/org.mockito/mockito-inline
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
     // https://mvnrepository.com/artifact/org.json/json
     implementation group: 'org.json', name: 'json', version: '20210307'

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
@@ -1,11 +1,22 @@
 package org.code.theater;
 
+import java.util.HashMap;
 import org.code.media.Image;
+import org.code.protocol.GlobalProtocol;
+import org.code.protocol.OutputAdapter;
 
 public class Prompter {
-  protected Prompter() {}
+  private final OutputAdapter outputAdapter;
+
+  protected Prompter() {
+    this.outputAdapter = GlobalProtocol.getInstance().getOutputAdapter();
+  }
 
   public Image getImage(String prompt) {
+    HashMap<String, String> getImageDetails = new HashMap<>();
+    getImageDetails.put("prompt", prompt);
+    this.outputAdapter.sendMessage(new TheaterMessage(TheaterSignalKey.GET_IMAGE, getImageDetails));
+
     return null;
   }
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
@@ -2,19 +2,27 @@ package org.code.theater;
 
 import java.util.HashMap;
 import org.code.media.Image;
+import org.code.protocol.ClientMessageDetailKeys;
 import org.code.protocol.GlobalProtocol;
 import org.code.protocol.OutputAdapter;
 
 public class Prompter {
   private final OutputAdapter outputAdapter;
 
+  // Used in Theater to create Prompter "singleton"
+  // accessed by students.
   protected Prompter() {
-    this.outputAdapter = GlobalProtocol.getInstance().getOutputAdapter();
+    this(GlobalProtocol.getInstance().getOutputAdapter());
+  }
+
+  // Used to directly instantiate Prompter in tests.
+  protected Prompter(OutputAdapter outputAdapter) {
+    this.outputAdapter = outputAdapter;
   }
 
   public Image getImage(String prompt) {
     HashMap<String, String> getImageDetails = new HashMap<>();
-    getImageDetails.put("prompt", prompt);
+    getImageDetails.put(ClientMessageDetailKeys.PROMPT, prompt);
     this.outputAdapter.sendMessage(new TheaterMessage(TheaterSignalKey.GET_IMAGE, getImageDetails));
 
     return null;

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
@@ -25,6 +25,9 @@ public class Prompter {
     getImageDetails.put(ClientMessageDetailKeys.PROMPT, prompt);
     this.outputAdapter.sendMessage(new TheaterMessage(TheaterSignalKey.GET_IMAGE, getImageDetails));
 
+    // TO DO: get provided image from Javalab.
+    // https://codedotorg.atlassian.net/browse/CSA-936
+
     return null;
   }
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/TheaterSignalKey.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/TheaterSignalKey.java
@@ -4,5 +4,7 @@ public enum TheaterSignalKey {
   // This message contains the url to a visual element
   VISUAL_URL,
   // This message contains the url to an audio element
-  AUDIO_URL
+  AUDIO_URL,
+  // Get an image from the user via Prompter
+  GET_IMAGE
 }

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/PrompterTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/PrompterTest.java
@@ -1,0 +1,47 @@
+package org.code.theater;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import org.code.protocol.GlobalProtocol;
+import org.code.protocol.OutputAdapter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+public class PrompterTest {
+  private OutputAdapter outputAdapter;
+  private MockedStatic<GlobalProtocol> globalProtocol;
+  private Prompter unitUnderTest;
+
+  @BeforeEach
+  public void setUp() {
+    outputAdapter = mock(OutputAdapter.class);
+
+    globalProtocol = mockStatic(GlobalProtocol.class);
+    final GlobalProtocol globalProtocolInstance = mock(GlobalProtocol.class);
+    globalProtocol.when(GlobalProtocol::getInstance).thenReturn(globalProtocolInstance);
+    when(globalProtocolInstance.getOutputAdapter()).thenReturn(outputAdapter);
+
+    unitUnderTest = new Prompter();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    globalProtocol.close();
+  }
+
+  @Test
+  public void testGetImageSendsMessage() {
+    String prompt = "Upload an image please!";
+    ArgumentCaptor<TheaterMessage> message = ArgumentCaptor.forClass(TheaterMessage.class);
+
+    unitUnderTest.getImage(prompt);
+
+    verify(outputAdapter, times(1)).sendMessage(message.capture());
+    assertEquals(TheaterSignalKey.GET_IMAGE.toString(), message.getValue().getValue());
+    assertEquals(prompt, message.getValue().getDetail().get("prompt"));
+  }
+}

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/PrompterTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/PrompterTest.java
@@ -3,34 +3,20 @@ package org.code.theater;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
-import org.code.protocol.GlobalProtocol;
+import org.code.protocol.ClientMessageDetailKeys;
 import org.code.protocol.OutputAdapter;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.MockedStatic;
 
 public class PrompterTest {
   private OutputAdapter outputAdapter;
-  private MockedStatic<GlobalProtocol> globalProtocol;
   private Prompter unitUnderTest;
 
   @BeforeEach
   public void setUp() {
     outputAdapter = mock(OutputAdapter.class);
-
-    globalProtocol = mockStatic(GlobalProtocol.class);
-    final GlobalProtocol globalProtocolInstance = mock(GlobalProtocol.class);
-    globalProtocol.when(GlobalProtocol::getInstance).thenReturn(globalProtocolInstance);
-    when(globalProtocolInstance.getOutputAdapter()).thenReturn(outputAdapter);
-
-    unitUnderTest = new Prompter();
-  }
-
-  @AfterEach
-  public void tearDown() {
-    globalProtocol.close();
+    unitUnderTest = new Prompter(outputAdapter);
   }
 
   @Test
@@ -42,6 +28,6 @@ public class PrompterTest {
 
     verify(outputAdapter, times(1)).sendMessage(message.capture());
     assertEquals(TheaterSignalKey.GET_IMAGE.toString(), message.getValue().getValue());
-    assertEquals(prompt, message.getValue().getDetail().get("prompt"));
+    assertEquals(prompt, message.getValue().getDetail().get(ClientMessageDetailKeys.PROMPT));
   }
 }


### PR DESCRIPTION
Sends a message ("GET_IMAGE") to Javalab when getImage is called, and includes the prompt that should be displayed in the `details`.

## Testing story

Added unit test, and tested manually that I saw these messages appearing when I called Theater.prompter.getImage("") from Javalab.