### PR TITLE
Close gif writer to clean up disk resources

### DIFF
--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
@@ -65,6 +65,7 @@ class GifWriter {
     try {
       this.writer.endWriteSequence();
       this.imageOutputStream.flush();
+      this.imageOutputStream.close();
     } catch (IOException e) {
       throw new InternalServerRuntimeError(
           InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION, e.getCause());


### PR DESCRIPTION
(Fix for a urgent issue. More details coming Monday)