### PR TITLE
Error if no java files on all compilations

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilder.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilder.java
@@ -49,15 +49,16 @@ public class CodeBuilder implements AutoCloseable {
     }
     final List<JavaProjectFile> javaProjectFiles =
         this.userProjectFiles.getMatchingJavaFiles(compileList);
-    if (javaProjectFiles.isEmpty()) {
-      throw new UserInitiatedException(UserInitiatedExceptionKey.NO_FILES_TO_COMPILE);
-    }
 
     this.compileCode(javaProjectFiles);
   }
 
   private void compileCode(List<JavaProjectFile> javaProjectFiles)
       throws InternalServerError, UserInitiatedException {
+    if (javaProjectFiles.isEmpty()) {
+      throw new UserInitiatedException(UserInitiatedExceptionKey.NO_FILES_TO_COMPILE);
+    }
+
     this.saveProjectAssets();
     UserCodeCompiler codeCompiler =
         new UserCodeCompiler(javaProjectFiles, this.tempFolder, this.outputAdapter);

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/CodeBuilderTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/CodeBuilderTest.java
@@ -47,4 +47,12 @@ public class CodeBuilderTest {
         assertThrows(UserInitiatedException.class, () -> codeBuilder.buildUserCode(compileList));
     assertEquals(UserInitiatedExceptionKey.NO_FILES_TO_COMPILE.toString(), exception.getMessage());
   }
+
+  @Test
+  public void testBuildAllUserCodeThrowsExceptionIfNoFilesToCompile() {
+    when(userProjectFiles.getJavaFiles()).thenReturn(new ArrayList<>());
+    final Exception exception =
+        assertThrows(UserInitiatedException.class, () -> codeBuilder.buildAllUserCode());
+    assertEquals(UserInitiatedExceptionKey.NO_FILES_TO_COMPILE.toString(), exception.getMessage());
+  }
 }


### PR DESCRIPTION
Throw an error any time we try to compile a project with no java files. We currently do this only in "compile only" mode -- moves the check so it will happen any time we try to compile (whether the entire project, or when compiling a subset of files).

[Parallel PR on Javalab side](https://github.com/code-dot-org/code-dot-org/pull/44165) with user friendly error message. This can be merged without that Javalab piece in place, as it will just return a less pretty error message in the meantime.