### PR TITLE
Updated all labs to have at least 90s timeout

### DIFF
--- a/template.yml.erb
+++ b/template.yml.erb
@@ -301,8 +301,8 @@ Resources:
 
 <%{
   Theater: {MemorySize: 1769, Timeout: 90},
-  Neighborhood: {MemorySize: 512, Timeout: 60},
-  Console: {MemorySize: 512, Timeout: 60},
+  Neighborhood: {MemorySize: 512, Timeout: 90},
+  Console: {MemorySize: 512, Timeout: 90},
   Playground: {MemorySize: 512, Timeout: 300}
 }.each do |name, config| -%>
   BuildAndRunJava<%=name%>ProjectFunction:


### PR DESCRIPTION
Prompted by some feedback from the curriculum team: https://codedotorg.slack.com/archives/C02LSA6FUJ1/p1642566862002900 

Some of the more expressive Neighborhood and Console projects were starting to hit our 60s time limit for their respective lambdas. For console, it made sense to increase this limit to 90s permanently since that is the same limit we have on Theater - if students want more runtime, we'd rather they use Playground than Theater for cost reasons. Setting the same timeout for Theater as Console takes away one reason to use Theater. 

For Neighborhood projects, the limiting factor is likely the large number of network requests used to send neighborhood actions across the websocket. We plan to batch the messages in the future; however, in the short term, we'll increase the timeout.