### PR TITLE
Unify checks for .java extension in Javabuilder

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/FileNameUtils.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/FileNameUtils.java
@@ -1,0 +1,17 @@
+package org.code.javabuilder;
+
+/** Convenience methods for handling file names */
+public class FileNameUtils {
+  public static final String JAVA_EXTENSION = ".java";
+
+  /**
+   * Whether the given file name is a valid Java file name. Must end with ".java" and have at least
+   * one character before the extension.
+   *
+   * @param fileName file name to check
+   * @return whether the file name is a valid Java file name
+   */
+  public static boolean isJavaFile(String fileName) {
+    return fileName.endsWith(JAVA_EXTENSION) && fileName.indexOf(JAVA_EXTENSION) > 0;
+  }
+}

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavaProjectFile.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavaProjectFile.java
@@ -8,8 +8,8 @@ public class JavaProjectFile implements ProjectFile {
 
   public JavaProjectFile(String fileName) throws UserInitiatedException {
     this.fileName = fileName;
-    if (fileName.endsWith(".java")) {
-      this.className = fileName.substring(0, fileName.indexOf(".java"));
+    if (FileNameUtils.isJavaFile(fileName)) {
+      this.className = fileName.substring(0, fileName.indexOf(FileNameUtils.JAVA_EXTENSION));
     } else {
       throw new UserInitiatedException(UserInitiatedExceptionKey.JAVA_EXTENSION_MISSING);
     }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserProjectFileParser.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserProjectFileParser.java
@@ -29,7 +29,7 @@ public class UserProjectFileParser {
       for (String fileName : sources.keySet()) {
         UserFileData fileData = sources.get(fileName);
 
-        if (fileName.endsWith(".java")) {
+        if (FileNameUtils.isJavaFile(fileName)) {
           userProjectFiles.addJavaFile(new JavaProjectFile(fileName, fileData.getText()));
         } else {
           // we treat any non-Java file as a plain text file

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/FileNameUtilsTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/FileNameUtilsTest.java
@@ -1,0 +1,23 @@
+package org.code.javabuilder;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class FileNameUtilsTest {
+
+  @Test
+  public void testIsJavaFile() {
+    String fileName = "MyClass.java";
+    assertTrue(FileNameUtils.isJavaFile(fileName));
+
+    fileName = ".java"; // At least one character before extension is required
+    assertFalse(FileNameUtils.isJavaFile(fileName));
+
+    fileName = "MyClass.txt"; // Java extension required
+    assertFalse(FileNameUtils.isJavaFile(fileName));
+
+    fileName = "MyClass.Java"; // Java extension must be lowercase
+    assertFalse(FileNameUtils.isJavaFile(fileName));
+  }
+}


### PR DESCRIPTION
Moves checks for the `.java` extension to a single util class.

JIRA: https://codedotorg.atlassian.net/browse/CSA-873

Testing: unit + checked locally that user experience is unchanged