### PR TITLE
Added error message when a theater project's output is longer than 120s

### DIFF
--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -414,6 +414,7 @@ public class Stage {
     if (this.hasPlayed) {
       throw new TheaterRuntimeException(ExceptionKeys.DUPLICATE_PLAY_COMMAND);
     } else {
+      this.outputAdapter.sendMessage(new StatusMessage(StatusMessageKey.GENERATING_RESULTS));
       this.progressPublisher.onPlay(this.audioWriter.getTotalAudioLength());
       this.gifWriter.writeToGif(this.image, 0);
       this.gifWriter.close();

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/TheaterProgressPublisher.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/TheaterProgressPublisher.java
@@ -9,6 +9,7 @@ import org.code.protocol.*;
  */
 class TheaterProgressPublisher {
   private static final double UPDATE_TIME_S = 5.0;
+  private static final double MAX_TIME_S = 120.0;
 
   private final OutputAdapter outputAdapter;
   private double pauseTimeSeconds;
@@ -26,6 +27,13 @@ class TheaterProgressPublisher {
 
   public void onPause(double seconds) {
     this.pauseTimeSeconds += seconds;
+    if (this.pauseTimeSeconds > MAX_TIME_S) {
+      String message =
+          "Your video is longer than "
+              + MAX_TIME_S
+              + " seconds. Decrease the length of your video and try again.";
+      throw new RuntimeException(message);
+    }
 
     if (this.pauseTimeSeconds - this.lastUpdateTimeSeconds >= UPDATE_TIME_S) {
       this.publishProgress();


### PR DESCRIPTION
This adds on to a [change](https://github.com/code-dot-org/javabuilder/pull/163) that logs a message to the user after every 5s of theater output generated. 

Here, we hook in to the onPause method. If a project will add more than 120s to its output, it will trigger an error.

Currently, the error is not translatable. This is because we're trying to get this out as an urgent fix for the disk space issue. As a follow-up, we should add a translated version of this error on the client side.

This change also adds back in the "Generating results..." message - this will allow us to merge and deploy the Javabuilder changes prior to the dashboard changes. As a follow-up, we should remove this message.

Error output:
![image](https://user-images.githubusercontent.com/8324574/146279123-985b0e40-aec0-4c8d-a863-901c7644d0b8.png)

Success output:
![image](https://user-images.githubusercontent.com/8324574/146279167-df8bb423-b9fc-4925-a6b3-133dd6c9bae9.png)

Note: The above output includes the message to the user after every 5s of Theater output generated. This has not been merged into production yet. Currently, the output would look like this:

Error output:
![image](https://user-images.githubusercontent.com/8324574/146279589-619825cb-61a4-4f93-8010-0aade2a753d8.png)


Success output:
![image](https://user-images.githubusercontent.com/8324574/146279517-81ec613a-4ac8-4ebe-a9fe-1d0d22f76882.png)


