### PR TITLE
Do not try and close non-existent queue on disconnect

### DIFF
--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -20,13 +20,14 @@ def on_connect(event, context)
 
   request_context = event["requestContext"]
   # Add in some logging to make debugging easier
-  puts request_context
+  puts "CONNECT REQUEST CONTEXT: #{request_context}"
 
-  # Return early if this is the user connectivity test
   authorizer = request_context['authorizer']
-  if authorizer && authorizer['connectivityTest']
+  # Return early if this is the user connectivity test
+  if is_connectivity_test(authorizer)
     return { statusCode: 200, body: "connection successful" }
   end
+
   # -- Create SQS for this session --
   sqs_client = Aws::SQS::Client.new(region: region)
   queue_name = get_session_id(event) + '.fifo'
@@ -70,18 +71,15 @@ def on_disconnect(event, context)
   begin
     sqs.delete_queue(queue_url: get_sqs_url(event, context))
   rescue Aws::SQS::Errors::NonExistentQueue => e
-    # Do some sort of check here for whether is connectivity test.
-    # Maybe refactor connectivity test checking logic into its own helper.
-    # Basically, useful information is in event
-    #     request_context = event["requestContext"]
-    #
-    #     # Return early if this is the user connectivity test
-    #     authorizer = request_context['authorizer']
-    #     if authorizer && authorizer['connectivityTest']
-    #     if event["requestContext"]
-    puts event # {"headers"=>{"Host"=>"javabuilder-ben.d...
-    puts context # #<LambdaContext:0x0000000003523bd8>
-    puts e # The specified queue does not exist for this wsdl version.
+    request_context = event['requestContext']
+    authorizer = request_context['authorizer']
+
+    # This exception is expected during connectivity tests,
+    # so do not log in those cases.
+    unless is_connectivity_test(authorizer)
+      puts "DISCONNECT ERROR REQUEST CONTEXT: #{request_context.to_s}"
+      puts "DISCONNECT ERROR: #{e.message}"
+    end
   end
 
   { statusCode: 200, body: "success"}
@@ -138,4 +136,8 @@ def get_sqs_url(event, context)
   account_id = context.invoked_function_arn.split(':')[4]
   connection_id = get_session_id(event)
   "https://sqs.#{region}.amazonaws.com/#{account_id}/#{connection_id}.fifo"
+end
+
+def is_connectivity_test(authorizer)
+  !!(authorizer && authorizer['connectivityTest'])
 end

--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -19,10 +19,11 @@ def on_connect(event, context)
   region = get_region(context)
 
   request_context = event["requestContext"]
+  authorizer = request_context['authorizer']
+
   # Add in some logging to make debugging easier
   puts "CONNECT REQUEST CONTEXT: #{request_context}"
 
-  authorizer = request_context['authorizer']
   # Return early if this is the user connectivity test
   if is_connectivity_test(authorizer)
     return { statusCode: 200, body: "connection successful" }
@@ -77,7 +78,7 @@ def on_disconnect(event, context)
     # This exception is expected during connectivity tests,
     # so do not log in those cases.
     unless is_connectivity_test(authorizer)
-      puts "DISCONNECT ERROR REQUEST CONTEXT: #{request_context.to_s}"
+      puts "DISCONNECT ERROR REQUEST CONTEXT: #{request_context}"
       puts "DISCONNECT ERROR: #{e.message}"
     end
   end

--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -70,9 +70,18 @@ def on_disconnect(event, context)
   begin
     sqs.delete_queue(queue_url: get_sqs_url(event, context))
   rescue Aws::SQS::Errors::NonExistentQueue => e
-    puts event
-    puts context
-    puts e
+    # Do some sort of check here for whether is connectivity test.
+    # Maybe refactor connectivity test checking logic into its own helper.
+    # Basically, useful information is in event
+    #     request_context = event["requestContext"]
+    #
+    #     # Return early if this is the user connectivity test
+    #     authorizer = request_context['authorizer']
+    #     if authorizer && authorizer['connectivityTest']
+    #     if event["requestContext"]
+    puts event # {"headers"=>{"Host"=>"javabuilder-ben.d...
+    puts context # #<LambdaContext:0x0000000003523bd8>
+    puts e # The specified queue does not exist for this wsdl version.
   end
 
   { statusCode: 200, body: "success"}

--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -62,7 +62,18 @@ end
 
 def on_disconnect(event, context)
   sqs = Aws::SQS::Client.new(region: get_region(context))
-  sqs.delete_queue(queue_url: get_sqs_url(event, context))
+
+  # Handle if queue does not exist,
+  # such as in case of connectivity test.
+  # The NonExistentQueue error is not documented in the AWS SDK,
+  # but was observed in errors accumulated from our connectivity tests.
+  begin
+    sqs.delete_queue(queue_url: get_sqs_url(event, context))
+  rescue Aws::SQS::Errors::NonExistentQueue => e
+    puts event
+    puts context
+    puts e
+  end
 
   { statusCode: 200, body: "success"}
 end


### PR DESCRIPTION
We noticed elevated execution errors in API Gateway while monitoring our websocket connectivity test, which is currently happening on applab and teacher dashboard page loads in Code Studio.

Errors were traced to our `on_disconnect`, where we try to delete a queue that does not exist. Catch when this occurs during connectivity tests, and add logging if it occurs in other cases.

**Testing Story**

Tested manually via Postman that a connectivity test no longer generates errors, a real project execution also does not generate any additional logging, and that the new logging appears when a queue does not exist (ie, if I reverse the `if is_connectivity_test condition).