### PR TITLE
Exit the JVM if the disk use exceeds 50% of available resources

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -14,7 +14,9 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -183,6 +185,12 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
       // program.
     } finally {
       cleanUpResources(connectionId, api);
+      File f = Paths.get(System.getProperty("java.io.tmpdir")).toFile();
+      if ((double) f.getUsableSpace() / f.getTotalSpace() < 0.5) {
+        // The current project holds a lock on too many resources. Force the JVM to quit in
+        // order to release the resources for the next use of the container.
+        System.exit(1);
+      }
     }
     return "done";
   }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -38,6 +38,9 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
   private static final int TIMEOUT_WARNING_MS = 20000;
   private static final int TIMEOUT_CLEANUP_BUFFER_MS = 5000;
   private static final String LAMBDA_ID = UUID.randomUUID().toString();
+  // This is an error code we made up to signal that available disk space is less than 50%.
+  // It may be used in tracking on Cloud Watch.
+  private static final int LOW_DISK_SPACE_ERROR_CODE = 50;
 
   public LambdaRequestHandler() {
     // create CachedResources once for the entire container.
@@ -189,7 +192,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
       if ((double) f.getUsableSpace() / f.getTotalSpace() < 0.5) {
         // The current project holds a lock on too many resources. Force the JVM to quit in
         // order to release the resources for the next use of the container.
-        System.exit(50);
+        System.exit(LOW_DISK_SPACE_ERROR_CODE);
       }
     }
     return "done";

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -189,7 +189,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
       if ((double) f.getUsableSpace() / f.getTotalSpace() < 0.5) {
         // The current project holds a lock on too many resources. Force the JVM to quit in
         // order to release the resources for the next use of the container.
-        System.exit(1);
+        System.exit(50);
       }
     }
     return "done";


### PR DESCRIPTION
Calling System.exit forces the JVM to exit and release all its resources. This means that a project that leaves a bunch of resources locked will be forced to release all its locks. 

Calling System.exit results in the maximum possible disk space being available the next time the lambda runs. 

However, calling System.exit has some side effects: The lambda runtime get a bit longer during the next execution. When tested on a 20s project, the project runtime extended to 28s. Additionally AWS tracks a System.exit() as an error in the dashboard. Finally, System.exit() triggers a lambda retry.

As part of this work, we will need to temporarily disable our alarms that check for errors on the lambdas. This change will intentionally increase the error rate.

Exiting results in following AWS message:
RequestId: <ID> Error: Runtime exited with error: exit status 50
Runtime.ExitError