### PR TITLE
Reorganize disk space logs

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilder.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilder.java
@@ -97,9 +97,9 @@ public class CodeBuilder implements AutoCloseable {
     if (this.tempFolder != null) {
       try {
         // Clean up the temp folder and temp directory
-        LoggerUtils.sendDiskSpaceUpdate(SessionTime.START_SESSION, ClearStatus.BEFORE_CLEAR);
+        LoggerUtils.sendDiskSpaceUpdate(SessionTime.END_SESSION, ClearStatus.BEFORE_CLEAR);
         this.fileManager.cleanUpTempDirectory(this.tempFolder);
-        LoggerUtils.sendDiskSpaceUpdate(SessionTime.START_SESSION, ClearStatus.AFTER_CLEAR);
+        LoggerUtils.sendDiskSpaceUpdate(SessionTime.END_SESSION, ClearStatus.AFTER_CLEAR);
       } catch (IOException e) {
         throw new InternalFacingException(e.toString(), e);
       }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilder.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilder.java
@@ -6,6 +6,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import org.code.protocol.*;
+import org.code.protocol.LoggerUtils.ClearStatus;
+import org.code.protocol.LoggerUtils.SessionTime;
 
 /** The orchestrator for code compilation and execution. */
 public class CodeBuilder implements AutoCloseable {
@@ -95,7 +97,9 @@ public class CodeBuilder implements AutoCloseable {
     if (this.tempFolder != null) {
       try {
         // Clean up the temp folder and temp directory
+        LoggerUtils.sendDiskSpaceUpdate(SessionTime.START_SESSION, ClearStatus.BEFORE_CLEAR);
         this.fileManager.cleanUpTempDirectory(this.tempFolder);
+        LoggerUtils.sendDiskSpaceUpdate(SessionTime.START_SESSION, ClearStatus.AFTER_CLEAR);
       } catch (IOException e) {
         throw new InternalFacingException(e.toString(), e);
       }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -21,6 +21,8 @@ import java.util.UUID;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
 import org.code.protocol.*;
+import org.code.protocol.LoggerUtils.ClearStatus;
+import org.code.protocol.LoggerUtils.SessionTime;
 import org.json.JSONObject;
 
 /**
@@ -110,7 +112,12 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     props.put("sun.awt.fontconfig", "/opt/fontconfig.properties");
 
     try {
+      // Log disk space before clearing the directory
+      LoggerUtils.sendDiskSpaceReport();
+
+      LoggerUtils.sendDiskSpaceUpdate(SessionTime.START_SESSION, ClearStatus.BEFORE_CLEAR);
       fileManager.cleanUpTempDirectory(null);
+      LoggerUtils.sendDiskSpaceUpdate(SessionTime.START_SESSION, ClearStatus.AFTER_CLEAR);
     } catch (IOException e) {
       // Wrap this in our error type so we can log it and tell the user.
       InternalServerError error = new InternalServerError(INTERNAL_EXCEPTION, e);

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/Util.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/Util.java
@@ -49,9 +49,7 @@ public class Util {
   }
 
   public static void recursivelyClearDirectory(Path directory) throws IOException {
-    LoggerUtils.sendDiskSpaceLogs();
     Files.walk(directory).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
     LoggerUtils.sendClearedDirectoryLog(directory);
-    LoggerUtils.sendDiskSpaceLogs();
   }
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerUtils.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerUtils.java
@@ -9,21 +9,66 @@ import java.util.logging.Logger;
 import org.json.JSONObject;
 
 public class LoggerUtils {
-  public static void sendDiskSpaceLogs() {
-    File f = Paths.get(System.getProperty("java.io.tmpdir")).toFile();
-    JSONObject eventData = new JSONObject();
-    eventData.put(LoggerConstants.TYPE, "diskSpaceUtilization");
-    eventData.put(LoggerConstants.DIRECTORY, f.getPath());
-    eventData.put(LoggerConstants.USABLE_SPACE, f.getUsableSpace());
-    eventData.put(LoggerConstants.FREE_SPACE, f.getFreeSpace());
-    eventData.put(LoggerConstants.TOTAL_SPACE, f.getTotalSpace());
-    Logger.getLogger(MAIN_LOGGER).info(eventData.toString());
+  private static final String DISK_SPACE_LOG_TYPE = "diskSpaceUtilization";
+
+  public enum SessionTime {
+    START_SESSION("startSession"),
+    END_SESSION("endSession");
+
+    String metricName;
+
+    SessionTime(String name) {
+      this.metricName = name;
+    }
+  }
+
+  public enum ClearStatus {
+    BEFORE_CLEAR("beforeClear"),
+    AFTER_CLEAR("afterClear");
+
+    String metricName;
+
+    ClearStatus(String name) {
+      this.metricName = name;
+    }
+  }
+
+  /**
+   * Logs metrics describing the total, free, and usable disk space in the temp directory. Meant to
+   * be published once per session.
+   */
+  public static void sendDiskSpaceReport() {
+    LoggerUtils.sendDiskSpaceLogs(DISK_SPACE_LOG_TYPE);
+  }
+
+  /**
+   * Logs an update describing the disk space in the temp directory. This update can be published at
+   * various times per session, described by {@link SessionTime} and {@link ClearStatus}
+   *
+   * @param sessionTime the time in the session this update occurred
+   * @param clearStatus whether this update happened before or after the directory was cleared
+   */
+  public static void sendDiskSpaceUpdate(SessionTime sessionTime, ClearStatus clearStatus) {
+    final String type =
+        DISK_SPACE_LOG_TYPE + "-" + sessionTime.metricName + "-" + clearStatus.metricName;
+    LoggerUtils.sendDiskSpaceLogs(type);
   }
 
   public static void sendClearedDirectoryLog(Path p) {
     JSONObject eventData = new JSONObject();
     eventData.put(LoggerConstants.TYPE, "clearedDirectory");
     eventData.put(LoggerConstants.DIRECTORY, p.toFile().getPath());
+    Logger.getLogger(MAIN_LOGGER).info(eventData.toString());
+  }
+
+  private static void sendDiskSpaceLogs(String type) {
+    File f = Paths.get(System.getProperty("java.io.tmpdir")).toFile();
+    JSONObject eventData = new JSONObject();
+    eventData.put(LoggerConstants.TYPE, type);
+    eventData.put(LoggerConstants.DIRECTORY, f.getPath());
+    eventData.put(LoggerConstants.USABLE_SPACE, f.getUsableSpace());
+    eventData.put(LoggerConstants.FREE_SPACE, f.getFreeSpace());
+    eventData.put(LoggerConstants.TOTAL_SPACE, f.getTotalSpace());
     Logger.getLogger(MAIN_LOGGER).info(eventData.toString());
   }
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
@@ -65,7 +65,7 @@ class GifWriter {
     try {
       this.writer.endWriteSequence();
       this.imageOutputStream.flush();
-      // this.imageOutputStream.close();
+      this.imageOutputStream.close();
     } catch (IOException e) {
       throw new InternalServerRuntimeError(
           InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION, e.getCause());

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
@@ -65,7 +65,7 @@ class GifWriter {
     try {
       this.writer.endWriteSequence();
       this.imageOutputStream.flush();
-      this.imageOutputStream.close();
+      // this.imageOutputStream.close();
     } catch (IOException e) {
       throw new InternalServerRuntimeError(
           InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION, e.getCause());


### PR DESCRIPTION
Reorganizes how we log disk space slightly. Now, only one disk space log report (type: `"diskSpaceUtilization"`) is sent at the start of each session. However, we still do also log before and after clearing the temp directory at the start and end of the session, but these have more specific metric types (ex. `"diskSpaceUtilization-startSession-afterClear"`). This way, our existing metrics and graphs will still work but now just go off of the report published at the beginning of the session, and the other metrics are available to us for further analysis.

Tested on dev lambda.