### PR TITLE
Move shared exception message methods to helper

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/InternalFacingException.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/InternalFacingException.java
@@ -1,7 +1,6 @@
 package org.code.javabuilder;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import org.code.protocol.JavabuilderThrowableMessageUtils;
 
 /**
  * Exception intended to eventually bubble up to a logger (i.e. CloudWatch) but have no functional
@@ -15,9 +14,6 @@ public class InternalFacingException extends Exception {
 
   /** @return A pretty version of the exception and stack trace. */
   public String getLoggingString() {
-    StringWriter stringWriter = new StringWriter();
-    PrintWriter printWriter = new PrintWriter(stringWriter);
-    printStackTrace(printWriter);
-    return stringWriter.toString();
+    return JavabuilderThrowableMessageUtils.getLoggingString(this);
   }
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderException.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderException.java
@@ -23,12 +23,12 @@ public abstract class JavabuilderException extends Exception
   }
 
   public JavabuilderThrowableMessage getExceptionMessage() {
-    return JavabuilderThrowableMessageHelper.getExceptionMessage(
+    return JavabuilderThrowableMessageUtils.getExceptionMessage(
         this, this.key, this.fallbackMessage);
   }
 
   /** @return A pretty version of the exception and stack trace. */
   public String getLoggingString() {
-    return JavabuilderThrowableMessageHelper.getLoggingString(this);
+    return JavabuilderThrowableMessageUtils.getLoggingString(this);
   }
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderException.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderException.java
@@ -1,9 +1,5 @@
 package org.code.protocol;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.HashMap;
-
 /** Parent exception for all exceptions that will be displayed to the user. */
 public abstract class JavabuilderException extends Exception
     implements JavabuilderThrowableProtocol {
@@ -27,27 +23,12 @@ public abstract class JavabuilderException extends Exception
   }
 
   public JavabuilderThrowableMessage getExceptionMessage() {
-    HashMap<String, String> detail = new HashMap<>();
-    detail.put(ClientMessageDetailKeys.CONNECTION_ID, Properties.getConnectionId());
-    if (this.getCause() != null) {
-      detail.put(ClientMessageDetailKeys.CAUSE, this.getLoggingString());
-      if (this.getCause().getMessage() != null) {
-        detail.put(ClientMessageDetailKeys.CAUSE_MESSAGE, this.getCause().getMessage());
-      }
-    }
-
-    if (this.fallbackMessage != null) {
-      detail.put(ClientMessageDetailKeys.FALLBACK_MESSAGE, this.fallbackMessage);
-    }
-
-    return new JavabuilderThrowableMessage(this.key, detail);
+    return JavabuilderThrowableMessageHelper.getExceptionMessage(
+        this, this.key, this.fallbackMessage);
   }
 
   /** @return A pretty version of the exception and stack trace. */
   public String getLoggingString() {
-    StringWriter stringWriter = new StringWriter();
-    PrintWriter printWriter = new PrintWriter(stringWriter);
-    this.printStackTrace(printWriter);
-    return stringWriter.toString();
+    return JavabuilderThrowableMessageHelper.getLoggingString(this);
   }
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderRuntimeException.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderRuntimeException.java
@@ -23,11 +23,11 @@ public abstract class JavabuilderRuntimeException extends RuntimeException
   }
 
   public JavabuilderThrowableMessage getExceptionMessage() {
-    return JavabuilderThrowableMessageHelper.getExceptionMessage(
+    return JavabuilderThrowableMessageUtils.getExceptionMessage(
         this, this.key, this.fallbackMessage);
   }
 
   public String getLoggingString() {
-    return JavabuilderThrowableMessageHelper.getLoggingString(this);
+    return JavabuilderThrowableMessageUtils.getLoggingString(this);
   }
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderRuntimeException.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderRuntimeException.java
@@ -1,9 +1,5 @@
 package org.code.protocol;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.HashMap;
-
 /** Parent error for all errors that will be displayed to the user. */
 public abstract class JavabuilderRuntimeException extends RuntimeException
     implements JavabuilderThrowableProtocol {
@@ -27,27 +23,11 @@ public abstract class JavabuilderRuntimeException extends RuntimeException
   }
 
   public JavabuilderThrowableMessage getExceptionMessage() {
-    HashMap<String, String> detail = new HashMap<>();
-    detail.put(ClientMessageDetailKeys.CONNECTION_ID, Properties.getConnectionId());
-    if (this.getCause() != null) {
-      detail.put(ClientMessageDetailKeys.CAUSE, this.getLoggingString());
-      if (this.getCause().getMessage() != null) {
-        detail.put(ClientMessageDetailKeys.CAUSE_MESSAGE, this.getCause().getMessage());
-      }
-    }
-
-    if (this.fallbackMessage != null) {
-      detail.put(ClientMessageDetailKeys.FALLBACK_MESSAGE, this.fallbackMessage);
-    }
-
-    return new JavabuilderThrowableMessage(this.key, detail);
+    return JavabuilderThrowableMessageHelper.getExceptionMessage(
+        this, this.key, this.fallbackMessage);
   }
 
-  /** @return A pretty version of the exception and stack trace. */
   public String getLoggingString() {
-    StringWriter stringWriter = new StringWriter();
-    PrintWriter printWriter = new PrintWriter(stringWriter);
-    this.printStackTrace(printWriter);
-    return stringWriter.toString();
+    return JavabuilderThrowableMessageHelper.getLoggingString(this);
   }
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderThrowableMessageHelper.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderThrowableMessageHelper.java
@@ -1,0 +1,36 @@
+package org.code.protocol;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.HashMap;
+
+/* Helper for formatting exceptions that will be displayed to the user. */
+class JavabuilderThrowableMessageHelper {
+  private JavabuilderThrowableMessageHelper() {}
+
+  static JavabuilderThrowableMessage getExceptionMessage(
+      Throwable throwable, Enum key, String fallbackMessage) {
+    HashMap<String, String> detail = new HashMap<>();
+    detail.put(ClientMessageDetailKeys.CONNECTION_ID, Properties.getConnectionId());
+    if (throwable.getCause() != null) {
+      detail.put(ClientMessageDetailKeys.CAUSE, getLoggingString(throwable));
+      if (throwable.getCause().getMessage() != null) {
+        detail.put(ClientMessageDetailKeys.CAUSE_MESSAGE, throwable.getCause().getMessage());
+      }
+    }
+
+    if (fallbackMessage != null) {
+      detail.put(ClientMessageDetailKeys.FALLBACK_MESSAGE, fallbackMessage);
+    }
+
+    return new JavabuilderThrowableMessage(key, detail);
+  }
+
+  /** @return A pretty version of the exception and stack trace. */
+  static String getLoggingString(Throwable throwable) {
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter printWriter = new PrintWriter(stringWriter);
+    throwable.printStackTrace(printWriter);
+    return stringWriter.toString();
+  }
+}

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderThrowableMessageUtils.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderThrowableMessageUtils.java
@@ -5,10 +5,12 @@ import java.io.StringWriter;
 import java.util.HashMap;
 
 /* Helper for formatting exceptions that will be displayed to the user. */
-class JavabuilderThrowableMessageHelper {
-  private JavabuilderThrowableMessageHelper() {}
+public final class JavabuilderThrowableMessageUtils {
+  private JavabuilderThrowableMessageUtils() {
+    throw new UnsupportedOperationException("Instantiation of utility class is not allowed.");
+  }
 
-  static JavabuilderThrowableMessage getExceptionMessage(
+  public static JavabuilderThrowableMessage getExceptionMessage(
       Throwable throwable, Enum key, String fallbackMessage) {
     HashMap<String, String> detail = new HashMap<>();
     detail.put(ClientMessageDetailKeys.CONNECTION_ID, Properties.getConnectionId());
@@ -27,7 +29,7 @@ class JavabuilderThrowableMessageHelper {
   }
 
   /** @return A pretty version of the exception and stack trace. */
-  static String getLoggingString(Throwable throwable) {
+  public static String getLoggingString(Throwable throwable) {
     StringWriter stringWriter = new StringWriter();
     PrintWriter printWriter = new PrintWriter(stringWriter);
     throwable.printStackTrace(printWriter);


### PR DESCRIPTION
In preparation for [having a shorter stack trace for students](https://codedotorg.atlassian.net/browse/JAVA-409), moving shared message formatting helpers (currently copied exactly between `JavabuilderException` and `JavabuilderRuntimeException`) into their own util class. This change should introduce no behavior changes.

## Testing story

Tested manually in Javalab that a `JavabuilderException` (dividing by 0 in student code) and a `JavabuilderRuntimeException` (throwing `RuntimeException` in student code) both printed the long stack trace that is the current behavior.