### PR TITLE
Create test fixture for using GlobalProtocol in tests

### DIFF
--- a/org-code-javabuilder/neighborhood/build.gradle
+++ b/org-code-javabuilder/neighborhood/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     // https://mvnrepository.com/artifact/org.json/json
     implementation group: 'org.json', name: 'json', version: '20210307'
     implementation project(':protocol')
+    testImplementation testFixtures(project(':protocol'))
 }
 
 test {

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
@@ -21,8 +21,7 @@ public class PainterTest {
 
   @BeforeEach
   public void setUp() {
-    GlobalProtocol.create(
-        outputAdapter, mock(InputAdapter.class), "", "", "", mock(JavabuilderFileManager.class));
+    GlobalProtocolTestFactory.builder().withOutputAdapter(outputAdapter).create();
     System.setOut(new PrintStream(outputStreamCaptor));
     World w = new World(singleSquareGrid);
     World.setInstance(w);

--- a/org-code-javabuilder/playground/build.gradle
+++ b/org-code-javabuilder/playground/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation group: 'org.json', name: 'json', version: '20210307'
     implementation project(':protocol')
     implementation project(':media')
+    testImplementation testFixtures(project(':protocol'))
 }
 
 test {

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/ImageItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/ImageItemTest.java
@@ -22,13 +22,7 @@ public class ImageItemTest {
   public void setUp() {
     playgroundMessageHandler = mock(PlaygroundMessageHandler.class);
     messageCaptor = ArgumentCaptor.forClass(PlaygroundMessage.class);
-    GlobalProtocol.create(
-        mock(OutputAdapter.class),
-        mock(InputAdapter.class),
-        "",
-        "",
-        "",
-        mock(JavabuilderFileManager.class));
+    GlobalProtocolTestFactory.builder().create();
     messageHandlerMockedStatic = mockStatic(PlaygroundMessageHandler.class);
     messageHandlerMockedStatic
         .when(PlaygroundMessageHandler::getInstance)

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/ItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/ItemTest.java
@@ -20,13 +20,7 @@ public class ItemTest {
   public void setUp() {
     playgroundMessageHandler = mock(PlaygroundMessageHandler.class);
     messageCaptor = ArgumentCaptor.forClass(PlaygroundMessage.class);
-    GlobalProtocol.create(
-        mock(OutputAdapter.class),
-        mock(InputAdapter.class),
-        "",
-        "",
-        "",
-        mock(JavabuilderFileManager.class));
+    GlobalProtocolTestFactory.builder().create();
 
     messageHandlerMockedStatic = mockStatic(PlaygroundMessageHandler.class);
     messageHandlerMockedStatic

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
@@ -24,13 +24,7 @@ public class TextItemTest {
   public void setUp() {
     playgroundMessageHandler = mock(PlaygroundMessageHandler.class);
     messageCaptor = ArgumentCaptor.forClass(PlaygroundMessage.class);
-    GlobalProtocol.create(
-        mock(OutputAdapter.class),
-        mock(InputAdapter.class),
-        "",
-        "",
-        "",
-        mock(JavabuilderFileManager.class));
+    GlobalProtocolTestFactory.builder().create();
     CachedResources.create();
     messageHandlerMockedStatic = mockStatic(PlaygroundMessageHandler.class);
     messageHandlerMockedStatic

--- a/org-code-javabuilder/protocol/build.gradle
+++ b/org-code-javabuilder/protocol/build.gradle
@@ -9,6 +9,7 @@
 plugins {
     // Apply the java-library plugin for API and implementation separation.
     id 'java-library'
+    id 'java-test-fixtures'
     id 'com.github.sherter.google-java-format' version '0.8'
 }
 
@@ -28,6 +29,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     // https://mvnrepository.com/artifact/org.mockito/mockito-core
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.9.0'
+    testFixturesImplementation group: 'org.mockito', name: 'mockito-core', version: '3.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
 }
 

--- a/org-code-javabuilder/protocol/src/testFixtures/java/org/code/protocol/GlobalProtocolTestFactory.java
+++ b/org-code-javabuilder/protocol/src/testFixtures/java/org/code/protocol/GlobalProtocolTestFactory.java
@@ -1,0 +1,67 @@
+package org.code.protocol;
+
+import static org.mockito.Mockito.*;
+
+public class GlobalProtocolTestFactory {
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private OutputAdapter outputAdapter;
+    private InputAdapter inputAdapter;
+    private String dashboardHostname;
+    private String channelId;
+    private String levelId;
+    private JavabuilderFileManager fileManager;
+
+    private Builder() {
+      this.outputAdapter = mock(OutputAdapter.class);
+      this.inputAdapter = mock(InputAdapter.class);
+      this.dashboardHostname = "";
+      this.channelId = "";
+      this.levelId = "";
+      this.fileManager = mock(JavabuilderFileManager.class);
+    }
+
+    public Builder withOutputAdapter(OutputAdapter outputAdapter) {
+      this.outputAdapter = outputAdapter;
+      return this;
+    }
+
+    public Builder withInputAdapter(InputAdapter inputAdapter) {
+      this.inputAdapter = inputAdapter;
+      return this;
+    }
+
+    public Builder withDashboardHostname(String dashboardHostname) {
+      this.dashboardHostname = dashboardHostname;
+      return this;
+    }
+
+    public Builder withChannelId(String channelId) {
+      this.channelId = channelId;
+      return this;
+    }
+
+    public Builder withLevelId(String levelId) {
+      this.levelId = levelId;
+      return this;
+    }
+
+    public Builder withFileManager(JavabuilderFileManager fileManager) {
+      this.fileManager = fileManager;
+      return this;
+    }
+
+    public void create() {
+      GlobalProtocol.create(
+          this.outputAdapter,
+          this.inputAdapter,
+          this.dashboardHostname,
+          this.channelId,
+          this.levelId,
+          this.fileManager);
+    }
+  }
+}

--- a/org-code-javabuilder/theater/build.gradle
+++ b/org-code-javabuilder/theater/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation project(':protocol')
     implementation project(':media')
     compile 'commons-io:commons-io:2.9.0'
+    testImplementation testFixtures(project(':protocol'))
 }
 
 test {

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
@@ -36,8 +36,7 @@ public class StageTest {
 
   @BeforeEach
   public void setUp() {
-    GlobalProtocol.create(
-        outputAdapter, mock(InputAdapter.class), "", "", "", mock(JavabuilderFileManager.class));
+    GlobalProtocolTestFactory.builder().withOutputAdapter(outputAdapter).create();
     CachedResources.create();
     System.setOut(new PrintStream(outputStreamCaptor));
     bufferedImage = mock(BufferedImage.class);


### PR DESCRIPTION
This is a small quality of life change/prefactor for upcoming changes to https://github.com/code-dot-org/javabuilder/pull/180 which helps us limit the amount of file changes we need to make whenever the contract of `GlobalProtocol.create()` is updated. Now, whenever that changes, only `GlobalProtocolTestFactory` needs to be updated, and test classes can choose which mocks they want to provide to the create method. All other fields are mocked/set to empty strings automatically.

Testing: all unit tests pass.