### PR TITLE
Updated gitignore to ignore generated template.yml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Ignore Gradle build output directory
 build
+
+# Ignore the generated template.yml file
+template.yml


### PR DESCRIPTION
Quick quality of life fix to ignore the template.yml when creating PRs. The source of truth for the CloudFormation template is the template.yml.erb file.