### PR TITLE
Use Stack-specific names for CloudWatch Alarms

### DIFF
--- a/template.yml.erb
+++ b/template.yml.erb
@@ -414,7 +414,7 @@ Resources:
   HighConcurrentExecutionsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub "${SubDomainName}_javabuilder_high_concurrent_executions"
+      AlarmName: !Sub "${SubDomainName}_high_concurrent_executions"
       AlarmDescription: !Sub |
           This will page the DOTD if javabuilder usage exceeds 50 concurrent
           executions for 10 minutes. Occasional spikes are expected, but
@@ -458,7 +458,7 @@ Resources:
   <%=name%>HighSevereErrorRateAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub "${SubDomainName}_javabuilder_<%=name.downcase%>_high_severe_error_rate"
+      AlarmName: !Sub "${SubDomainName}_<%=name.downcase%>_high_severe_error_rate"
       AlarmDescription: Send page if Javabuilder severe error rate exceeds 10% for 20
           minutes. Occasional spikes are expected, but a sustained high error rate
           is an indication of an outage.
@@ -502,7 +502,7 @@ Resources:
   <%=name%>HighErrorRateAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub "${SubDomainName}_javabuilder_build_and_run_<%=name.downcase%>_lambda_error_rate"
+      AlarmName: !Sub "${SubDomainName}_build_and_run_<%=name.downcase%>_lambda_error_rate"
       AlarmDescription: Error rate in Javabuilder's <%=name%> build and run lambda (the core of
           Javabuilder, which executes student <%=name%> code) exceeded 10% for four
           consecutive 5 minute periods.

--- a/template.yml.erb
+++ b/template.yml.erb
@@ -414,7 +414,7 @@ Resources:
   HighConcurrentExecutionsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: javabuilder_high_concurrent_executions
+      AlarmName: !Sub "${SubDomainName}_javabuilder_high_concurrent_executions"
       AlarmDescription: !Sub |
           This will page the DOTD if javabuilder usage exceeds 50 concurrent
           executions for 10 minutes. Occasional spikes are expected, but
@@ -458,7 +458,7 @@ Resources:
   <%=name%>HighSevereErrorRateAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: javabuilder_<%=name.downcase%>_high_severe_error_rate
+      AlarmName: !Sub "${SubDomainName}_javabuilder_<%=name.downcase%>_high_severe_error_rate"
       AlarmDescription: Send page if Javabuilder severe error rate exceeds 10% for 20
           minutes. Occasional spikes are expected, but a sustained high error rate
           is an indication of an outage.
@@ -502,7 +502,7 @@ Resources:
   <%=name%>HighErrorRateAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: javabuilder_build_and_run_<%=name.downcase%>_lambda_error_rate
+      AlarmName: !Sub "${SubDomainName}_javabuilder_build_and_run_<%=name.downcase%>_lambda_error_rate"
       AlarmDescription: Error rate in Javabuilder's <%=name%> build and run lambda (the core of
           Javabuilder, which executes student <%=name%> code) exceeded 10% for four
           consecutive 5 minute periods.


### PR DESCRIPTION
Include subdomain name in CloudWatch Alarm Names to ensure each CloudWatch Alarm Name is unique within an AWS account. Without this change, it isn't possible to provision more than one Javabuilder CloudFormation Stack in a single AWS account. We informally have a 1:1 mapping between AWS accounts and base domain names (production --> `code.org` / development --> `dev-code.org`) so the subdomain name should be sufficient for ensuring uniqueness. Eliminate `_javabuilder` prefix for Alarm Name because by convention, the subdomain always includes `javabuilder` prefix (`javabuilderbeta.code.org`, `javabuilder-staging.code.org`, `javabuilder-suresh.dev-code.org`, etc.).

Example: javabuilder-suresh.dev-code.org and javabuilder-mrcunningham.dev-code.org have different Alarm Names:
<img width="430" alt="image" src="https://user-images.githubusercontent.com/2157034/150625002-14205c12-3f58-4869-9a5b-aea824ad7e43.png">
