### PR TITLE
Enable custom classloader

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
+import org.code.protocol.LoggerConstants;
 import org.json.JSONObject;
 
 /**
@@ -50,8 +51,8 @@ public class UserClassLoader extends URLClassLoader {
     // Log that we are going to throw an exception. Log as a warning
     // as it is most likely user error, but we want to track it.
     JSONObject eventData = new JSONObject();
-    eventData.put("type", "invalidClass");
-    eventData.put("className", name);
+    eventData.put(LoggerConstants.TYPE, "invalidClass");
+    eventData.put(LoggerConstants.CLASS_NAME, name);
     Logger.getLogger(MAIN_LOGGER).warning(eventData.toString());
     throw new ClassNotFoundException(name);
   }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
@@ -46,16 +46,14 @@ public class UserClassLoader extends URLClassLoader {
       }
     }
 
-    // Log that we are going to throw an exception
+    // Log that we are going to throw an exception. Log as a warning as it is most likely user
+    // error,
+    // but we want to track it.
     JSONObject eventData = new JSONObject();
     eventData.put("type", "invalidClass");
     eventData.put("className", name);
     Logger.getLogger(MAIN_LOGGER).warning(eventData.toString());
-    // For now, don't throw an exception, and instead go on to the approved class loader.
-    // We want to ensure we aren't blocking anything needed by users, so we are running this in
-    // silent mode.
-    // throw new ClassNotFoundException(name);
-    return this.approvedClassLoader.loadClass(name);
+    throw new ClassNotFoundException(name);
   }
 
   // Allowed individual classes.

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
@@ -46,9 +46,8 @@ public class UserClassLoader extends URLClassLoader {
       }
     }
 
-    // Log that we are going to throw an exception. Log as a warning as it is most likely user
-    // error,
-    // but we want to track it.
+    // Log that we are going to throw an exception. Log as a warning
+    // as it is most likely user error, but we want to track it.
     JSONObject eventData = new JSONObject();
     eventData.put("type", "invalidClass");
     eventData.put("className", name);

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerConstants.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerConstants.java
@@ -18,4 +18,5 @@ public class LoggerConstants {
   public static final String USABLE_SPACE = "usableSpace";
   public static final String FREE_SPACE = "freeSpace";
   public static final String TOTAL_SPACE = "totalSpace";
+  public static final String CLASS_NAME = "className";
 }


### PR DESCRIPTION
Enable the custom class loader in javabuilder. Once this is deployed, users will see the following error messages if they use a disallowed class:

## Regular Code Execution
![Screen Shot 2022-01-05 at 10 55 36 AM](https://user-images.githubusercontent.com/33666587/148273351-d51abf66-82f9-451c-8bdc-cf194fc8e3c9.png)


## Running a test
![Screen Shot 2022-01-05 at 10 55 49 AM](https://user-images.githubusercontent.com/33666587/148273338-6e264c5e-82ca-45e5-bf93-71d5645a0bcf.png)



Note: this PR depends on [this PR](https://github.com/code-dot-org/javabuilder/pull/177) being merged first. 