### PR TITLE
Increased memory to maximum single thread memory for Lambdas

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -277,7 +277,7 @@ Resources:
       ProvisionedConcurrencyConfig:
         ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
       Description: Compile and execute a JavaLab project.
-      MemorySize: 1024
+      MemorySize: 1769
       Timeout: 300
       Role:
         Fn::ImportValue: JavabuilderLambdaExecutionRole


### PR DESCRIPTION
Students and teachers have been asking for faster execution of Theater projects. This changes increases our Lambda memory to the highest available for single-threaded execution: 1769MB. With our small usage right now, this will lead to a daily cost increase from ~$2.51 to $3.04-$4.33 on high usage days with ~150 million ms of use. It will lead to a ~30% performance improvement for Theater projects.

Eventually, we will want to select memory and expiration time based on the type of mini-app running.

Additional details here: [Customizing Lambda Configuration Per Mini-App](https://docs.google.com/document/d/1cWpdw5vJkmgdcw4yLg1EO4vM5N3a8M4AtzroPK52j9E/edit#)