### PR TITLE
Allow Javabuilder output bucket to accept PUT requests

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -292,7 +292,7 @@ Resources:
       BucketName: !If [IsDevCondition, !Sub "cdo-dev-${SubDomainName}-output", !Sub "cdo-${SubDomainName}-output"] 
       CorsConfiguration:
         CorsRules:
-          - AllowedMethods: [GET]
+          - AllowedMethods: [GET, PUT]
             AllowedOrigins: ['*']
             AllowedHeaders: ['*']
       BucketEncryption:


### PR DESCRIPTION
This will be needed for Javalab to upload images using signed URLs.

Tested on dev instance lambda + postman.