### PR TITLE
Add lifecycle listener and notifier pattern, and integrate with Theater classes

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
@@ -22,7 +22,8 @@ public class LocalMain {
     // turn off the default console logger
     logger.setUseParentHandlers(false);
 
-    GlobalProtocol.create(outputAdapter, inputAdapter, "", "", "", new LocalFileManager());
+    GlobalProtocol.create(
+        outputAdapter, inputAdapter, "", "", "", new LocalFileManager(), new LifecycleNotifier());
     CachedResources.create();
 
     // Create and invoke the code execution environment
@@ -33,7 +34,8 @@ public class LocalMain {
             outputAdapter,
             ExecutionType.RUN,
             null,
-            GlobalProtocol.getInstance().getFileManager());
+            GlobalProtocol.getInstance().getFileManager(),
+            new LifecycleNotifier());
     codeExecutionManager.execute();
   }
 }

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -74,8 +74,15 @@ public class WebSocketServer {
 
     outputAdapter = new WebSocketOutputAdapter(session);
     inputAdapter = new WebSocketInputAdapter();
+    final LifecycleNotifier lifecycleNotifier = new LifecycleNotifier();
     GlobalProtocol.create(
-        outputAdapter, inputAdapter, dashboardHostname, channelId, levelId, new LocalFileManager());
+        outputAdapter,
+        inputAdapter,
+        dashboardHostname,
+        channelId,
+        levelId,
+        new LocalFileManager(),
+        lifecycleNotifier);
     final UserProjectFileLoader fileLoader =
         new UserProjectFileLoader(
             GlobalProtocol.getInstance().generateSourcesUrl(),
@@ -89,7 +96,8 @@ public class WebSocketServer {
             outputAdapter,
             executionType,
             compileList,
-            GlobalProtocol.getInstance().getFileManager());
+            GlobalProtocol.getInstance().getFileManager(),
+            lifecycleNotifier);
 
     executionManager.execute();
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeExecutionManager.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeExecutionManager.java
@@ -25,6 +25,7 @@ public class CodeExecutionManager {
   private final ExecutionType executionType;
   private final List<String> compileList;
   private final JavabuilderFileManager fileManager;
+  private final LifecycleNotifier lifecycleNotifier;
   private final CodeBuilderRunnableFactory codeBuilderRunnableFactory;
 
   private File tempFolder;
@@ -52,7 +53,8 @@ public class CodeExecutionManager {
       OutputAdapter outputAdapter,
       ExecutionType executionType,
       List<String> compileList,
-      JavabuilderFileManager fileManager) {
+      JavabuilderFileManager fileManager,
+      LifecycleNotifier lifecycleNotifier) {
     this(
         fileLoader,
         inputHandler,
@@ -60,6 +62,7 @@ public class CodeExecutionManager {
         executionType,
         compileList,
         fileManager,
+        lifecycleNotifier,
         new CodeBuilderRunnableFactory());
   }
 
@@ -70,6 +73,7 @@ public class CodeExecutionManager {
       ExecutionType executionType,
       List<String> compileList,
       JavabuilderFileManager fileManager,
+      LifecycleNotifier lifecycleNotifier,
       CodeBuilderRunnableFactory codeBuilderRunnableFactory) {
     this.fileLoader = fileLoader;
     this.inputHandler = inputHandler;
@@ -77,6 +81,7 @@ public class CodeExecutionManager {
     this.executionType = executionType;
     this.compileList = compileList;
     this.fileManager = fileManager;
+    this.lifecycleNotifier = lifecycleNotifier;
     this.codeBuilderRunnableFactory = codeBuilderRunnableFactory;
     this.executionInProgress = false;
   }
@@ -145,8 +150,8 @@ public class CodeExecutionManager {
   }
 
   /**
-   * Post-execution steps: 1) [TODO] Notify listeners, 2) clean up global resources, 3) clear
-   * temporary folder, 4) close custom in/out streams, 5) Replace System.in/out with original in/out
+   * Post-execution steps: 1) Notify listeners, 2) clean up global resources, 3) clear temporary
+   * folder, 4) close custom in/out streams, 5) Replace System.in/out with original in/out
    */
   private void onPostExecute() throws InternalServerError {
     if (!this.executionInProgress) {
@@ -154,7 +159,8 @@ public class CodeExecutionManager {
           .warning("onPostExecute() called while execution not in progress.");
       return;
     }
-    // TODO: Notify listeners
+    // Notify listeners
+    this.lifecycleNotifier.onExecutionEnded();
     GlobalProtocol.getInstance().cleanUpResources();
     try {
       // Clear temp folder

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -110,9 +110,16 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     final AmazonS3 s3Client = AmazonS3ClientBuilder.standard().build();
     final AWSFileManager fileManager =
         new AWSFileManager(s3Client, outputBucketName, javabuilderSessionId, getOutputUrl, context);
+    final LifecycleNotifier lifecycleNotifier = new LifecycleNotifier();
     // TODO: Move common setup steps into CodeExecutionManager#onPreExecute
     GlobalProtocol.create(
-        outputAdapter, inputAdapter, dashboardHostname, channelId, levelId, fileManager);
+        outputAdapter,
+        inputAdapter,
+        dashboardHostname,
+        channelId,
+        levelId,
+        fileManager,
+        lifecycleNotifier);
 
     // Create file loader
     final UserProjectFileLoader userProjectFileLoader =
@@ -155,7 +162,8 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
             outputAdapter,
             executionType,
             compileList,
-            fileManager);
+            fileManager,
+            lifecycleNotifier);
 
     final Thread timeoutNotifierThread =
         createTimeoutThread(context, outputAdapter, codeExecutionManager, connectionId, api);

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/CodeExecutionManagerTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/CodeExecutionManagerTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 import org.code.javabuilder.CodeExecutionManager.CodeBuilderRunnableFactory;
 import org.code.protocol.*;
@@ -19,6 +18,7 @@ class CodeExecutionManagerTest {
   private ExecutionType executionType;
   private List<String> compileList;
   private JavabuilderFileManager fileManager;
+  private LifecycleNotifier lifecycleNotifier;
   private CodeBuilderRunnableFactory codeBuilderRunnableFactory;
   private CodeBuilderRunnable codeBuilderRunnable;
   private CodeExecutionManager unitUnderTest;
@@ -31,6 +31,7 @@ class CodeExecutionManagerTest {
     executionType = ExecutionType.RUN;
     compileList = mock(List.class);
     fileManager = mock(JavabuilderFileManager.class);
+    lifecycleNotifier = mock(LifecycleNotifier.class);
     codeBuilderRunnableFactory = mock(CodeBuilderRunnableFactory.class);
     codeBuilderRunnable = mock(CodeBuilderRunnable.class);
 
@@ -38,7 +39,8 @@ class CodeExecutionManagerTest {
             eq(fileLoader), eq(outputAdapter), any(File.class), eq(executionType), eq(compileList)))
         .thenReturn(codeBuilderRunnable);
 
-    GlobalProtocol.create(outputAdapter, mock(InputAdapter.class), "", "", "", fileManager);
+    GlobalProtocol.create(
+        outputAdapter, mock(InputAdapter.class), "", "", "", fileManager, lifecycleNotifier);
 
     unitUnderTest =
         new CodeExecutionManager(
@@ -48,23 +50,24 @@ class CodeExecutionManagerTest {
             executionType,
             compileList,
             fileManager,
+            lifecycleNotifier,
             codeBuilderRunnableFactory);
   }
 
   @Test
-  public void testExitEarlyDoesNothingIfExecutionFinished() throws IOException {
+  public void testExitEarlyDoesNothingIfExecutionFinished() {
     unitUnderTest.execute();
     verify(codeBuilderRunnable).run();
     // Verify post-execute
-    verify(fileManager, times(1)).cleanUpTempDirectory(any(File.class));
+    verify(lifecycleNotifier, times(1)).onExecutionEnded();
 
     unitUnderTest.requestEarlyExit();
     // Should not call post-execute again
-    verify(fileManager, times(1)).cleanUpTempDirectory(any(File.class));
+    verify(lifecycleNotifier, times(1)).onExecutionEnded();
   }
 
   @Test
-  public void testPostExecuteCalledOnlyOnceIfEarlyExitRequested() throws IOException {
+  public void testPostExecuteCalledOnlyOnceIfEarlyExitRequested() {
     // Hack to simulate the timeout scenario where requestEarlyExit is called before run() is
     // finished
     doAnswer(
@@ -78,6 +81,6 @@ class CodeExecutionManagerTest {
     unitUnderTest.execute();
 
     // Verify post-execute happened only once
-    verify(fileManager, times(1)).cleanUpTempDirectory(any(File.class));
+    verify(lifecycleNotifier, times(1)).onExecutionEnded();
   }
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
@@ -19,7 +19,8 @@ public class GlobalProtocol {
   private final String dashboardHostname;
   private final String channelId;
   private final AssetFileHelper assetFileHelper;
-  private Set<MessageHandler> messageHandlers;
+  private final Set<MessageHandler> messageHandlers;
+  private final LifecycleNotifier lifecycleNotifier;
 
   private GlobalProtocol(
       OutputAdapter outputAdapter,
@@ -27,7 +28,8 @@ public class GlobalProtocol {
       String dashboardHostname,
       String channelId,
       JavabuilderFileManager fileManager,
-      AssetFileHelper assetFileHelper) {
+      AssetFileHelper assetFileHelper,
+      LifecycleNotifier lifecycleNotifier) {
     this.outputAdapter = outputAdapter;
     this.inputHandler = inputHandler;
     this.dashboardHostname = dashboardHostname;
@@ -35,6 +37,7 @@ public class GlobalProtocol {
     this.fileManager = fileManager;
     this.assetFileHelper = assetFileHelper;
     this.messageHandlers = new HashSet<>();
+    this.lifecycleNotifier = lifecycleNotifier;
   }
 
   public static void create(
@@ -43,7 +46,8 @@ public class GlobalProtocol {
       String dashboardHostname,
       String channelId,
       String levelId,
-      JavabuilderFileManager fileManager) {
+      JavabuilderFileManager fileManager,
+      LifecycleNotifier lifecycleNotifier) {
     GlobalProtocol.protocolInstance =
         new GlobalProtocol(
             outputAdapter,
@@ -51,7 +55,8 @@ public class GlobalProtocol {
             dashboardHostname,
             channelId,
             fileManager,
-            new AssetFileHelper(dashboardHostname, channelId, levelId));
+            new AssetFileHelper(dashboardHostname, channelId, levelId),
+            lifecycleNotifier);
   }
 
   public static GlobalProtocol getInstance() {
@@ -88,6 +93,10 @@ public class GlobalProtocol {
 
   public void registerMessageHandler(MessageHandler handler) {
     this.messageHandlers.add(handler);
+  }
+
+  public void registerLifecycleListener(LifecycleListener listener) {
+    this.lifecycleNotifier.registerListener(listener);
   }
 
   // Clean up resources that require explicit clean up before exiting

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LifecycleListener.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LifecycleListener.java
@@ -1,0 +1,6 @@
+package org.code.protocol;
+
+public interface LifecycleListener {
+
+  void onExecutionEnded();
+}

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LifecycleNotifier.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LifecycleNotifier.java
@@ -1,0 +1,25 @@
+package org.code.protocol;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/** Notifies delegates of code execution lifecycle events. */
+public class LifecycleNotifier implements LifecycleListener {
+
+  private final Set<LifecycleListener> listeners;
+
+  public LifecycleNotifier() {
+    this.listeners = new HashSet<>();
+  }
+
+  public void registerListener(LifecycleListener listener) {
+    this.listeners.add(listener);
+  }
+
+  @Override
+  public void onExecutionEnded() {
+    for (LifecycleListener listener : this.listeners) {
+      listener.onExecutionEnded();
+    }
+  }
+}

--- a/org-code-javabuilder/protocol/src/testFixtures/java/org/code/protocol/GlobalProtocolTestFactory.java
+++ b/org-code-javabuilder/protocol/src/testFixtures/java/org/code/protocol/GlobalProtocolTestFactory.java
@@ -14,6 +14,7 @@ public class GlobalProtocolTestFactory {
     private String channelId;
     private String levelId;
     private JavabuilderFileManager fileManager;
+    private LifecycleNotifier lifecycleNotifier;
 
     private Builder() {
       this.outputAdapter = mock(OutputAdapter.class);
@@ -22,6 +23,7 @@ public class GlobalProtocolTestFactory {
       this.channelId = "";
       this.levelId = "";
       this.fileManager = mock(JavabuilderFileManager.class);
+      this.lifecycleNotifier = mock(LifecycleNotifier.class);
     }
 
     public Builder withOutputAdapter(OutputAdapter outputAdapter) {
@@ -54,6 +56,11 @@ public class GlobalProtocolTestFactory {
       return this;
     }
 
+    public Builder withLifecycleNotifier(LifecycleNotifier lifecycleNotifier) {
+      this.lifecycleNotifier = lifecycleNotifier;
+      return this;
+    }
+
     public void create() {
       GlobalProtocol.create(
           this.outputAdapter,
@@ -61,7 +68,8 @@ public class GlobalProtocolTestFactory {
           this.dashboardHostname,
           this.channelId,
           this.levelId,
-          this.fileManager);
+          this.fileManager,
+          this.lifecycleNotifier);
     }
   }
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/GifWriter.java
@@ -51,8 +51,6 @@ class GifWriter {
   public void writeToGif(BufferedImage img, int delay) {
     try {
       if (this.imageOutputStream.length() > MAX_STREAM_LENGTH_BYTES) {
-        // TODO: Remove this once we have a clean up notifier for stage.
-        Theater.stage.close();
         // TODO: Make this translatable: https://codedotorg.atlassian.net/browse/CSA-1108
         String message =
             "Your video is too large. Please decrease the number of frames in your video and try again.";

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -421,19 +421,23 @@ public class Stage implements LifecycleListener {
       this.progressPublisher.onPlay(this.audioWriter.getTotalAudioLength());
       this.gifWriter.writeToGif(this.image, 0);
       this.audioWriter.writeToAudioStream();
-      // We must call onExecutionEnded() before write so that the streams are flushed.
-      this.onExecutionEnded();
+      // We must call close() before write so that the streams are flushed.
+      this.close();
       this.writeImageAndAudioToFile();
       this.hasPlayed = true;
     }
+  }
+
+  @Override
+  public void onExecutionEnded() {
+    this.close();
   }
 
   /**
    * Clean up resources created by this instance. If onExecutionEnded or play has already been
    * called this method does nothing.
    */
-  @Override
-  public void onExecutionEnded() {
+  private void close() {
     if (!this.hasClosed) {
       this.gifWriter.close();
       this.audioWriter.close();

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -15,7 +15,7 @@ import org.code.media.Font;
 import org.code.media.Image;
 import org.code.protocol.*;
 
-public class Stage {
+public class Stage implements LifecycleListener {
   private final BufferedImage image;
   private final OutputAdapter outputAdapter;
   private final JavabuilderFileManager fileManager;
@@ -79,6 +79,7 @@ public class Stage {
     this.clear(Color.WHITE);
 
     System.setProperty("java.awt.headless", "true");
+    GlobalProtocol.getInstance().registerLifecycleListener(this);
   }
 
   /** Returns the width of the theater canvas. */
@@ -420,18 +421,19 @@ public class Stage {
       this.progressPublisher.onPlay(this.audioWriter.getTotalAudioLength());
       this.gifWriter.writeToGif(this.image, 0);
       this.audioWriter.writeToAudioStream();
-      // We must call close before write so that the streams are flushed.
-      this.close();
+      // We must call onExecutionEnded() before write so that the streams are flushed.
+      this.onExecutionEnded();
       this.writeImageAndAudioToFile();
       this.hasPlayed = true;
     }
   }
 
   /**
-   * Clean up resources created by this instance. If close or play has already been called this
-   * method does nothing.
+   * Clean up resources created by this instance. If onExecutionEnded or play has already been
+   * called this method does nothing.
    */
-  public void close() {
+  @Override
+  public void onExecutionEnded() {
     if (!this.hasClosed) {
       this.gifWriter.close();
       this.audioWriter.close();

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/TheaterProgressPublisher.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/TheaterProgressPublisher.java
@@ -28,8 +28,6 @@ class TheaterProgressPublisher {
   public void onPause(double seconds) {
     this.pauseTimeSeconds += seconds;
     if (this.pauseTimeSeconds > MAX_TIME_S) {
-      // TODO: Remove this once we have a clean up notifier for stage.
-      Theater.stage.close();
       String message =
           "Your video is longer than "
               + MAX_TIME_S


### PR DESCRIPTION
Note: this is a change that was originally introduced in https://github.com/code-dot-org/javabuilder/pull/172 but split out for clarity.

This change introduces a lifecycle listener pattern that allows us to hook components in to code execution lifecycle events. The expected use is that components can implement the `LifecycleListener` interface and register themselves with `GlobalProtocol.registerLifecycleListener()` to receive updates. Updates are dispatched via the `LifecycleNotifier`, which is currently managed by `CodeExecutionManager`, as it manages the code execution lifecycle directly and can notify listeners accordingly. In this specific change, the pattern is implemented in Theater with `Stage` - Stage implements the interface and registers itself with GlobalProtocol. This ensures that Stage will always be notified with code execution has ended and can perform its resource cleanup steps.

Our current use cases only require an event for when code execution has ended, but if and when we need to hook into other lifecycle events, we can do so in the same way.

Testing: local development and dev lambda