### PR TITLE
Stage's onExecutionEnded should not be publicly accessible

### DIFF
--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -15,7 +15,7 @@ import org.code.media.Font;
 import org.code.media.Image;
 import org.code.protocol.*;
 
-public class Stage implements LifecycleListener {
+public class Stage {
   private final BufferedImage image;
   private final OutputAdapter outputAdapter;
   private final JavabuilderFileManager fileManager;
@@ -35,6 +35,19 @@ public class Stage implements LifecycleListener {
   private static final int WIDTH = 400;
   private static final int HEIGHT = 400;
   private static final java.awt.Color DEFAULT_COLOR = java.awt.Color.BLACK;
+
+  private static class CloseListener implements LifecycleListener {
+    private final Stage stage;
+
+    public CloseListener(Stage stage) {
+      this.stage = stage;
+    }
+
+    @Override
+    public void onExecutionEnded() {
+      this.stage.close();
+    }
+  }
 
   /**
    * Initialize Stage with a default image. Stage should be initialized outside of org.code.theater
@@ -79,7 +92,7 @@ public class Stage implements LifecycleListener {
     this.clear(Color.WHITE);
 
     System.setProperty("java.awt.headless", "true");
-    GlobalProtocol.getInstance().registerLifecycleListener(this);
+    GlobalProtocol.getInstance().registerLifecycleListener(new CloseListener(this));
   }
 
   /** Returns the width of the theater canvas. */
@@ -426,11 +439,6 @@ public class Stage implements LifecycleListener {
       this.writeImageAndAudioToFile();
       this.hasPlayed = true;
     }
-  }
-
-  @Override
-  public void onExecutionEnded() {
-    this.close();
   }
 
   /**

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
@@ -19,6 +19,7 @@ import org.code.protocol.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 public class StageTest {
@@ -31,12 +32,19 @@ public class StageTest {
   private AudioWriter audioWriter;
   private InstrumentSampleLoader instrumentSampleLoader;
   private TheaterProgressPublisher progressPublisher;
+  private ArgumentCaptor<LifecycleListener> stageCloseListenerCaptor;
 
   private Stage s;
 
   @BeforeEach
   public void setUp() {
-    GlobalProtocolTestFactory.builder().withOutputAdapter(outputAdapter).create();
+    final LifecycleNotifier lifecycleNotifier = mock(LifecycleNotifier.class);
+    stageCloseListenerCaptor = ArgumentCaptor.forClass(LifecycleListener.class);
+    doNothing().when(lifecycleNotifier).registerListener(stageCloseListenerCaptor.capture());
+    GlobalProtocolTestFactory.builder()
+        .withOutputAdapter(outputAdapter)
+        .withLifecycleNotifier(lifecycleNotifier)
+        .create();
     CachedResources.create();
     System.setOut(new PrintStream(outputStreamCaptor));
     bufferedImage = mock(BufferedImage.class);
@@ -242,6 +250,29 @@ public class StageTest {
     when(audioWriter.getTotalAudioLength()).thenReturn(audioLength);
     s.play();
     verify(progressPublisher).onPlay(audioLength);
+  }
+
+  @Test
+  void testClosesStreamsOnPlay() {
+    s.play();
+    verify(gifWriter, times(1)).close();
+    verify(audioWriter, times(1)).close();
+  }
+
+  @Test
+  void testClosesStreamsIfExecutionEnded() {
+    final LifecycleListener stageCloseListener = stageCloseListenerCaptor.getValue();
+
+    stageCloseListener.onExecutionEnded();
+
+    verify(gifWriter, times(1)).close();
+    verify(audioWriter, times(1)).close();
+
+    // Should not close again if close was already called
+    reset(gifWriter, audioWriter);
+    s.play();
+    verify(gifWriter, never()).close();
+    verify(audioWriter, never()).close();
   }
 
   private void verifyInvalidShapeThrowsException(Stage s, int[] points, boolean close) {


### PR DESCRIPTION
Small follow-on fix from the lifecycle pattern changes. I realized that with `onExecutionEnded` being public in Stage, it could be potentially called from student/external code and produce weird potential side effects. This change puts that method inside a private inner class so it cannot be invoked publicly.

Testing: unit - confirmed `close()` still gets called on `play()` and when execution ends.