### PR TITLE
Make unit test results user friendly

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavabuilderTestExecutionListener.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavabuilderTestExecutionListener.java
@@ -22,6 +22,9 @@ import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
  * https://junit.org/junit5/docs/5.0.0/api/org/junit/platform/launcher/TestExecutionListener.html
  */
 public class JavabuilderTestExecutionListener extends SummaryGeneratingListener {
+  private static final String CHECK_MARK = "✔";
+  private static final String HEAVY_X = "✖";
+
   private final OutputAdapter outputAdapter;
 
   public JavabuilderTestExecutionListener(OutputAdapter outputAdapter) {
@@ -48,13 +51,13 @@ public class JavabuilderTestExecutionListener extends SummaryGeneratingListener 
    * outcome. This listener publishes the test result and, if the test failed, the error message to
    * the OutputAdapter.
    *
-   * <p>The format of the test result is: [test class name] > [test name] [test result]
+   * <p>The format of the test result is: [icon] [test class name] > [test name] [test result]
    *
    * <p>for example:
    *
-   * <p>MyTestClass > myTest SUCCEEDED
+   * <p>✔ MyTestClass > myTest SUCCEEDED
    *
-   * <p>MyTestClass > myTest FAILED
+   * <p>✖ MyTestClass > myTest FAILED
    *
    * <p>failure message (MyTestClass:1)
    *
@@ -80,8 +83,9 @@ public class JavabuilderTestExecutionListener extends SummaryGeneratingListener 
     }
 
     final TestExecutionResult.Status status = testExecutionResult.getStatus();
+    final String icon = status == TestExecutionResult.Status.SUCCESSFUL ? CHECK_MARK : HEAVY_X;
     final String resultMessage =
-        String.format("%s > %s %s\n", className, testIdentifier.getDisplayName(), status);
+        String.format("%s %s > %s %s\n", icon, className, testIdentifier.getDisplayName(), status);
     this.outputAdapter.sendMessage(new SystemOutMessage(resultMessage));
 
     final Optional<Throwable> throwable = testExecutionResult.getThrowable();


### PR DESCRIPTION
Most of the formatting output work was done in a previous PR, so this just adds check marks and Xs for passing/failing tests.

JIRA: https://codedotorg.atlassian.net/browse/CSA-932
Testing: all the things

![Screen Shot 2021-10-25 at 2 35 34 PM](https://user-images.githubusercontent.com/85528507/138759356-517fb381-06c6-4da1-9b4a-9ad51577c5b6.png)

