### PR TITLE
No retries in build and run lambda

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -284,7 +284,9 @@ Resources:
         ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
       Description: Compile and execute a JavaLab project.
       MemorySize: 1769
-      Timeout: 300
+      Timeout: 30
+      EventInvokeConfig:
+        MaximumRetryAttempts: 0
       Role:
         Fn::ImportValue: JavabuilderLambdaExecutionRole
       Environment:

--- a/template.yml
+++ b/template.yml
@@ -284,7 +284,7 @@ Resources:
         ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
       Description: Compile and execute a JavaLab project.
       MemorySize: 1769
-      Timeout: 30
+      Timeout: 300
       EventInvokeConfig:
         MaximumRetryAttempts: 0
       Role:


### PR DESCRIPTION
Lambda by default will retry twice on timeout or error -- this sets it such that we do not retry. This will be particularly useful if we start using `System.exit` (which will error) after all projects.

Deployment might be a little tricky, as on my dev deploy this setting did not stick until I fully deleted/recreated my dev deploy.

A proposal would be to deploy this change, then change the setting manually. If we do this, we should check the next time that we deploy to make sure that the setting sticks.