### PR TITLE
Limit size of theater gifs

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSFileManager.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSFileManager.java
@@ -1,7 +1,5 @@
 package org.code.javabuilder;
 
-import static org.code.protocol.LoggerNames.MAIN_LOGGER;
-
 import com.amazonaws.AbortedException;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.SdkClientException;
@@ -16,9 +14,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Date;
-import java.util.logging.Logger;
 import org.code.protocol.*;
-import org.json.JSONObject;
 
 public class AWSFileManager implements JavabuilderFileManager {
   private final String outputBucketName;
@@ -72,16 +68,6 @@ public class AWSFileManager implements JavabuilderFileManager {
     }
 
     this.writes++;
-    try {
-      inputStream.close();
-    } catch (IOException e) {
-      // We could not close the stream. This won't affect the user but may affect us, so we log it
-      // as a severe error.
-      JSONObject eventData = new JSONObject();
-      eventData.put(LoggerConstants.EXCEPTION_MESSAGE, e.getMessage());
-      eventData.put(LoggerConstants.TYPE, "streamCloseError");
-      Logger.getLogger(MAIN_LOGGER).severe(eventData.toString());
-    }
     return this.getOutputURL + "/" + filePath;
   }
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSFileManager.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSFileManager.java
@@ -1,5 +1,7 @@
 package org.code.javabuilder;
 
+import static org.code.protocol.LoggerNames.MAIN_LOGGER;
+
 import com.amazonaws.AbortedException;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.SdkClientException;
@@ -14,7 +16,9 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Date;
+import java.util.logging.Logger;
 import org.code.protocol.*;
+import org.json.JSONObject;
 
 public class AWSFileManager implements JavabuilderFileManager {
   private final String outputBucketName;
@@ -68,6 +72,16 @@ public class AWSFileManager implements JavabuilderFileManager {
     }
 
     this.writes++;
+    try {
+      inputStream.close();
+    } catch (IOException e) {
+      // We could not close the stream. This won't affect the user but may affect us, so we log it
+      // as a severe error.
+      JSONObject eventData = new JSONObject();
+      eventData.put(LoggerConstants.EXCEPTION_MESSAGE, e.getMessage());
+      eventData.put(LoggerConstants.TYPE, "streamCloseError");
+      Logger.getLogger(MAIN_LOGGER).severe(eventData.toString());
+    }
     return this.getOutputURL + "/" + filePath;
   }
 

--- a/org-code-javabuilder/media/src/main/java/org/code/media/AudioWriter.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/AudioWriter.java
@@ -71,7 +71,7 @@ public class AudioWriter {
    * Writes the raw audio data in audioSamples to audioOutputStream in a valid audio file format and
    * closes output streams.
    */
-  public void writeToAudioStreamAndClose() {
+  public void writeToAudioStream() {
     if (this.audioSamples.length == 0) {
       // Add a silent audio sample so we can build a valid wav file.
       // TODO: Send a "No audio" signal instead
@@ -81,7 +81,9 @@ public class AudioWriter {
     AudioUtils.writeBytesToOutputStream(
         AudioUtils.convertDoubleArrayToByteArray(this.audioSamples), this.audioOutputStream);
     this.currentSampleIndex = 0;
+  }
 
+  public void close() {
     try {
       this.audioOutputStream.close();
     } catch (IOException e) {

--- a/org-code-javabuilder/media/src/test/java/org/code/media/AudioWriterTest.java
+++ b/org-code-javabuilder/media/src/test/java/org/code/media/AudioWriterTest.java
@@ -10,7 +10,8 @@ public class AudioWriterTest {
   public void testWriteAddsSilentSoundIfEmpty() {
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
     AudioWriter writer = new AudioWriter(stream);
-    writer.writeToAudioStreamAndClose();
+    writer.writeToAudioStream();
+    writer.close();
     byte[] result = stream.toByteArray();
     // The length is 46 because there is a lot of metadata before the data begins. The data are
     // zeros because we add in a single silent sound sample.
@@ -24,7 +25,8 @@ public class AudioWriterTest {
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
     AudioWriter writer = new AudioWriter(stream);
     writer.writeAudioSamples(new double[] {1});
-    writer.writeToAudioStreamAndClose();
+    writer.writeToAudioStream();
+    writer.close();
     byte[] result = stream.toByteArray();
     // The exact values don't matter so much as ensuring they are something specific and not zero.
     // The length is 46 because there is a lot of metadata before the data begins.

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
@@ -51,6 +51,7 @@ class GifWriter {
   public void writeToGif(BufferedImage img, int delay) {
     try {
       if (this.imageOutputStream.length() > MAX_STREAM_LENGTH_BYTES) {
+        // TODO: Remove this once we have a clean up notifier for stage.
         Theater.stage.close();
         // TODO: Make this translatable: https://codedotorg.atlassian.net/browse/CSA-1108
         String message =

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
@@ -19,6 +19,8 @@ class GifWriter {
   private ImageWriter writer;
   private ImageWriteParam params;
   private ImageOutputStream imageOutputStream;
+  // 30 mb
+  private static final int MAX_STREAM_LENGTH_BYTES = 31457280;
 
   public static class Factory {
     public GifWriter createGifWriter(ByteArrayOutputStream out) {
@@ -48,6 +50,13 @@ class GifWriter {
    */
   public void writeToGif(BufferedImage img, int delay) {
     try {
+      if (this.imageOutputStream.length() > MAX_STREAM_LENGTH_BYTES) {
+        Theater.stage.close();
+        // TODO: Make this translatable: https://codedotorg.atlassian.net/browse/CSA-1108
+        String message =
+            "Your video is too large. Please decrease the number of frames in your video and try again.";
+        throw new RuntimeException(message);
+      }
       this.writer.writeToSequence(
           new IIOImage(img, null, getMetadataForFrame(delay, img.getType())), this.params);
 

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -420,15 +420,16 @@ public class Stage {
       this.progressPublisher.onPlay(this.audioWriter.getTotalAudioLength());
       this.gifWriter.writeToGif(this.image, 0);
       this.audioWriter.writeToAudioStream();
+      // We must call close before write so that the streams are flushed.
+      this.close();
       this.writeImageAndAudioToFile();
       this.hasPlayed = true;
-      this.close();
     }
   }
 
   /**
-   * Clean up resources created by this instance. If close has already been called this method does
-   * nothing.
+   * Clean up resources created by this instance. If close or play has already been called this
+   * method does nothing.
    */
   public void close() {
     if (!this.hasClosed) {

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -30,6 +30,7 @@ public class Stage {
   private java.awt.Color strokeColor;
   private java.awt.Color fillColor;
   private boolean hasPlayed;
+  private boolean hasClosed;
 
   private static final int WIDTH = 400;
   private static final int HEIGHT = 400;
@@ -72,6 +73,7 @@ public class Stage {
     this.progressPublisher = progressPublisher;
     this.fontHelper = new FontHelper();
     this.hasPlayed = false;
+    this.hasClosed = false;
 
     // set up the image for drawing (set a white background and black stroke/fill)
     this.clear(Color.WHITE);
@@ -417,10 +419,22 @@ public class Stage {
       this.outputAdapter.sendMessage(new StatusMessage(StatusMessageKey.GENERATING_RESULTS));
       this.progressPublisher.onPlay(this.audioWriter.getTotalAudioLength());
       this.gifWriter.writeToGif(this.image, 0);
-      this.gifWriter.close();
-      this.audioWriter.writeToAudioStreamAndClose();
+      this.audioWriter.writeToAudioStream();
       this.writeImageAndAudioToFile();
       this.hasPlayed = true;
+      this.close();
+    }
+  }
+
+  /**
+   * Clean up resources created by this instance. If close has already been called this method does
+   * nothing.
+   */
+  public void close() {
+    if (!this.hasClosed) {
+      this.gifWriter.close();
+      this.audioWriter.close();
+      this.hasClosed = true;
     }
   }
 

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/TheaterProgressPublisher.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/TheaterProgressPublisher.java
@@ -28,6 +28,7 @@ class TheaterProgressPublisher {
   public void onPause(double seconds) {
     this.pauseTimeSeconds += seconds;
     if (this.pauseTimeSeconds > MAX_TIME_S) {
+      // TODO: Remove this once we have a clean up notifier for stage.
       Theater.stage.close();
       String message =
           "Your video is longer than "

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/TheaterProgressPublisher.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/TheaterProgressPublisher.java
@@ -28,6 +28,7 @@ class TheaterProgressPublisher {
   public void onPause(double seconds) {
     this.pauseTimeSeconds += seconds;
     if (this.pauseTimeSeconds > MAX_TIME_S) {
+      Theater.stage.close();
       String message =
           "Your video is longer than "
               + MAX_TIME_S


### PR DESCRIPTION
Limit theater gifs to 30 mb in size, and ensure we clean up theater resources if we terminate the program due to a too-long or too-large gif.

I also noticed when we write the gif and audio to file we have a stream that's not closed, so added a close to that as well.

As a follow-up to this, also ensure we call `Theater.stage.close()` every time a theater mini-app project is run.