### PR TITLE
Fix web socket server

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -89,25 +89,31 @@ public class WebSocketServer {
             levelId,
             dashboardHostname,
             useNeighborhood);
-    final CodeExecutionManager executionManager =
-        new CodeExecutionManager(
-            fileLoader,
-            GlobalProtocol.getInstance().getInputHandler(),
-            outputAdapter,
-            executionType,
-            compileList,
-            GlobalProtocol.getInstance().getFileManager(),
-            lifecycleNotifier);
 
-    executionManager.execute();
+    // the code must be run in a thread so we can receive input messages
+    Thread codeExecutor =
+        new Thread(
+            () -> {
+              final CodeExecutionManager executionManager =
+                  new CodeExecutionManager(
+                      fileLoader,
+                      GlobalProtocol.getInstance().getInputHandler(),
+                      outputAdapter,
+                      executionType,
+                      compileList,
+                      GlobalProtocol.getInstance().getFileManager(),
+                      lifecycleNotifier);
+              executionManager.execute();
+              // Clean up session
+              try {
+                session.close();
+                logger.removeHandler(this.logHandler);
+              } catch (IOException e) {
+                e.printStackTrace();
+              }
+            });
 
-    // Clean up session
-    try {
-      session.close();
-      logger.removeHandler(this.logHandler);
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+    codeExecutor.start();
   }
 
   @OnClose


### PR DESCRIPTION
When we removed threading from Javabuilder we erroneously removed threading from `WebSocketServer`. `WebSocketServer` needs to run the student code in a thread so it can receive input messages while code is running. This change goes back to running student code in a thread.