### PR TITLE
Added translatable messages and fallback messages

### DIFF
--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
@@ -29,4 +29,6 @@ public class ClientMessageDetailKeys {
   public static final String CONNECTION_ID = "connectionId";
   public static final String CAUSE = "cause";
   public static final String CAUSE_MESSAGE = "causeMessage";
+  // Message used until translation is set up on the front end
+  public static final String FALLBACK_MESSAGE = "fallbackMessage";
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderException.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderException.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 public abstract class JavabuilderException extends Exception
     implements JavabuilderThrowableProtocol {
   private final Enum key;
+  private String fallbackMessage;
 
   protected JavabuilderException(Enum key) {
     super(key.toString());
@@ -19,6 +20,12 @@ public abstract class JavabuilderException extends Exception
     this.key = key;
   }
 
+  protected JavabuilderException(Enum key, String fallbackMessage) {
+    super(key.toString());
+    this.key = key;
+    this.fallbackMessage = fallbackMessage;
+  }
+
   public JavabuilderThrowableMessage getExceptionMessage() {
     HashMap<String, String> detail = new HashMap<>();
     detail.put(ClientMessageDetailKeys.CONNECTION_ID, Properties.getConnectionId());
@@ -27,6 +34,10 @@ public abstract class JavabuilderException extends Exception
       if (this.getCause().getMessage() != null) {
         detail.put(ClientMessageDetailKeys.CAUSE_MESSAGE, this.getCause().getMessage());
       }
+    }
+
+    if (this.fallbackMessage != null) {
+      detail.put(ClientMessageDetailKeys.FALLBACK_MESSAGE, this.fallbackMessage);
     }
 
     return new JavabuilderThrowableMessage(this.key, detail);

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderRuntimeException.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderRuntimeException.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 public abstract class JavabuilderRuntimeException extends RuntimeException
     implements JavabuilderThrowableProtocol {
   private final Enum key;
+  private String fallbackMessage;
 
   protected JavabuilderRuntimeException(Enum key) {
     super(key.toString());
@@ -19,6 +20,12 @@ public abstract class JavabuilderRuntimeException extends RuntimeException
     this.key = key;
   }
 
+  protected JavabuilderRuntimeException(Enum key, String fallbackMessage) {
+    super(key.toString());
+    this.key = key;
+    this.fallbackMessage = fallbackMessage;
+  }
+
   public JavabuilderThrowableMessage getExceptionMessage() {
     HashMap<String, String> detail = new HashMap<>();
     detail.put(ClientMessageDetailKeys.CONNECTION_ID, Properties.getConnectionId());
@@ -27,6 +34,10 @@ public abstract class JavabuilderRuntimeException extends RuntimeException
       if (this.getCause().getMessage() != null) {
         detail.put(ClientMessageDetailKeys.CAUSE_MESSAGE, this.getCause().getMessage());
       }
+    }
+
+    if (this.fallbackMessage != null) {
+      detail.put(ClientMessageDetailKeys.FALLBACK_MESSAGE, this.fallbackMessage);
     }
 
     return new JavabuilderThrowableMessage(this.key, detail);

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/ExceptionKeys.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/ExceptionKeys.java
@@ -2,5 +2,7 @@ package org.code.theater;
 
 public enum ExceptionKeys {
   DUPLICATE_PLAY_COMMAND,
-  INVALID_SHAPE
+  INVALID_SHAPE,
+  VIDEO_TOO_LONG,
+  VIDEO_TOO_LARGE
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
@@ -53,10 +53,7 @@ class GifWriter {
       if (this.imageOutputStream.length() > MAX_STREAM_LENGTH_BYTES) {
         // TODO: Remove this once we have a clean up notifier for stage.
         Theater.stage.close();
-        // TODO: Make this translatable: https://codedotorg.atlassian.net/browse/CSA-1108
-        String message =
-            "Your video is too large. Please decrease the number of frames in your video and try again.";
-        throw new RuntimeException(message);
+        throw new TheaterRuntimeException(ExceptionKeys.VIDEO_TOO_LARGE);
       }
       this.writer.writeToSequence(
           new IIOImage(img, null, getMetadataForFrame(delay, img.getType())), this.params);

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -416,7 +416,6 @@ public class Stage {
     if (this.hasPlayed) {
       throw new TheaterRuntimeException(ExceptionKeys.DUPLICATE_PLAY_COMMAND);
     } else {
-      this.outputAdapter.sendMessage(new StatusMessage(StatusMessageKey.GENERATING_RESULTS));
       this.progressPublisher.onPlay(this.audioWriter.getTotalAudioLength());
       this.gifWriter.writeToGif(this.image, 0);
       this.audioWriter.writeToAudioStream();

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/TheaterProgressPublisher.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/TheaterProgressPublisher.java
@@ -30,11 +30,7 @@ class TheaterProgressPublisher {
     if (this.pauseTimeSeconds > MAX_TIME_S) {
       // TODO: Remove this once we have a clean up notifier for stage.
       Theater.stage.close();
-      String message =
-          "Your video is longer than "
-              + MAX_TIME_S
-              + " seconds. Decrease the length of your video and try again.";
-      throw new RuntimeException(message);
+      throw new TheaterRuntimeException(ExceptionKeys.VIDEO_TOO_LONG);
     }
 
     if (this.pauseTimeSeconds - this.lastUpdateTimeSeconds >= UPDATE_TIME_S) {

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/TheaterRuntimeException.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/TheaterRuntimeException.java
@@ -10,4 +10,8 @@ public class TheaterRuntimeException extends JavabuilderRuntimeException {
   protected TheaterRuntimeException(ExceptionKeys key, Throwable cause) {
     super(key, cause);
   }
+
+  protected TheaterRuntimeException(ExceptionKeys key, String fallbackMessage) {
+    super(key, fallbackMessage);
+  }
 }


### PR DESCRIPTION
This does a couple of cleanup fixes as well as a quality of life improvement:

1. Add translations for messages from Javabuilder indicating that a video is too long or too large.
1. Remove the Generating Results message as it's no longer needed.
1. Add support for fallback messages so errors can be added to Javabuilder without a DTP.

This is paired with https://github.com/code-dot-org/code-dot-org/pull/44266 from the code-dot-org repo. This PR should be merged second.

- Jira ticket: [CSA-1108](https://codedotorg.atlassian.net/browse/CSA-1108)