### PR TITLE
Update allowed classes

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
@@ -64,6 +64,7 @@ public class UserClassLoader extends URLClassLoader {
           "java.lang.ArithmeticException",
           "java.lang.ArrayIndexOutOfBoundsException",
           "java.lang.Boolean",
+          "java.lang.Byte",
           "java.lang.Character",
           "java.lang.CharSequence",
           "java.lang.Class",
@@ -71,17 +72,24 @@ public class UserClassLoader extends URLClassLoader {
           "java.lang.Double",
           "java.lang.Enum",
           "java.lang.Exception",
-          "java.lang.IndexOUtOfBoundsException",
+          "java.lang.Float",
+          "java.lang.IndexOutOfBoundsException",
           "java.lang.Integer",
+          "java.lang.invoke.LambdaMetafactory", // needed if you want to create a lambda function
           "java.lang.invoke.StringConcatFactory", // needed for any String concatenation
           "java.lang.IllegalArgumentException",
+          "java.lang.Long",
           "java.lang.Math",
           "java.lang.NullPointerException",
+          "java.lang.Number",
           "java.lang.Object",
           "java.lang.RuntimeException",
           "java.lang.SecurityException",
+          "java.lang.Short",
           "java.lang.StackTraceElement",
           "java.lang.String",
+          "java.lang.StringBuffer",
+          "java.lang.StringBuilder",
           "java.lang.System",
           "java.lang.Throwable");
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
@@ -63,8 +63,13 @@ public class UserClassLoader extends URLClassLoader {
       Set.of(
           "java.lang.ArithmeticException",
           "java.lang.ArrayIndexOutOfBoundsException",
+          "java.lang.Boolean",
+          "java.lang.Character",
+          "java.lang.CharSequence",
+          "java.lang.Class",
           "java.lang.Comparable",
           "java.lang.Double",
+          "java.lang.Enum",
           "java.lang.Exception",
           "java.lang.IndexOUtOfBoundsException",
           "java.lang.Integer",
@@ -73,7 +78,9 @@ public class UserClassLoader extends URLClassLoader {
           "java.lang.Math",
           "java.lang.NullPointerException",
           "java.lang.Object",
+          "java.lang.RuntimeException",
           "java.lang.SecurityException",
+          "java.lang.StackTraceElement",
           "java.lang.String",
           "java.lang.System",
           "java.lang.Throwable");
@@ -82,6 +89,9 @@ public class UserClassLoader extends URLClassLoader {
   private static final String[] allowedPackages =
       new String[] {
         "java.io.",
+        "java.math.",
+        "java.text.",
+        "java.time.",
         "java.util.",
         "org.junit.jupiter.api.",
         "org.code.media.",


### PR DESCRIPTION
Add a few more classes to our allowed class list. These classes encompass:
- primitive types that are wrapped in java.lang (such as `java.lang.Boolean`)
- a few more exceptions
- some helper packages such as `java.math`
- low-risk java utilities such as `StringBuilder`

## Future Work
After this update is merged we can turn the classloader fully on (it currently runs in silent mode).