### PR TITLE
Give tests access to org.code.validation

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavaRunner.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavaRunner.java
@@ -43,14 +43,17 @@ public class JavaRunner {
    *     finished executing.
    */
   public void runMain() throws InternalFacingException, JavabuilderException {
-    this.run(this.mainRunner);
+    this.run(this.mainRunner, false);
   }
 
   public void runTests() throws JavabuilderException, InternalFacingException {
-    this.run(this.testRunner);
+    // Tests have more permissions than a regular run--as of now, all
+    // tests have access to the org.code.validation package.
+    this.run(this.testRunner, true);
   }
 
-  private void run(CodeRunner runner) throws JavabuilderException, InternalFacingException {
+  private void run(CodeRunner runner, boolean hasElevatedPermissions)
+      throws JavabuilderException, InternalFacingException {
     // Include the user-facing api jars in the code we are loading so student code can access them.
     URL[] classLoaderUrls = Util.getAllJarURLs(this.executableLocation);
 
@@ -58,7 +61,10 @@ public class JavaRunner {
     // packages/classes.
     UserClassLoader urlClassLoader =
         new UserClassLoader(
-            classLoaderUrls, JavaRunner.class.getClassLoader(), this.javaClassNames);
+            classLoaderUrls,
+            JavaRunner.class.getClassLoader(),
+            this.javaClassNames,
+            hasElevatedPermissions);
 
     runner.run(urlClassLoader);
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavaRunner.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/JavaRunner.java
@@ -43,16 +43,17 @@ public class JavaRunner {
    *     finished executing.
    */
   public void runMain() throws InternalFacingException, JavabuilderException {
-    this.run(this.mainRunner, false);
+    this.run(this.mainRunner, RunPermissionLevel.USER);
   }
 
   public void runTests() throws JavabuilderException, InternalFacingException {
-    // Tests have more permissions than a regular run--as of now, all
-    // tests have access to the org.code.validation package.
-    this.run(this.testRunner, true);
+    // Tests have more permissions than a regular run: as of now, all
+    // tests will be run under the VALIDATOR permission. Once we split out validation and
+    // project tests run we will need to give different permissions to each run type.
+    this.run(this.testRunner, RunPermissionLevel.VALIDATOR);
   }
 
-  private void run(CodeRunner runner, boolean hasElevatedPermissions)
+  private void run(CodeRunner runner, RunPermissionLevel permissionLevel)
       throws JavabuilderException, InternalFacingException {
     // Include the user-facing api jars in the code we are loading so student code can access them.
     URL[] classLoaderUrls = Util.getAllJarURLs(this.executableLocation);
@@ -64,7 +65,7 @@ public class JavaRunner {
             classLoaderUrls,
             JavaRunner.class.getClassLoader(),
             this.javaClassNames,
-            hasElevatedPermissions);
+            permissionLevel);
 
     runner.run(urlClassLoader);
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/RunPermissionLevel.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/RunPermissionLevel.java
@@ -1,0 +1,10 @@
+package org.code.javabuilder;
+
+/** Permission level for running code. */
+public enum RunPermissionLevel {
+  // Basic permission level. Has access to all standard packages.
+  USER,
+  // Permission level for running validation code. Has access to everything user has access to,
+  // plus validation-specific packages.
+  VALIDATOR
+}

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
@@ -20,12 +20,18 @@ import org.json.JSONObject;
 public class UserClassLoader extends URLClassLoader {
   private final Set<String> userProvidedClasses;
   private final URLClassLoader approvedClassLoader;
+  private final boolean hasElevatedPermissions;
 
-  public UserClassLoader(URL[] urls, ClassLoader parent, List<String> userProvidedClasses) {
+  public UserClassLoader(
+      URL[] urls,
+      ClassLoader parent,
+      List<String> userProvidedClasses,
+      boolean hasElevatedPermissions) {
     super(urls, parent);
     this.userProvidedClasses = new HashSet<>();
     this.userProvidedClasses.addAll(userProvidedClasses);
     this.approvedClassLoader = new URLClassLoader(urls, JavaRunner.class.getClassLoader());
+    this.hasElevatedPermissions = hasElevatedPermissions;
   }
 
   @Override
@@ -41,11 +47,13 @@ public class UserClassLoader extends URLClassLoader {
     if (this.allowedClasses.contains(name)) {
       return this.approvedClassLoader.loadClass(name);
     }
-    // allow .<specific-class> usage from valid packages
-    for (int i = 0; i < this.allowedPackages.length; i++) {
-      if (name.startsWith(this.allowedPackages[i])) {
-        return this.approvedClassLoader.loadClass(name);
-      }
+    // allow .<specific-class> usage from allowed packages. If this code has elevated permissions,
+    // also check the
+    // elevated permissions allowed package list.
+    if (this.isInAllowedPackage(this.allowedPackages, name)
+        || (this.hasElevatedPermissions
+            && this.isInAllowedPackage(this.elevatedPermissionsAllowedPackages, name))) {
+      return this.approvedClassLoader.loadClass(name);
     }
 
     // Log that we are going to throw an exception. Log as a warning
@@ -55,6 +63,21 @@ public class UserClassLoader extends URLClassLoader {
     eventData.put(LoggerConstants.CLASS_NAME, name);
     Logger.getLogger(MAIN_LOGGER).warning(eventData.toString());
     throw new ClassNotFoundException(name);
+  }
+
+  /**
+   * @param allowedPackageList
+   * @param name
+   * @return true if name is in a package a in the allowedPackageList, i.e. if name is prefixed with
+   *     any value in allowedPackageList
+   */
+  private boolean isInAllowedPackage(String[] allowedPackageList, String name) {
+    for (int i = 0; i < allowedPackageList.length; i++) {
+      if (name.startsWith(allowedPackageList[i])) {
+        return true;
+      }
+    }
+    return false;
   }
 
   // Allowed individual classes.
@@ -106,4 +129,8 @@ public class UserClassLoader extends URLClassLoader {
         "org.code.playground.",
         "org.code.theater.",
       };
+
+  // Allowed packages for code with elevated permissions, such as validation code.
+  private static final String[] elevatedPermissionsAllowedPackages =
+      new String[] {"org.code.validation"};
 }


### PR DESCRIPTION
For now, give all user-written and levelbuilder-written tests access to the org.code.validation package. Students aren't writing unit tests until post-pilot, and the validation package is hidden mostly to avoid confusion, not because it exposes any information. To do this, I added an 'elevated permissions' option to the user class loader, and gave all test runs elevated permissions.

## Links
- [jira](https://codedotorg.atlassian.net/browse/JAVA-422)