### PR TITLE
Implement local content manager

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalContentManager.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalContentManager.java
@@ -36,11 +36,15 @@ public class LocalContentManager implements ContentManager, ProjectFileLoader {
   }
 
   @Override
-  public String generateAssetUrl(String filename) {
+  public String getAssetUrl(String filename) {
     try {
       this.loadProjectDataIfNeeded();
     } catch (InternalServerError e) {
-      // Log this error since this indicates an issue reading project data
+      // We should only hit this exception if we try to load an asset URL before source code has
+      // been loaded, which should only be in the the case of manual testing. Log this exception but
+      // don't throw to preserve the method contract.
+      // Note / TODO: Once we fully migrate away from Dashboard sources, we can remove the
+      // loadProjectDataIfNeeded() call here and this exception handling.
       LoggerUtils.logException(e);
       return null;
     }
@@ -51,7 +55,9 @@ public class LocalContentManager implements ContentManager, ProjectFileLoader {
   public String generateAssetUploadUrl(String filename) throws InternalServerError {
     this.loadProjectDataIfNeeded();
     final String uploadUrl = String.format(SERVER_URL_FORMAT, DIRECTORY, filename);
-    // Add new asset URL to our project data so it can be referenced later.
+    // The URL to GET this asset once it is uploaded will be the same as the upload
+    // URL since it points to the same location on the local file server. Add this
+    // URL to our project data so it can be referenced later.
     this.projectData.addNewAssetUrl(filename, uploadUrl);
     return uploadUrl;
   }

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalContentManager.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalContentManager.java
@@ -13,6 +13,7 @@ import org.code.protocol.ContentManager;
 import org.code.protocol.InternalErrorKey;
 import org.code.protocol.JavabuilderException;
 import org.code.protocol.LoggerUtils;
+import org.json.JSONException;
 
 public class LocalContentManager implements ContentManager, ProjectFileLoader {
   private static final String SERVER_URL_FORMAT = "http://localhost:8080/%s/%s";
@@ -84,7 +85,7 @@ public class LocalContentManager implements ContentManager, ProjectFileLoader {
               System.getProperty("java.io.tmpdir"), DIRECTORY, ProjectData.PROJECT_DATA_FILE_NAME);
       try {
         this.projectData = new ProjectData(Files.readString(sourcesPath));
-      } catch (IOException e) {
+      } catch (IOException | JSONException e) {
         // Error reading JSON file from local storage
         throw new InternalServerError(InternalErrorKey.INTERNAL_EXCEPTION, e);
       }

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalContentManager.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalContentManager.java
@@ -1,0 +1,93 @@
+package dev.javabuilder;
+
+import static dev.javabuilder.LocalWebserverConstants.DIRECTORY;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.code.javabuilder.*;
+import org.code.protocol.ContentManager;
+import org.code.protocol.InternalErrorKey;
+import org.code.protocol.JavabuilderException;
+import org.code.protocol.LoggerUtils;
+
+public class LocalContentManager implements ContentManager, ProjectFileLoader {
+  private static final String SERVER_URL_FORMAT = "http://localhost:8080/%s/%s";
+
+  private ProjectData projectData;
+
+  public LocalContentManager() {
+    this.projectData = null;
+  }
+
+  // Used for testing
+  LocalContentManager(ProjectData projectData) {
+    this.projectData = projectData;
+  }
+
+  @Override
+  public UserProjectFiles loadFiles() throws InternalServerError, UserInitiatedException {
+    this.loadProjectDataIfNeeded();
+    return this.projectData.getSources();
+  }
+
+  @Override
+  public String generateAssetUrl(String filename) {
+    try {
+      this.loadProjectDataIfNeeded();
+    } catch (InternalServerError e) {
+      // Log this error since this indicates an issue reading project data
+      LoggerUtils.logException(e);
+      return null;
+    }
+    return this.projectData.getAssetUrl(filename);
+  }
+
+  @Override
+  public String generateAssetUploadUrl(String filename) throws InternalServerError {
+    this.loadProjectDataIfNeeded();
+    final String uploadUrl = String.format(SERVER_URL_FORMAT, DIRECTORY, filename);
+    // Add new asset URL to our project data so it can be referenced later.
+    this.projectData.addNewAssetUrl(filename, uploadUrl);
+    return uploadUrl;
+  }
+
+  @Override
+  public String writeToOutputFile(String filename, byte[] inputBytes, String contentType)
+      throws JavabuilderException {
+    final File file = Paths.get(System.getProperty("java.io.tmpdir"), DIRECTORY, filename).toFile();
+    try {
+      Files.write(file.toPath(), inputBytes);
+    } catch (IOException e) {
+      throw new InternalServerError(InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION, e);
+    }
+    return String.format(SERVER_URL_FORMAT, DIRECTORY, filename);
+  }
+
+  @Override
+  public void verifyAssetFilename(String filename) throws FileNotFoundException {
+    if (!this.projectData.doesAssetUrlExist(filename)) {
+      throw new FileNotFoundException(filename);
+    }
+  }
+
+  // TODO: Project JSON data loading is deferred because it will not exist if we are
+  // still using dashboard sources. Once we stop using dashboard sources, this step
+  // can probably just happen immediately in the constructor.
+  private void loadProjectDataIfNeeded() throws InternalServerError {
+    if (this.projectData == null) {
+      final Path sourcesPath =
+          Paths.get(
+              System.getProperty("java.io.tmpdir"), DIRECTORY, ProjectData.PROJECT_DATA_FILE_NAME);
+      try {
+        this.projectData = new ProjectData(Files.readString(sourcesPath));
+      } catch (IOException e) {
+        // Error reading JSON file from local storage
+        throw new InternalServerError(InternalErrorKey.INTERNAL_EXCEPTION, e);
+      }
+    }
+  }
+}

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ProjectData.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ProjectData.java
@@ -1,0 +1,85 @@
+package org.code.javabuilder;
+
+import java.util.Map;
+import org.code.protocol.InternalErrorKey;
+import org.json.JSONObject;
+
+/**
+ * Represents the JSON project data for a Javabuilder session. Expected structure:
+ *
+ * <pre>
+ * {
+ *   "sources": {
+ *     "main.json": <main source file for a project>
+ *     "grid.txt": <serialized maze if it exists>
+ *   },
+ *   "assetUrls": {"asset_name_1": <asset_url>, ...}
+ *   "validation": <all validation code for a project, in json format>
+ * }
+ * </pre>
+ */
+public class ProjectData {
+  public static final String PROJECT_DATA_FILE_NAME = "sources.json";
+  // Expected JSON keys
+  private static final String SOURCES_KEY = "sources";
+  private static final String ASSET_URLS_KEY = "assetUrls";
+  private static final String VALIDATION_KEY = "validation";
+
+  private static final String MAIN_JSON_KEY = "main.json";
+  private static final String MAZE_FILE_KEY = "grid.txt";
+
+  private final JSONObject jsonData;
+  private final UserProjectFileParser projectFileParser;
+
+  public ProjectData(String json) {
+    this(json, new UserProjectFileParser());
+  }
+
+  ProjectData(String json, UserProjectFileParser projectFileParser) {
+    this.jsonData = new JSONObject(json);
+    this.projectFileParser = projectFileParser;
+  }
+
+  public UserProjectFiles getSources() throws InternalServerError, UserInitiatedException {
+    if (!this.jsonData.has(SOURCES_KEY)
+        || !this.jsonData.getJSONObject(SOURCES_KEY).has(MAIN_JSON_KEY)) {
+      throw new InternalServerError(
+          InternalErrorKey.INTERNAL_EXCEPTION, new Exception("Code sources missing"));
+    }
+    final JSONObject sources = this.jsonData.getJSONObject(SOURCES_KEY);
+    final UserProjectFiles projectFiles =
+        this.projectFileParser.parseFileJson(sources.getString(MAIN_JSON_KEY));
+
+    if (sources.has(MAZE_FILE_KEY)) {
+      projectFiles.addTextFile(
+          new TextProjectFile(MAZE_FILE_KEY, sources.getString(MAZE_FILE_KEY)));
+    }
+
+    return projectFiles;
+  }
+
+  public String getAssetUrl(String filename) {
+    if (!this.jsonData.has(ASSET_URLS_KEY)
+        || !this.jsonData.getJSONObject(ASSET_URLS_KEY).has(filename)) {
+      return null;
+    }
+
+    return this.jsonData.getJSONObject(ASSET_URLS_KEY).getString(filename);
+  }
+
+  public boolean doesAssetUrlExist(String filename) {
+    if (!this.jsonData.has(ASSET_URLS_KEY)) {
+      return false;
+    }
+
+    return this.jsonData.getJSONObject(ASSET_URLS_KEY).has(filename);
+  }
+
+  public void addNewAssetUrl(String filename, String url) {
+    if (!this.jsonData.has(ASSET_URLS_KEY)) {
+      this.jsonData.put(ASSET_URLS_KEY, Map.of());
+    }
+
+    this.jsonData.getJSONObject(ASSET_URLS_KEY).put(filename, url);
+  }
+}

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ProjectData.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ProjectData.java
@@ -2,6 +2,7 @@ package org.code.javabuilder;
 
 import java.util.Map;
 import org.code.protocol.InternalErrorKey;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 /**
@@ -31,11 +32,11 @@ public class ProjectData {
   private final JSONObject jsonData;
   private final UserProjectFileParser projectFileParser;
 
-  public ProjectData(String json) {
+  public ProjectData(String json) throws JSONException {
     this(json, new UserProjectFileParser());
   }
 
-  ProjectData(String json, UserProjectFileParser projectFileParser) {
+  ProjectData(String json, UserProjectFileParser projectFileParser) throws JSONException {
     this.jsonData = new JSONObject(json);
     this.projectFileParser = projectFileParser;
   }

--- a/org-code-javabuilder/lib/src/test/java/dev/javabuilder/LocalContentManagerTest.java
+++ b/org-code-javabuilder/lib/src/test/java/dev/javabuilder/LocalContentManagerTest.java
@@ -37,7 +37,7 @@ class LocalContentManagerTest {
     final String filename = "file";
     final String url = "url";
     when(projectData.getAssetUrl(filename)).thenReturn(url);
-    assertEquals(url, unitUnderTest.generateAssetUrl(filename));
+    assertEquals(url, unitUnderTest.getAssetUrl(filename));
   }
 
   @Test

--- a/org-code-javabuilder/lib/src/test/java/dev/javabuilder/LocalContentManagerTest.java
+++ b/org-code-javabuilder/lib/src/test/java/dev/javabuilder/LocalContentManagerTest.java
@@ -1,0 +1,67 @@
+package dev.javabuilder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.FileNotFoundException;
+import org.code.javabuilder.InternalServerError;
+import org.code.javabuilder.ProjectData;
+import org.code.javabuilder.UserInitiatedException;
+import org.code.javabuilder.UserProjectFiles;
+import org.code.protocol.JavabuilderException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LocalContentManagerTest {
+
+  private ProjectData projectData;
+  private UserProjectFiles projectFiles;
+  private LocalContentManager unitUnderTest;
+
+  @BeforeEach
+  public void setUp() {
+    projectData = mock(ProjectData.class);
+    projectFiles = mock(UserProjectFiles.class);
+    unitUnderTest = new LocalContentManager(projectData);
+  }
+
+  @Test
+  public void testLoadFilesReturnsSourcesFromProjectData()
+      throws UserInitiatedException, InternalServerError {
+    when(projectData.getSources()).thenReturn(projectFiles);
+    assertSame(projectFiles, unitUnderTest.loadFiles());
+  }
+
+  @Test
+  public void testGenerateAssetUrlReturnsUrlFromProjectData() {
+    final String filename = "file";
+    final String url = "url";
+    when(projectData.getAssetUrl(filename)).thenReturn(url);
+    assertEquals(url, unitUnderTest.generateAssetUrl(filename));
+  }
+
+  @Test
+  public void testGenerateUploadUrlCreatesUrlAndAddsToProjectData() throws InternalServerError {
+    final String filename = "file";
+    final String url = unitUnderTest.generateAssetUploadUrl(filename);
+    assertTrue(url.contains(filename));
+    verify(projectData).addNewAssetUrl(filename, url);
+  }
+
+  @Test
+  public void testWriteToOutputFileReturnsUrlWithFileName() throws JavabuilderException {
+    final String filename = "file";
+    assertTrue(
+        unitUnderTest.writeToOutputFile(filename, new byte[] {}, "image/png").contains(filename));
+  }
+
+  @Test
+  public void testVerifyAssetFileNameThrowsExceptionIfFileNotFound() {
+    final String filename = "file";
+    when(projectData.doesAssetUrlExist(anyString())).thenReturn(false);
+    final Exception actual =
+        assertThrows(
+            FileNotFoundException.class, () -> unitUnderTest.verifyAssetFilename(filename));
+    assertEquals(filename, actual.getMessage());
+  }
+}

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/ProjectDataTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/ProjectDataTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-// TODO: Test validation JSON when available
 class ProjectDataTest {
   private static final String MAIN_JSON_CONTENT = "{ main json }";
   private static final String MAZE_FILE_CONTENT = "{ maze file }";

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/ProjectDataTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/ProjectDataTest.java
@@ -1,0 +1,89 @@
+package org.code.javabuilder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.code.protocol.InternalErrorKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+// TODO: Test validation JSON when available
+class ProjectDataTest {
+  private static final String MAIN_JSON_CONTENT = "{ main json }";
+  private static final String MAZE_FILE_CONTENT = "{ maze file }";
+  private static final String ASSET_FILE_1 = "assetFile1.png";
+  private static final String ASSET_URL_1 = "assetUrl1.com";
+  private static final String SOURCE_JSON =
+      "{ 'sources': { 'main.json': '"
+          + MAIN_JSON_CONTENT
+          + "', 'grid.txt': '"
+          + MAZE_FILE_CONTENT
+          + "' }, 'assetUrls': { '"
+          + ASSET_FILE_1
+          + "': '"
+          + ASSET_URL_1
+          + "' } }";
+
+  private UserProjectFileParser projectFileParser;
+  private UserProjectFiles projectFiles;
+  private ArgumentCaptor<TextProjectFile> textProjectFileCaptor;
+  private ProjectData unitUnderTest;
+
+  @BeforeEach
+  public void setUp() {
+    projectFileParser = mock(UserProjectFileParser.class);
+    projectFiles = mock(UserProjectFiles.class);
+    textProjectFileCaptor = ArgumentCaptor.forClass(TextProjectFile.class);
+    unitUnderTest = new ProjectData(SOURCE_JSON, projectFileParser);
+  }
+
+  @Test
+  public void testGetSourcesThrowsExceptionIfSourcesOrMainJsonMissing() {
+    unitUnderTest = new ProjectData("{}", projectFileParser);
+    Exception actual = assertThrows(InternalServerError.class, () -> unitUnderTest.getSources());
+    assertEquals(InternalErrorKey.INTERNAL_EXCEPTION.toString(), actual.getMessage());
+
+    unitUnderTest = new ProjectData("{ 'sources': {} }", projectFileParser);
+    actual = assertThrows(InternalServerError.class, () -> unitUnderTest.getSources());
+    assertEquals(InternalErrorKey.INTERNAL_EXCEPTION.toString(), actual.getMessage());
+  }
+
+  @Test
+  public void testGetSourcesParsesAndReturnsSourceFiles()
+      throws UserInitiatedException, InternalServerError {
+    when(projectFileParser.parseFileJson(MAIN_JSON_CONTENT)).thenReturn(projectFiles);
+    doNothing().when(projectFiles).addTextFile(textProjectFileCaptor.capture());
+
+    assertSame(projectFiles, unitUnderTest.getSources());
+    verify(projectFileParser).parseFileJson(MAIN_JSON_CONTENT);
+    assertEquals(MAZE_FILE_CONTENT, textProjectFileCaptor.getValue().getFileContents());
+  }
+
+  @Test
+  public void testGetAssetUrlReturnsNullIfMissing() {
+    assertNull(unitUnderTest.getAssetUrl("otherFile.png"));
+  }
+
+  @Test
+  public void testGetAssetUrlReturnsUrlIfPresent() {
+    assertEquals(ASSET_URL_1, unitUnderTest.getAssetUrl(ASSET_FILE_1));
+  }
+
+  @Test
+  public void testDoesAssetUrlExistReturnsTrueIfAssetExists() {
+    assertTrue(unitUnderTest.doesAssetUrlExist(ASSET_FILE_1));
+    assertFalse(unitUnderTest.doesAssetUrlExist("otherFile.png"));
+  }
+
+  @Test
+  public void testAddAssetUrlAddsToJsonData() {
+    final String newAssetFile = "newAsset.wav";
+    final String newAssetUrl = "newAsset.com";
+
+    unitUnderTest.addNewAssetUrl(newAssetFile, newAssetUrl);
+
+    assertTrue(unitUnderTest.doesAssetUrlExist(newAssetFile));
+    assertEquals(newAssetUrl, unitUnderTest.getAssetUrl(newAssetFile));
+  }
+}

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ContentManager.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ContentManager.java
@@ -1,14 +1,48 @@
 package org.code.protocol;
 
+import java.io.FileNotFoundException;
+
 /**
  * Manages content (such as code sources and assets) that are used and generated during a
  * Javabuilder session.
  */
 public interface ContentManager {
-  byte[] getAssetData(String filename) throws JavabuilderException;
+  /**
+   * Generates a URL pointing to the asset file referenced by the asset file name.
+   *
+   * @param filename asset file name to generate a URL for
+   * @return generated URL
+   */
+  String generateAssetUrl(String filename);
 
+  /**
+   * Generates a URL that a client may use to upload a specific asset named by the provided file
+   * name.
+   *
+   * @param filename file to generate an asset for
+   * @return upload URL
+   * @throws JavabuilderException if the URL cannot be generated
+   */
   String generateAssetUploadUrl(String filename) throws JavabuilderException;
 
+  /**
+   * Writes the content in bytes to a file in the current session's storage location.
+   *
+   * @param filename name of the file to create
+   * @param inputBytes content of the file
+   * @param contentType content MIME type
+   * @return a URL pointing to the written file
+   * @throws JavabuilderException if the file cannot be written
+   */
   String writeToOutputFile(String filename, byte[] inputBytes, String contentType)
       throws JavabuilderException;
+
+  /**
+   * Verifies that the given asset exists in the session's storage location, and throws an exception
+   * if not.
+   *
+   * @param filename file to verify
+   * @throws FileNotFoundException if the file cannot be found
+   */
+  void verifyAssetFilename(String filename) throws FileNotFoundException;
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ContentManager.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ContentManager.java
@@ -8,16 +8,16 @@ import java.io.FileNotFoundException;
  */
 public interface ContentManager {
   /**
-   * Generates a URL pointing to the asset file referenced by the asset file name.
+   * Retrieves the URL pointing to the asset file referenced by the asset file name.
    *
-   * @param filename asset file name to generate a URL for
-   * @return generated URL
+   * @param filename asset file name to retrieve a URL for
+   * @return asset URL
    */
-  String generateAssetUrl(String filename);
+  String getAssetUrl(String filename);
 
   /**
    * Generates a URL that a client may use to upload a specific asset named by the provided file
-   * name.
+   * name, using a PUT request.
    *
    * @param filename file to generate an asset for
    * @return upload URL


### PR DESCRIPTION
First part of JAVA-449. This sets up the LocalContentManager which fetches the project JSON payload from local storage and parses it. The actual parsing and reading is handled by a separate class, ProjectData.java, so it can be reused by AWSContentManager since the JSON-level operations will be the same. As of now, this content manager is not hooked up to anything so it should not result in any changes. Also, some of LocalContentManager's methods like generateAssetUploadUrl and writeToOutputFile are very similar or the same as the existing LocalFileManager methods.

JIRA: https://codedotorg.atlassian.net/browse/JAVA-449

Tested by manually seeding local storage with a JSON file and parsing sources and assets data via print statements, as well as unit tests.