### PR TITLE
Show invalid class message for tests

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavabuilderTestExecutionListener.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavabuilderTestExecutionListener.java
@@ -172,7 +172,7 @@ public class JavabuilderTestExecutionListener extends SummaryGeneratingListener 
       if (className != null) {
         // the message will be the name of the invalid class, with '.' replaced by '/'.
         className = className.replace('/', '.');
-        return className + " is not supported.";
+        return className + " is not supported";
       }
     }
     return "";

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavabuilderTestExecutionListener.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavabuilderTestExecutionListener.java
@@ -126,11 +126,9 @@ public class JavabuilderTestExecutionListener extends SummaryGeneratingListener 
     } else {
       String additionalMessage = this.getAdditionalErrorMessage(throwable);
       errorMessage =
-          String.format("\t%s thrown at %s", this.getThrowableDisplayName(throwable), errorLine);
+          String.format("\t%s thrown at %s\n", this.getThrowableDisplayName(throwable), errorLine);
       if (additionalMessage != null) {
-        errorMessage = String.format("%s. %s\n", errorMessage, additionalMessage);
-      } else {
-        errorMessage += "\n";
+        errorMessage = String.format("%s \t%s\n", errorMessage, additionalMessage);
       }
     }
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavabuilderTestExecutionListener.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavabuilderTestExecutionListener.java
@@ -156,7 +156,7 @@ public class JavabuilderTestExecutionListener extends SummaryGeneratingListener 
     // A NoClassDefFoundError occurs when a user uses a disallowed class. We should
     // instead show a ClassNotFoundException.
     if (throwable instanceof NoClassDefFoundError) {
-      return "ClassNotFoundException";
+      return ClassNotFoundException.class.getSimpleName();
     } else {
       return throwable.getClass().getSimpleName();
     }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavabuilderTestExecutionListener.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavabuilderTestExecutionListener.java
@@ -173,6 +173,6 @@ public class JavabuilderTestExecutionListener extends SummaryGeneratingListener 
         return className + " is not supported";
       }
     }
-    return "";
+    return null;
   }
 }


### PR DESCRIPTION
This PR properly handles the upcoming invalid class exception thrown by the custom class loader when running tests (currently merged in silent mode). The exception will be thrown as a `NoClassDefFoundError`, but we want to surface it to the end user as a `ClassNotFoundException`, with a message that the class is not supported. The new error will look like this on the javalab side:
![Screen Shot 2021-11-19 at 1 47 40 PM](https://user-images.githubusercontent.com/33666587/142701239-2c9a1577-d6e5-400b-8f63-36799ba42b7b.png)

