### PR TITLE
Update default lambda size to be smaller

### DIFF
--- a/template.yml.erb
+++ b/template.yml.erb
@@ -36,7 +36,7 @@ Globals:
   Function:
     Runtime: ruby2.7
     Timeout: 30
-    MemorySize: 3008
+    MemorySize: 256
     Tracing: Active
 Conditions:
   IsDevCondition: !Equals [!Ref BaseDomainName, "dev-code.org"]


### PR DESCRIPTION
We had the default lambda size accidentally set to ~3GB. This value is applied to the message relay lambda and the authorizer lambda, neither of which do computation-heavy work. This value can be made significantly smaller. 

Tested against project that sends 10 messages back and forth. The execution time didn't change. Average duration in the authorizer was still around high single digits of milliseconds and average duration in the message relay lambda was still around mid double digits of milliseconds.

Note: We may need to set a higher memory value for the authorizer lambda when we start throttling access to Javabuilder because the authorizer will be processing much more data.