### PR TITLE
Allow clients to upload sources on localhost

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/CORSFilter.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/CORSFilter.java
@@ -1,6 +1,7 @@
 package dev.javabuilder;
 
 import static dev.javabuilder.LocalWebserverConstants.DIRECTORY;
+import static dev.javabuilder.LocalWebserverConstants.SEED_SOURCES_ENDPOINT;
 import static org.code.protocol.AllowedFileNames.*;
 
 import java.io.IOException;
@@ -41,8 +42,11 @@ public class CORSFilter extends HttpFilter {
       response.sendError(
           403,
           String.format(
-              "Only %s, %s, and %s files can be accessed.",
-              THEATER_IMAGE_NAME, THEATER_AUDIO_NAME, PROMPTER_FILE_NAME_PREFIX));
+              "Only %s, %s, %s, and %s files/endpoints can be accessed.",
+              SEED_SOURCES_ENDPOINT,
+              THEATER_IMAGE_NAME,
+              THEATER_AUDIO_NAME,
+              PROMPTER_FILE_NAME_PREFIX));
       return;
     }
 
@@ -52,7 +56,8 @@ public class CORSFilter extends HttpFilter {
       return;
     }
 
-    if (fileName.indexOf(PROMPTER_FILE_NAME_PREFIX) == 0) {
+    if (fileName.equals(SEED_SOURCES_ENDPOINT)
+        || fileName.indexOf(PROMPTER_FILE_NAME_PREFIX) == 0) {
       // Add CORS headers only if the request is for a known file
       response.addHeader("Access-Control-Allow-Origin", requestOrigin);
       response.addHeader("Access-Control-Allow-Headers", "*");
@@ -68,7 +73,8 @@ public class CORSFilter extends HttpFilter {
   }
 
   private boolean getAllowedExternal(String fileName) {
-    return fileName.equals(THEATER_IMAGE_NAME)
+    return fileName.equals(SEED_SOURCES_ENDPOINT)
+        || fileName.equals(THEATER_IMAGE_NAME)
         || fileName.equals(THEATER_AUDIO_NAME)
         || fileName.indexOf(PROMPTER_FILE_NAME_PREFIX) == 0;
   }

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/HttpFileServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/HttpFileServer.java
@@ -4,6 +4,7 @@ import static dev.javabuilder.LocalWebserverConstants.DIRECTORY;
 import static dev.javabuilder.LocalWebserverConstants.SEED_SOURCES_ENDPOINT;
 import static org.code.protocol.AllowedFileNames.PROMPTER_FILE_NAME_PREFIX;
 
+import dev.javabuilder.util.TempDirectoryUtils;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -14,7 +15,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.code.javabuilder.ProjectData;
-import org.code.javabuilder.util.TempDirectoryUtils;
 
 /**
  * This sets up an HTTP server for local development when the client needs to be able to access
@@ -57,6 +57,8 @@ public class HttpFileServer extends HttpServlet {
     }
 
     if (fileName.equals(SEED_SOURCES_ENDPOINT)) {
+      // If a client is accessing this endpoint, they are uploading project data as a JSON payload.
+      // Use the pre-defined project data file name (rather than the endpoint name).
       fileName = ProjectData.PROJECT_DATA_FILE_NAME;
     }
 

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalFileManager.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalFileManager.java
@@ -2,6 +2,7 @@ package dev.javabuilder;
 
 import static dev.javabuilder.LocalWebserverConstants.DIRECTORY;
 
+import dev.javabuilder.util.TempDirectoryUtils;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -11,7 +12,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.code.javabuilder.InternalServerError;
 import org.code.javabuilder.util.FileUtils;
-import org.code.javabuilder.util.TempDirectoryUtils;
 import org.code.protocol.InternalErrorKey;
 import org.code.protocol.JavabuilderException;
 import org.code.protocol.JavabuilderFileManager;

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalFileManager.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalFileManager.java
@@ -11,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.code.javabuilder.InternalServerError;
 import org.code.javabuilder.util.FileUtils;
+import org.code.javabuilder.util.TempDirectoryUtils;
 import org.code.protocol.InternalErrorKey;
 import org.code.protocol.JavabuilderException;
 import org.code.protocol.JavabuilderFileManager;
@@ -24,10 +25,7 @@ public class LocalFileManager implements JavabuilderFileManager {
       throws JavabuilderException {
     File file = Paths.get(System.getProperty("java.io.tmpdir"), DIRECTORY, filename).toFile();
     try {
-      File parentDirectory = Paths.get(System.getProperty("java.io.tmpdir"), DIRECTORY).toFile();
-      if (!parentDirectory.exists()) {
-        parentDirectory.mkdirs();
-      }
+      TempDirectoryUtils.createTempDirectoryIfNeeded();
       Files.write(file.toPath(), inputBytes);
     } catch (IOException e) {
       throw new InternalServerError(InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION, e);
@@ -37,10 +35,7 @@ public class LocalFileManager implements JavabuilderFileManager {
 
   @Override
   public String getUploadUrl(String filename) {
-    File parentDirectory = Paths.get(System.getProperty("java.io.tmpdir"), DIRECTORY).toFile();
-    if (!parentDirectory.exists()) {
-      parentDirectory.mkdirs();
-    }
+    TempDirectoryUtils.createTempDirectoryIfNeeded();
     return String.format(SERVER_URL_FORMAT, DIRECTORY, filename);
   }
 

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalWebserverConstants.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalWebserverConstants.java
@@ -2,4 +2,5 @@ package dev.javabuilder;
 
 public class LocalWebserverConstants {
   public static final String DIRECTORY = "javabuilderfiles";
+  public static final String SEED_SOURCES_ENDPOINT = "seedsources";
 }

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/util/TempDirectoryUtils.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/util/TempDirectoryUtils.java
@@ -1,4 +1,4 @@
-package org.code.javabuilder.util;
+package dev.javabuilder.util;
 
 import static dev.javabuilder.LocalWebserverConstants.DIRECTORY;
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/util/TempDirectoryUtils.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/util/TempDirectoryUtils.java
@@ -1,0 +1,20 @@
+package org.code.javabuilder.util;
+
+import static dev.javabuilder.LocalWebserverConstants.DIRECTORY;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+public final class TempDirectoryUtils {
+  private TempDirectoryUtils() {
+    throw new UnsupportedOperationException("Instantiation of utility class is not allowed.");
+  }
+
+  public static void createTempDirectoryIfNeeded() {
+    final File parentDirectory =
+        Paths.get(System.getProperty("java.io.tmpdir"), DIRECTORY).toFile();
+    if (!parentDirectory.exists()) {
+      parentDirectory.mkdirs();
+    }
+  }
+}


### PR DESCRIPTION
Note: this is currently branched off of https://github.com/code-dot-org/javabuilder/pull/215/ only because it references a constant in `ProjectData` - all other changes are independent.

This allows clients (like Dashboard) to upload the sources JSON payload to the local fileserver when developing on localhost. It references a new "seed sources" endpoint (localhost:8080/javabuilderfiles/seedsources) that Dashboard will use to make a PUT request to.

Tested locally - confirmed that dashboard making a PUT request to this URL results in the json payload being placed in the temp directory.