### PR TITLE
Log mini-app type

### DIFF
--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -46,6 +46,7 @@ def on_connect(event, context)
     :options => authorizer["options"],
     :iss => authorizer["iss"],
     :channelId => authorizer["channel_id"],
+    :miniAppType => authorizer["mini_app_type"],
     :javabuilderSessionId => authorizer['sid'],
     :queueName => queue_name,
     :executionType => authorizer['execution_type']

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalLogHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalLogHandler.java
@@ -10,11 +10,14 @@ public class LocalLogHandler extends Handler {
   private final PrintStream logStream;
   private final String levelId;
   private final String channelId;
+  private final String miniAppType;
 
-  public LocalLogHandler(PrintStream logStream, String levelId, String channelId) {
+  public LocalLogHandler(
+      PrintStream logStream, String levelId, String channelId, String miniAppType) {
     this.logStream = logStream;
     this.levelId = levelId;
     this.channelId = channelId;
+    this.miniAppType = miniAppType;
   }
 
   @Override
@@ -22,6 +25,7 @@ public class LocalLogHandler extends Handler {
     JSONObject sessionMetadata = new JSONObject();
     sessionMetadata.put("levelId", this.levelId);
     sessionMetadata.put("channelId", this.channelId);
+    sessionMetadata.put("miniAppType", this.miniAppType);
 
     JSONObject logData = new JSONObject();
     logData.put("sessionMetadata", sessionMetadata);

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
@@ -18,7 +18,7 @@ public class LocalMain {
     final LocalProjectFileLoader fileLoader = new LocalProjectFileLoader();
 
     Logger logger = Logger.getLogger(MAIN_LOGGER);
-    logger.addHandler(new LocalLogHandler(System.out, "levelId", "channelId"));
+    logger.addHandler(new LocalLogHandler(System.out, "levelId", "channelId", "miniAppType"));
     // turn off the default console logger
     logger.setUseParentHandlers(false);
 

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -52,6 +52,7 @@ public class WebSocketServer {
     final String connectionId = "LocalhostWebSocketConnection";
     final String levelId = queryInput.getString("level_id");
     final String channelId = queryInput.getString("channel_id");
+    final String miniAppType = queryInput.getString("mini_app_type");
     final ExecutionType executionType =
         ExecutionType.valueOf(queryInput.getString("execution_type"));
     final String dashboardHostname = "http://" + queryInput.get("iss") + ":3000";
@@ -61,7 +62,7 @@ public class WebSocketServer {
     final List<String> compileList = JSONUtils.listFromJSONObjectMember(options, "compileList");
 
     this.logger = Logger.getLogger(MAIN_LOGGER);
-    this.logHandler = new LocalLogHandler(System.out, levelId, channelId);
+    this.logHandler = new LocalLogHandler(System.out, levelId, channelId, miniAppType);
     this.logger.addHandler(this.logHandler);
     // turn off the default console logger
     this.logger.setUseParentHandlers(false);

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaLogHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaLogHandler.java
@@ -14,6 +14,7 @@ public class LambdaLogHandler extends Handler {
   private final String levelId;
   private final String containerId;
   private final String channelId;
+  private final String miniAppType;
 
   public LambdaLogHandler(
       LambdaLogger logger,
@@ -21,13 +22,15 @@ public class LambdaLogHandler extends Handler {
       String connectionId,
       String levelId,
       String containerId,
-      String channelId) {
+      String channelId,
+      String miniAppType) {
     this.logger = logger;
     this.sessionId = sessionId;
     this.connectionId = connectionId;
     this.levelId = levelId;
     this.containerId = containerId;
     this.channelId = channelId;
+    this.miniAppType = miniAppType;
   }
 
   @Override
@@ -38,6 +41,7 @@ public class LambdaLogHandler extends Handler {
     sessionMetadata.put(LoggerConstants.LEVEL_ID, this.levelId);
     sessionMetadata.put(LoggerConstants.CONTAINER_ID, this.containerId);
     sessionMetadata.put(LoggerConstants.CHANNEL_ID, this.channelId);
+    sessionMetadata.put(LoggerConstants.MINI_APP_TYPE, this.miniAppType);
 
     JSONObject logData = new JSONObject();
     logData.put(LoggerConstants.SESSION_METADATA, sessionMetadata);

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -54,6 +54,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     final String queueName = lambdaInput.get("queueName");
     final String levelId = lambdaInput.get("levelId");
     final String channelId = lambdaInput.get("channelId");
+    final String miniAppType = lambdaInput.get("miniAppType");
     final ExecutionType executionType = ExecutionType.valueOf(lambdaInput.get("executionType"));
     final String dashboardHostname = "https://" + lambdaInput.get("iss");
     final JSONObject options = new JSONObject(lambdaInput.get("options"));
@@ -72,7 +73,8 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
             connectionId,
             levelId,
             LambdaRequestHandler.LAMBDA_ID,
-            channelId));
+            channelId,
+            miniAppType));
     // turn off the default console logger
     logger.setUseParentHandlers(false);
 

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerConstants.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerConstants.java
@@ -12,6 +12,7 @@ public class LoggerConstants {
   public static final String CONTAINER_ID = "containerId";
   public static final String CONNECTION_ID = "connectionId";
   public static final String CHANNEL_ID = "channelId";
+  public static final String MINI_APP_TYPE = "miniAppType";
   public static final String SESSION_METADATA = "sessionMetadata";
   public static final String DIRECTORY = "directory";
   public static final String USABLE_SPACE = "usableSpace";


### PR DESCRIPTION
Logs the mini-app type (provided by the client) from which a Javabuilder execution took place.

Tested locally and via dev deploy.

**Local logging**
```
{"level":"INFO","sessionMetadata":{"levelId":"37579","miniAppType":"console","channelId":"gq9jKZt7PfZOit_I12GfJA"},"message":{"freeSpace":184570527744,"usableSpace":146448453632,"totalSpace":494384795648,"type":"diskSpaceUtilization","directory":"/var/folders/xp/9jb41z0n0y1fc7c_g45tgsqc0000gn/T"}}
{"level":"INFO","sessionMetadata":{"levelId":"37579","miniAppType":"console","channelId":"gq9jKZt7PfZOit_I12GfJA"},"message":{"type":"clearedDirectory","directory":"/var/folders/xp/9jb41z0n0y1fc7c_g45tgsqc0000gn/T/tmpdir9036047314468254371"}}
{"level":"INFO","sessionMetadata":{"levelId":"37579","miniAppType":"console","channelId":"gq9jKZt7PfZOit_I12GfJA"},"message":{"freeSpace":184570531840,"usableSpace":146448457728,"totalSpace":494384795648,"type":"diskSpaceUtilization","directory":"/var/folders/xp/9jb41z0n0y1fc7c_g45tgsqc0000gn/T"}}
{"level":"INFO","sessionMetadata":{"levelId":"37579","miniAppType":"console","channelId":"gq9jKZt7PfZOit_I12GfJA"},"message":"WebSocket Closed"}
```

**CloudWatch logs for my dev deploy**
![image](https://user-images.githubusercontent.com/25372625/146083538-e5d2efa1-379e-4c68-b48f-5a3528c730b6.png)


Should not be merged until staging-next work ([specifically, this PR](https://github.com/code-dot-org/code-dot-org/pull/43871/files)) has been deployed to production.