### PR TITLE
Add functionality to Javabuilder to get the uploaded prompter image

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalFileManager.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalFileManager.java
@@ -4,6 +4,7 @@ import static dev.javabuilder.LocalWebserverConstants.DIRECTORY;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.code.javabuilder.InternalServerError;
@@ -31,6 +32,12 @@ public class LocalFileManager implements JavabuilderFileManager {
   @Override
   public String getUploadUrl(String filename) throws JavabuilderException {
     // TODO: Return upload URL for localhost uploads
+    return null;
+  }
+
+  @Override
+  public URL getFileUrl(String filename) {
+    // TODO: Return file URL for locally uploaded files
     return null;
   }
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSFileManager.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSFileManager.java
@@ -7,6 +7,8 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Date;
 import org.code.protocol.*;
@@ -88,6 +90,15 @@ public class AWSFileManager implements JavabuilderFileManager {
     }
 
     return null;
+  }
+
+  @Override
+  public URL getFileUrl(String filename) throws FileNotFoundException {
+    try {
+      return new URL(this.getOutputURL + "/" + this.generateKey(filename));
+    } catch (MalformedURLException e) {
+      throw new FileNotFoundException(filename);
+    }
   }
 
   private String generateKey(String filename) {

--- a/org-code-javabuilder/media/src/main/java/org/code/media/Image.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/Image.java
@@ -67,6 +67,19 @@ public class Image {
   }
 
   /**
+   * Creates a new Image from the given BufferedImage. Only meant for internal use.
+   *
+   * @param bufferedImage BufferedImage that backs this Image object
+   */
+  private Image(BufferedImage bufferedImage) {
+    this.bufferedImage = bufferedImage;
+    this.width = bufferedImage.getWidth();
+    this.height = bufferedImage.getHeight();
+    // don't create pixel array until we need it
+    this.pixels = null;
+  }
+
+  /**
    * Get the Pixel at the (x,y) coordinate specified.
    *
    * @param x the x position of the pixel
@@ -152,6 +165,17 @@ public class Image {
   }
 
   /**
+   * Load the given image from a URL and return an Image object
+   *
+   * @param url to load the file from
+   * @return Image object
+   * @throws FileNotFoundException if the file is not found at the URL
+   */
+  public static Image fromUrl(URL url) throws FileNotFoundException {
+    return new Image(Image.getImageFromUrl(url));
+  }
+
+  /**
    * Load the given image asset from file and return it as a BufferedImage
    *
    * @param filename
@@ -159,16 +183,24 @@ public class Image {
    * @throws FileNotFoundException if the file is not found
    */
   public static BufferedImage getImageAssetFromFile(String filename) throws FileNotFoundException {
+    try {
+      return Image.getImageFromUrl(
+          new URL(GlobalProtocol.getInstance().generateAssetUrl(filename)));
+    } catch (IOException e) {
+      throw new FileNotFoundException(filename);
+    }
+  }
+
+  private static BufferedImage getImageFromUrl(URL url) throws FileNotFoundException {
     BufferedImage originalImage;
     try {
-      originalImage =
-          ImageIO.read(new URL(GlobalProtocol.getInstance().generateAssetUrl(filename)));
+      originalImage = ImageIO.read(url);
       if (originalImage == null) {
-        // this can happen if the filename is not associated with an image
+        // this can happen if the URL is not associated with an image
         throw new MediaRuntimeException(MediaRuntimeExceptionKeys.IMAGE_LOAD_ERROR);
       }
     } catch (IOException e) {
-      throw new FileNotFoundException(filename);
+      throw new FileNotFoundException(url.toString());
     }
 
     // Resize the image to its max size while maintaining the aspect ratio.

--- a/org-code-javabuilder/media/src/main/java/org/code/media/Image.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/Image.java
@@ -165,14 +165,24 @@ public class Image {
   }
 
   /**
-   * Load the given image from a URL and return an Image object
+   * Load the given image from a media file located in content storage.
    *
-   * @param url to load the file from
+   * @param filename name of the image located in content storage
    * @return Image object
-   * @throws FileNotFoundException if the file is not found at the URL
+   * @throws FileNotFoundException if the file is not found
    */
-  public static Image fromUrl(URL url) throws FileNotFoundException {
-    return new Image(Image.getImageFromUrl(url));
+  public static Image fromMediaFile(String filename) throws FileNotFoundException {
+    // This should ideally be a constructor, but an Image constructor that takes in a String
+    // already exists, which assumes that the file name refers to a file in the asset manager.
+    // TODO: Potentially refactor how asset and media/generated files are accessed by Javabuilder
+    // into a consistent interface.
+    try {
+      return new Image(
+          Image.getImageFromUrl(
+              GlobalProtocol.getInstance().getFileManager().getFileUrl(filename)));
+    } catch (IOException e) {
+      throw new FileNotFoundException(filename);
+    }
   }
 
   /**

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/InputMessageType.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/InputMessageType.java
@@ -2,5 +2,6 @@ package org.code.protocol;
 
 public enum InputMessageType {
   SYSTEM_IN,
-  PLAYGROUND
+  PLAYGROUND,
+  THEATER
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/InputMessages.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/InputMessages.java
@@ -1,0 +1,8 @@
+package org.code.protocol;
+
+/** Various kinds of messages Javabuilder expects to receive from Javalab */
+public class InputMessages {
+  // Theater-specific messages
+  public static final String UPLOAD_SUCCESS = "UPLOAD_SUCCESS";
+  public static final String UPLOAD_ERROR = "UPLOAD_ERROR";
+}

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderFileManager.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderFileManager.java
@@ -1,5 +1,8 @@
 package org.code.protocol;
 
+import java.io.FileNotFoundException;
+import java.net.URL;
+
 /** Manages content files that are created during a Javabuilder session */
 public interface JavabuilderFileManager {
   /**
@@ -23,4 +26,13 @@ public interface JavabuilderFileManager {
    * @throws JavabuilderException if there is an issue generating the URL
    */
   String getUploadUrl(String filename) throws JavabuilderException;
+
+  /**
+   * Get the URL pointing to the specified file
+   *
+   * @param filename name of the file
+   * @return URL pointing to the file
+   * @throws FileNotFoundException if there is an issue creating the URL
+   */
+  URL getFileUrl(String filename) throws FileNotFoundException;
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
@@ -52,10 +52,9 @@ public class Prompter {
     final String statusMessage = this.inputHandler.getNextMessageForType(InputMessageType.THEATER);
     if (statusMessage.equals(UPLOAD_SUCCESS)) {
       try {
-        return Image.fromUrl(this.fileManager.getFileUrl(prompterFileName));
+        return Image.fromMediaFile(prompterFileName);
       } catch (FileNotFoundException e) {
-        // If the image was uploaded successfully, a FileNotFoundException indicates an error on our
-        // end
+        // If the image was uploaded successfully, a FileNotFoundException means an error on our end
         throw new InternalServerRuntimeError(InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION, e);
       }
     } else if (statusMessage.equals(UPLOAD_ERROR)) {

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
@@ -1,5 +1,9 @@
 package org.code.theater;
 
+import static org.code.protocol.InputMessages.UPLOAD_ERROR;
+import static org.code.protocol.InputMessages.UPLOAD_SUCCESS;
+
+import java.io.FileNotFoundException;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.code.media.Image;
@@ -11,19 +15,23 @@ public class Prompter {
 
   private final OutputAdapter outputAdapter;
   private final JavabuilderFileManager fileManager;
+  private final InputHandler inputHandler;
 
   // Used in Theater to create Prompter "singleton"
   // accessed by students.
   protected Prompter() {
     this(
         GlobalProtocol.getInstance().getOutputAdapter(),
-        GlobalProtocol.getInstance().getFileManager());
+        GlobalProtocol.getInstance().getFileManager(),
+        GlobalProtocol.getInstance().getInputHandler());
   }
 
   // Used to directly instantiate Prompter in tests.
-  protected Prompter(OutputAdapter outputAdapter, JavabuilderFileManager fileManager) {
+  protected Prompter(
+      OutputAdapter outputAdapter, JavabuilderFileManager fileManager, InputHandler inputHandler) {
     this.outputAdapter = outputAdapter;
     this.fileManager = fileManager;
+    this.inputHandler = inputHandler;
   }
 
   public Image getImage(String prompt) {
@@ -40,9 +48,21 @@ public class Prompter {
     getImageDetails.put(ClientMessageDetailKeys.UPLOAD_URL, uploadUrl);
     this.outputAdapter.sendMessage(new TheaterMessage(TheaterSignalKey.GET_IMAGE, getImageDetails));
 
-    // TO DO: get provided image from Javalab.
-    // https://codedotorg.atlassian.net/browse/CSA-936
-
-    return null;
+    // Wait for an upload status message from Javalab
+    final String statusMessage = this.inputHandler.getNextMessageForType(InputMessageType.THEATER);
+    if (statusMessage.equals(UPLOAD_SUCCESS)) {
+      try {
+        return Image.fromUrl(this.fileManager.getFileUrl(prompterFileName));
+      } catch (FileNotFoundException e) {
+        // If the image was uploaded successfully, a FileNotFoundException indicates an error on our
+        // end
+        throw new InternalServerRuntimeError(InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION, e);
+      }
+    } else if (statusMessage.equals(UPLOAD_ERROR)) {
+      throw new InternalServerRuntimeError(
+          InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION, new Exception(UPLOAD_ERROR));
+    } else {
+      throw new InternalServerRuntimeError(InternalErrorKey.UNKNOWN_ERROR);
+    }
   }
 }

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/PrompterTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/PrompterTest.java
@@ -1,38 +1,57 @@
 package org.code.theater;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.code.protocol.InputMessages.UPLOAD_ERROR;
+import static org.code.protocol.InputMessages.UPLOAD_SUCCESS;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.io.FileNotFoundException;
+import java.net.URL;
 import java.util.List;
-import org.code.protocol.ClientMessageDetailKeys;
-import org.code.protocol.JavabuilderException;
-import org.code.protocol.JavabuilderFileManager;
-import org.code.protocol.OutputAdapter;
+import org.code.media.Image;
+import org.code.protocol.*;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 
 public class PrompterTest {
   private OutputAdapter outputAdapter;
   private JavabuilderFileManager fileManager;
+  private InputHandler inputHandler;
+  private MockedStatic<Image> image;
   private Prompter unitUnderTest;
 
   @BeforeEach
   public void setUp() {
     outputAdapter = mock(OutputAdapter.class);
     fileManager = mock(JavabuilderFileManager.class);
-    unitUnderTest = new Prompter(outputAdapter, fileManager);
+    inputHandler = mock(InputHandler.class);
+    image = mockStatic(Image.class);
+    unitUnderTest = new Prompter(outputAdapter, fileManager, inputHandler);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    image.close();
   }
 
   @Test
-  public void testGetImageSendsMessageWithUploadUrl() throws JavabuilderException {
+  public void testGetImageSendsMessageWithUploadUrlAndReturnsImage()
+      throws JavabuilderException, FileNotFoundException {
     String prompt = "Upload an image please!";
     ArgumentCaptor<TheaterMessage> message = ArgumentCaptor.forClass(TheaterMessage.class);
     final String uploadUrl = "uploadUrl";
     when(fileManager.getUploadUrl(anyString())).thenReturn(uploadUrl);
+    when(inputHandler.getNextMessageForType(InputMessageType.THEATER)).thenReturn(UPLOAD_SUCCESS);
 
-    unitUnderTest.getImage(prompt);
+    final URL fileUrl = mock(URL.class);
+    when(fileManager.getFileUrl(anyString())).thenReturn(fileUrl);
+    final Image expectedImage = mock(Image.class);
+    image.when(() -> Image.fromUrl(fileUrl)).thenReturn(expectedImage);
+
+    assertSame(expectedImage, unitUnderTest.getImage(prompt));
 
     verify(outputAdapter, times(1)).sendMessage(message.capture());
     assertEquals(TheaterSignalKey.GET_IMAGE.toString(), message.getValue().getValue());
@@ -41,9 +60,14 @@ public class PrompterTest {
   }
 
   @Test
-  public void testGetImageIncrementsUploadFileName() throws JavabuilderException {
+  public void testGetImageIncrementsUploadFileName()
+      throws JavabuilderException, FileNotFoundException {
     final ArgumentCaptor<String> fileNameCaptor = ArgumentCaptor.forClass(String.class);
     when(fileManager.getUploadUrl(fileNameCaptor.capture())).thenReturn("url");
+    when(inputHandler.getNextMessageForType(InputMessageType.THEATER)).thenReturn(UPLOAD_SUCCESS);
+
+    when(fileManager.getFileUrl(anyString())).thenReturn(mock(URL.class));
+    image.when(() -> Image.fromUrl(any(URL.class))).thenReturn(mock(Image.class));
 
     unitUnderTest.getImage("prompt");
     unitUnderTest.getImage("prompt");
@@ -54,5 +78,27 @@ public class PrompterTest {
       // Each file name should have an incremented index appended to it, starting from 1
       assertTrue(fileNames.get(i).contains(Integer.toString(i + 1)));
     }
+  }
+
+  @Test
+  public void testGetImageThrowsExceptionIfUploadFails() throws JavabuilderException {
+    when(fileManager.getUploadUrl(anyString())).thenReturn("url");
+    when(inputHandler.getNextMessageForType(InputMessageType.THEATER)).thenReturn(UPLOAD_ERROR);
+
+    final Exception actual =
+        assertThrows(InternalServerRuntimeError.class, () -> unitUnderTest.getImage("prompt"));
+
+    assertEquals(InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION.toString(), actual.getMessage());
+  }
+
+  @Test
+  public void testGetImageThrowsExceptionIfUnknownMessageReceived() throws JavabuilderException {
+    when(fileManager.getUploadUrl(anyString())).thenReturn("url");
+    when(inputHandler.getNextMessageForType(InputMessageType.THEATER)).thenReturn("other message");
+
+    final Exception actual =
+        assertThrows(InternalServerRuntimeError.class, () -> unitUnderTest.getImage("prompt"));
+
+    assertEquals(InternalErrorKey.UNKNOWN_ERROR.toString(), actual.getMessage());
   }
 }

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/PrompterTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/PrompterTest.java
@@ -46,10 +46,8 @@ public class PrompterTest {
     when(fileManager.getUploadUrl(anyString())).thenReturn(uploadUrl);
     when(inputHandler.getNextMessageForType(InputMessageType.THEATER)).thenReturn(UPLOAD_SUCCESS);
 
-    final URL fileUrl = mock(URL.class);
-    when(fileManager.getFileUrl(anyString())).thenReturn(fileUrl);
     final Image expectedImage = mock(Image.class);
-    image.when(() -> Image.fromUrl(fileUrl)).thenReturn(expectedImage);
+    image.when(() -> Image.fromMediaFile(anyString())).thenReturn(expectedImage);
 
     assertSame(expectedImage, unitUnderTest.getImage(prompt));
 
@@ -67,7 +65,7 @@ public class PrompterTest {
     when(inputHandler.getNextMessageForType(InputMessageType.THEATER)).thenReturn(UPLOAD_SUCCESS);
 
     when(fileManager.getFileUrl(anyString())).thenReturn(mock(URL.class));
-    image.when(() -> Image.fromUrl(any(URL.class))).thenReturn(mock(Image.class));
+    image.when(() -> Image.fromMediaFile(anyString())).thenReturn(mock(Image.class));
 
     unitUnderTest.getImage("prompt");
     unitUnderTest.getImage("prompt");


### PR DESCRIPTION
This is the final piece of prompter uploading functionality - Javabuilder waits for a status message from Javalab, and then downloads the image and returns an Image object, or throws an exception accordingly. Note: this should only be merged after the related [Javalab change](https://github.com/code-dot-org/code-dot-org/pull/43535) has been deployed to production, so that Javalab actually sends the status messages.

JIRA (this change ended up being a little different than the JIRA description due to how the work broke down): https://codedotorg.atlassian.net/browse/CSA-1052
Javalab PR: https://github.com/code-dot-org/code-dot-org/pull/43535

Testing: tested via deployed dev instance and postman, in conjunction with localhost Javalab. After providing the upload URL to Javalab manually, I copied the outputted websocket messages to postman and confirmed that Javabuilder did consume the messages properly and take the correct action.