### PR TITLE
Log identifier for lambda containers

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaLogHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaLogHandler.java
@@ -12,6 +12,7 @@ public class LambdaLogHandler extends Handler {
   private final String sessionId;
   private final String connectionId;
   private final String levelId;
+  private final String containerId;
   private final String channelId;
 
   public LambdaLogHandler(
@@ -19,11 +20,13 @@ public class LambdaLogHandler extends Handler {
       String sessionId,
       String connectionId,
       String levelId,
+      String containerId,
       String channelId) {
     this.logger = logger;
     this.sessionId = sessionId;
     this.connectionId = connectionId;
     this.levelId = levelId;
+    this.containerId = containerId;
     this.channelId = channelId;
   }
 
@@ -33,6 +36,7 @@ public class LambdaLogHandler extends Handler {
     sessionMetadata.put(LoggerConstants.SESSION_ID, this.sessionId);
     sessionMetadata.put(LoggerConstants.CONNECTION_ID, this.connectionId);
     sessionMetadata.put(LoggerConstants.LEVEL_ID, this.levelId);
+    sessionMetadata.put(LoggerConstants.CONTAINER_ID, this.containerId);
     sessionMetadata.put(LoggerConstants.CHANNEL_ID, this.channelId);
 
     JSONObject logData = new JSONObject();

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -67,6 +67,8 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
         JSONUtils.booleanFromJSONObjectMember(options, "useNeighborhood");
     final List<String> compileList = JSONUtils.listFromJSONObjectMember(options, "compileList");
 
+    // Generate an identifier that persists across uses of the same lambda container
+    // if one has not yet been created. Used for logging purposes.
     if (LambdaRequestHandler.LAMBDA_ID.equals("")) {
       LambdaRequestHandler.LAMBDA_ID = UUID.randomUUID().toString();
     }
@@ -172,13 +174,6 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
       // no-op if we have an interrupted exception, as it happened due to a user ending their
       // program.
     } finally {
-      try {
-        Path toClear = Paths.get(System.getProperty("java.io.tmpdir"));
-        LoggerUtils.sendDiskSpaceLogs();
-        Util.recursivelyClearDirectory(toClear);
-        LoggerUtils.sendClearedDirectoryLog(toClear);
-        LoggerUtils.sendDiskSpaceLogs();
-      } catch (IOException e) {}
       cleanUpResources(connectionId, api);
     }
     return "done";

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -19,12 +19,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
 import org.code.protocol.*;
 import org.json.JSONObject;
-
-import java.util.UUID;
 
 /**
  * This is the entry point for the lambda function. This should be thought of as similar to a main
@@ -36,7 +35,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
   private static final int CHECK_THREAD_INTERVAL_MS = 500;
   private static final int TIMEOUT_WARNING_MS = 20000;
   private static final int TIMEOUT_CLEANUP_BUFFER_MS = 5000;
-  private static String LAMBDA_ID = "";
+  private static final String LAMBDA_ID = UUID.randomUUID().toString();
   /**
    * This is the implementation of the long-running-lambda where user code will be compiled and
    * executed.
@@ -67,16 +66,15 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
         JSONUtils.booleanFromJSONObjectMember(options, "useNeighborhood");
     final List<String> compileList = JSONUtils.listFromJSONObjectMember(options, "compileList");
 
-    // Generate an identifier that persists across uses of the same lambda container
-    // if one has not yet been created. Used for logging purposes.
-    if (LambdaRequestHandler.LAMBDA_ID.equals("")) {
-      LambdaRequestHandler.LAMBDA_ID = UUID.randomUUID().toString();
-    }
-
     Logger logger = Logger.getLogger(MAIN_LOGGER);
     logger.addHandler(
         new LambdaLogHandler(
-            context.getLogger(), javabuilderSessionId, connectionId, levelId, LambdaRequestHandler.LAMBDA_ID, channelId));
+            context.getLogger(),
+            javabuilderSessionId,
+            connectionId,
+            levelId,
+            LambdaRequestHandler.LAMBDA_ID,
+            channelId));
     // turn off the default console logger
     logger.setUseParentHandlers(false);
 

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerConstants.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerConstants.java
@@ -9,6 +9,7 @@ public class LoggerConstants {
   public static final String SESSION_ID = "sessionId";
   public static final String LEVEL = "level";
   public static final String LEVEL_ID = "levelId";
+  public static final String CONTAINER_ID = "containerId";
   public static final String CONNECTION_ID = "connectionId";
   public static final String CHANNEL_ID = "channelId";
   public static final String SESSION_METADATA = "sessionMetadata";


### PR DESCRIPTION
Adds a persistent identifier for lambda containers to our logging.

Jessie remembered reading that the request handler persists across the lifetime of a lambda container (~~we can't find the source of this information~~ check out initialization code section [here for more information](https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html)), so that is where we implemented this change.

We did try to prove it out by the following though:
- repeated runs of the same program on a dev deploy return the same UUID (as verified via Postman)
- if one program is executing (ie, by putting a wait in such that the program does not complete its execution), executing another program returns a different UUID

This change should log the container ID any time we log to cloudwatch.