### PR TITLE
Enable prompter on localhost

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/CORSFilter.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/CORSFilter.java
@@ -1,0 +1,53 @@
+package dev.javabuilder;
+
+import static dev.javabuilder.LocalWebserverConstants.DIRECTORY;
+import static org.code.protocol.AllowedFileNames.PROMPTER_FILE_NAME_PREFIX;
+
+import java.io.IOException;
+import java.util.List;
+import javax.servlet.*;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A {@link HttpFilter} for local development that upgrades specific known and trusted requests by
+ * adding necessary CORS headers. In production, this is handled by S3.
+ *
+ * <p>https://www.oracle.com/java/technologies/filters.html
+ */
+@WebFilter(urlPatterns = {"/" + DIRECTORY + "/*"})
+public class CORSFilter extends HttpFilter {
+
+  private static final List<String> ALLOWED_ORIGINS =
+      List.of("http://localhost-studio.code.org:3000", "http://127.0.0.1:3000");
+
+  @Override
+  public void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    final String requestOrigin = request.getHeader("Origin");
+    if (requestOrigin == null || !ALLOWED_ORIGINS.contains(requestOrigin)) {
+      // May be an internal request or an unknown origin. Pass along the request without adding any
+      // headers.
+      chain.doFilter(request, response);
+      return;
+    }
+
+    final String[] urlParts = request.getRequestURI().split("/");
+    final String fileName = urlParts[urlParts.length - 1];
+    if (fileName.indexOf(PROMPTER_FILE_NAME_PREFIX) == 0) {
+      // Add CORS headers only if the request is for a known file
+      response.addHeader("Access-Control-Allow-Origin", requestOrigin);
+      response.addHeader("Access-Control-Allow-Headers", "*");
+      response.addHeader("Access-Control-Allow-Methods", "GET, OPTIONS, PUT");
+    }
+
+    if (request.getMethod().equals("OPTIONS")) {
+      response.setStatus(HttpServletResponse.SC_ACCEPTED);
+      return;
+    }
+
+    chain.doFilter(request, response);
+  }
+}

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/AllowedFileNames.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/AllowedFileNames.java
@@ -3,4 +3,5 @@ package org.code.protocol;
 public class AllowedFileNames {
   public static final String THEATER_IMAGE_NAME = "theaterImage.gif";
   public static final String THEATER_AUDIO_NAME = "theaterAudio.wav";
+  public static final String PROMPTER_FILE_NAME_PREFIX = "prompterImage-";
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
@@ -1,5 +1,6 @@
 package org.code.theater;
 
+import static org.code.protocol.AllowedFileNames.PROMPTER_FILE_NAME_PREFIX;
 import static org.code.protocol.InputMessages.UPLOAD_ERROR;
 import static org.code.protocol.InputMessages.UPLOAD_SUCCESS;
 
@@ -10,7 +11,6 @@ import org.code.media.Image;
 import org.code.protocol.*;
 
 public class Prompter {
-  private static final String FILE_NAME_PREFIX = "prompterImage-";
   private static final AtomicInteger FILE_INDEX = new AtomicInteger(0);
 
   private final OutputAdapter outputAdapter;
@@ -35,7 +35,7 @@ public class Prompter {
   }
 
   public Image getImage(String prompt) {
-    final String prompterFileName = FILE_NAME_PREFIX + FILE_INDEX.incrementAndGet();
+    final String prompterFileName = PROMPTER_FILE_NAME_PREFIX + FILE_INDEX.incrementAndGet();
     final String uploadUrl;
     try {
       uploadUrl = this.fileManager.getUploadUrl(prompterFileName);


### PR DESCRIPTION
This enables localhost file uploads in order to use Prompter on localhost. Specifically, this adds a `doPut` route to our existing localhost `HttpFileServer` as well as an `HttpFilter` that's necessary for adding CORS headers. 
One callout is that I changed the url patterns that our local file server matches from theater specific URLs to any URL at `localhost:8080/javabuilderfiles/*`. This is because we can't use wildcards to match partial url paths (can't do something like `prompterImage-*`) and all prompter images are suffixed with an index. We could in theory enumerate all prompter paths (current limit is 20) but we'd have to update this any time we change the limit, so I figured this would be simpler. The doPut and doGet methods also have internal validation and will reject requests with a 403 error if path is invalid (if it's not a GET request for a theater or prompter file, or if it's not a PUT request for a prompter file).

JIRA: https://codedotorg.atlassian.net/browse/CSA-1058

Tested locally with All the Things