### PR TITLE
Implement AWSContentManager

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalContentManager.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalContentManager.java
@@ -76,6 +76,16 @@ public class LocalContentManager implements ContentManager, ProjectFileLoader {
 
   @Override
   public void verifyAssetFilename(String filename) throws FileNotFoundException {
+    try {
+      // We should only hit this exception if we try to verify an asset before source code has
+      // been loaded, which should only be in the the case of manual testing. Log this exception but
+      // convert to a FileNotFoundException to preserve the method contract.
+      // Note / TODO: Once we fully migrate away from Dashboard sources, we can remove the
+      // loadProjectDataIfNeeded() call here and this exception handling.
+      this.loadProjectDataIfNeeded();
+    } catch (InternalServerError e) {
+      throw new FileNotFoundException("Error loading data");
+    }
     if (!this.projectData.doesAssetUrlExist(filename)) {
       throw new FileNotFoundException(filename);
     }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSContentManager.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSContentManager.java
@@ -28,7 +28,7 @@ public class AWSContentManager implements ContentManager, ProjectFileLoader {
   private final String bucketName;
   private final AmazonS3 s3Client;
   private final String javabuilderSessionId;
-  private final String getContentUrl;
+  private final String contentBucketUrl;
   private final Context context;
   private ProjectData projectData;
   private int writes;
@@ -38,22 +38,22 @@ public class AWSContentManager implements ContentManager, ProjectFileLoader {
       AmazonS3 s3Client,
       String bucketName,
       String javabuilderSessionId,
-      String getContentUrl,
+      String contentBucketUrl,
       Context context) {
-    this(s3Client, bucketName, javabuilderSessionId, getContentUrl, context, null);
+    this(s3Client, bucketName, javabuilderSessionId, contentBucketUrl, context, null);
   }
 
   AWSContentManager(
       AmazonS3 s3Client,
       String bucketName,
       String javabuilderSessionId,
-      String getContentUrl,
+      String contentBucketUrl,
       Context context,
       ProjectData projectData) {
     this.bucketName = bucketName;
     this.s3Client = s3Client;
     this.javabuilderSessionId = javabuilderSessionId;
-    this.getContentUrl = getContentUrl;
+    this.contentBucketUrl = contentBucketUrl;
     this.context = context;
     this.projectData = projectData;
     this.writes = 0;
@@ -96,8 +96,8 @@ public class AWSContentManager implements ContentManager, ProjectFileLoader {
               this.bucketName, key, new Date(expirationTimeMs), HttpMethod.PUT);
       this.uploads++;
       // Add the GET url for this file to the asset map so it can be referenced later.
-      this.projectData.addNewAssetUrl(filename, this.getContentUrl + "/" + key);
-      return this.getContentUrl + presignedUrl.getFile();
+      this.projectData.addNewAssetUrl(filename, this.contentBucketUrl + "/" + key);
+      return this.contentBucketUrl + presignedUrl.getFile();
     } catch (AbortedException e) {
       // this is most likely because the end user interrupted program execution. We can safely
       // ignore this.
@@ -131,7 +131,7 @@ public class AWSContentManager implements ContentManager, ProjectFileLoader {
     }
 
     this.writes++;
-    return this.getContentUrl + "/" + filePath;
+    return this.contentBucketUrl + "/" + filePath;
   }
 
   @Override
@@ -151,6 +151,10 @@ public class AWSContentManager implements ContentManager, ProjectFileLoader {
     }
   }
 
+  /**
+   * Generates the S3 key for this file. All files are stored in the Javabuilder S3 bucket under a
+   * sub-folder named after the current session's ID, so this returns "<session ID>/<file name>"
+   */
   private String generateKey(String filename) {
     return this.javabuilderSessionId + "/" + filename;
   }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSContentManager.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSContentManager.java
@@ -91,11 +91,13 @@ public class AWSContentManager implements ContentManager, ProjectFileLoader {
     final long expirationTimeMs = System.currentTimeMillis() + context.getRemainingTimeInMillis();
 
     try {
-      final URL uploadUrl =
+      final URL presignedUrl =
           s3Client.generatePresignedUrl(
               this.bucketName, key, new Date(expirationTimeMs), HttpMethod.PUT);
       this.uploads++;
-      return this.getContentUrl + uploadUrl.getFile();
+      // Add the GET url for this file to the asset map so it can be referenced later.
+      this.projectData.addNewAssetUrl(filename, this.getContentUrl + "/" + key);
+      return this.getContentUrl + presignedUrl.getFile();
     } catch (AbortedException e) {
       // this is most likely because the end user interrupted program execution. We can safely
       // ignore this.

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSContentManager.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSContentManager.java
@@ -1,0 +1,181 @@
+package org.code.javabuilder;
+
+import com.amazonaws.AbortedException;
+import com.amazonaws.HttpMethod;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import org.code.protocol.ContentManager;
+import org.code.protocol.InternalErrorKey;
+import org.code.protocol.JavabuilderException;
+import org.code.protocol.LoggerUtils;
+
+public class AWSContentManager implements ContentManager, ProjectFileLoader {
+  // Temporary limit on writes per session until we can more fully limit usage.
+  private static final int WRITES_PER_SESSION = 2;
+  // Limit on the amount of S3 file uploads per session to avoid spamming
+  private static final int UPLOADS_PER_SESSION = 20;
+
+  private final String bucketName;
+  private final AmazonS3 s3Client;
+  private final String javabuilderSessionId;
+  private final String getContentUrl;
+  private final Context context;
+  private ProjectData projectData;
+  private int writes;
+  private int uploads;
+
+  public AWSContentManager(
+      AmazonS3 s3Client,
+      String bucketName,
+      String javabuilderSessionId,
+      String getContentUrl,
+      Context context) {
+    this(s3Client, bucketName, javabuilderSessionId, getContentUrl, context, null);
+  }
+
+  AWSContentManager(
+      AmazonS3 s3Client,
+      String bucketName,
+      String javabuilderSessionId,
+      String getContentUrl,
+      Context context,
+      ProjectData projectData) {
+    this.bucketName = bucketName;
+    this.s3Client = s3Client;
+    this.javabuilderSessionId = javabuilderSessionId;
+    this.getContentUrl = getContentUrl;
+    this.context = context;
+    this.projectData = projectData;
+    this.writes = 0;
+    this.uploads = 0;
+  }
+
+  @Override
+  public UserProjectFiles loadFiles() throws InternalServerError, UserInitiatedException {
+    this.loadProjectDataIfNeeded();
+    return this.projectData.getSources();
+  }
+
+  @Override
+  public String getAssetUrl(String filename) {
+    try {
+      this.loadProjectDataIfNeeded();
+    } catch (InternalServerError e) {
+      // We should only hit this exception if we try to load an asset URL before source code has
+      // been loaded, which should only be in the the case of manual testing. Log this exception but
+      // don't throw to preserve the method contract.
+      // Note / TODO: Once we fully migrate away from Dashboard sources, we can remove the
+      // loadProjectDataIfNeeded() call here and this exception handling.
+      LoggerUtils.logException(e);
+      return null;
+    }
+    return this.projectData.getAssetUrl(filename);
+  }
+
+  @Override
+  public String generateAssetUploadUrl(String filename) throws JavabuilderException {
+    if (this.uploads >= UPLOADS_PER_SESSION) {
+      throw new UserInitiatedException(UserInitiatedExceptionKey.TOO_MANY_UPLOADS);
+    }
+    final String key = this.generateKey(filename);
+    final long expirationTimeMs = System.currentTimeMillis() + context.getRemainingTimeInMillis();
+
+    try {
+      final URL uploadUrl =
+          s3Client.generatePresignedUrl(
+              this.bucketName, key, new Date(expirationTimeMs), HttpMethod.PUT);
+      this.uploads++;
+      return this.getContentUrl + uploadUrl.getFile();
+    } catch (AbortedException e) {
+      // this is most likely because the end user interrupted program execution. We can safely
+      // ignore this.
+    } catch (SdkClientException e) {
+      throw new InternalServerError(InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION, e);
+    }
+
+    return null;
+  }
+
+  @Override
+  public String writeToOutputFile(String filename, byte[] inputBytes, String contentType)
+      throws JavabuilderException {
+    if (this.writes >= WRITES_PER_SESSION) {
+      throw new UserInitiatedException(UserInitiatedExceptionKey.TOO_MANY_WRITES);
+    }
+    String filePath = this.generateKey(filename);
+    ObjectMetadata metadata = new ObjectMetadata();
+    metadata.setContentType(contentType);
+    metadata.setContentLength(inputBytes.length);
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(inputBytes);
+
+    try {
+      this.s3Client.putObject(this.bucketName, filePath, inputStream, metadata);
+    } catch (AbortedException e) {
+      // this is most likely because the end user interrupted program execution. We can safely
+      // ignore this.
+    } catch (SdkClientException e) {
+      // We couldn't write to S3, send a message to the user and fail. The S3 SDK includes retries.
+      throw new InternalServerError(InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION, e);
+    }
+
+    this.writes++;
+    return this.getContentUrl + "/" + filePath;
+  }
+
+  @Override
+  public void verifyAssetFilename(String filename) throws FileNotFoundException {
+    try {
+      // We should only hit this exception if we try to verify an asset before source code has
+      // been loaded, which should only be in the the case of manual testing. Log this exception but
+      // convert to a FileNotFoundException to preserve the method contract.
+      // Note / TODO: Once we fully migrate away from Dashboard sources, we can remove the
+      // loadProjectDataIfNeeded() call here and this exception handling.
+      this.loadProjectDataIfNeeded();
+    } catch (InternalServerError e) {
+      throw new FileNotFoundException("Error loading data");
+    }
+    if (!this.projectData.doesAssetUrlExist(filename)) {
+      throw new FileNotFoundException(filename);
+    }
+  }
+
+  private String generateKey(String filename) {
+    return this.javabuilderSessionId + "/" + filename;
+  }
+
+  // TODO: Project JSON data loading is deferred because it will not exist if we are
+  // still using dashboard sources. Once we stop using dashboard sources, this step
+  // can probably just happen immediately in the constructor.
+  private void loadProjectDataIfNeeded() throws InternalServerError {
+    if (this.projectData != null) {
+      return;
+    }
+
+    final String key = this.generateKey(ProjectData.PROJECT_DATA_FILE_NAME);
+    final S3Object sourcesS3Object;
+
+    try {
+      sourcesS3Object = this.s3Client.getObject(this.bucketName, key);
+    } catch (SdkClientException e) {
+      throw new InternalServerError(InternalErrorKey.INTERNAL_EXCEPTION, e);
+    }
+
+    try (final S3ObjectInputStream inputStream = sourcesS3Object.getObjectContent()) {
+      final String jsonString = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+      this.projectData = new ProjectData(jsonString);
+    } catch (IOException e) {
+      // Error reading JSON file from S3
+      throw new InternalServerError(InternalErrorKey.INTERNAL_EXCEPTION, e);
+    }
+  }
+}

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserInitiatedException.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserInitiatedException.java
@@ -11,4 +11,8 @@ public class UserInitiatedException extends JavabuilderException {
   public UserInitiatedException(UserInitiatedExceptionKey key, Throwable cause) {
     super(key, cause);
   }
+
+  public UserInitiatedException(UserInitiatedExceptionKey key, String fallbackMessage) {
+    super(key, fallbackMessage);
+  }
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserInitiatedExceptionKey.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserInitiatedExceptionKey.java
@@ -14,9 +14,12 @@ public enum UserInitiatedExceptionKey {
   COMPILER_ERROR,
   // The user tried to include a source file that did not end in .java
   JAVA_EXTENSION_MISSING,
-  // The user is writing to file too many times
+  // The user is writing to a file in S3 too many times in a single session. The only file writing
+  // that may happen is during a Theater project, when the theater image and theater audio files are
+  // written to S3.
   TOO_MANY_WRITES,
-  // The user is uploading a file too many times
+  // The user is uploading a file to S3 too many times in a single session. The only file uploading
+  // that may happen is during a Theater project using the Prompter feature.
   TOO_MANY_UPLOADS,
   // The user tried to run a file without a class definition
   CLASS_NOT_FOUND,

--- a/org-code-javabuilder/lib/src/test/java/dev/javabuilder/LocalContentManagerTest.java
+++ b/org-code-javabuilder/lib/src/test/java/dev/javabuilder/LocalContentManagerTest.java
@@ -3,6 +3,7 @@ package dev.javabuilder;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import dev.javabuilder.util.TempDirectoryUtils;
 import java.io.FileNotFoundException;
 import org.code.javabuilder.InternalServerError;
 import org.code.javabuilder.ProjectData;
@@ -20,6 +21,7 @@ class LocalContentManagerTest {
 
   @BeforeEach
   public void setUp() {
+    TempDirectoryUtils.createTempDirectoryIfNeeded();
     projectData = mock(ProjectData.class);
     projectFiles = mock(UserProjectFiles.class);
     unitUnderTest = new LocalContentManager(projectData);

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/AWSContentManagerTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/AWSContentManagerTest.java
@@ -1,0 +1,123 @@
+package org.code.javabuilder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.s3.AmazonS3;
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.net.URL;
+import java.util.Date;
+import org.code.protocol.JavabuilderException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AWSContentManagerTest {
+  private AmazonS3 s3ClientMock;
+  private AWSContentManager contentManager;
+  private Context context;
+  private ProjectData projectData;
+  private UserProjectFiles projectFiles;
+
+  private static final String FAKE_BUCKET_NAME = "bucket-name";
+  private static final String FAKE_SESSION_ID = "12345";
+  private static final String FAKE_OUTPUT_URL = "a-url";
+
+  @BeforeEach
+  void setUp() {
+    s3ClientMock = mock(AmazonS3.class);
+    context = mock(Context.class);
+    projectData = mock(ProjectData.class);
+    projectFiles = mock(UserProjectFiles.class);
+    contentManager =
+        new AWSContentManager(
+            s3ClientMock, FAKE_BUCKET_NAME, FAKE_SESSION_ID, FAKE_OUTPUT_URL, context, projectData);
+  }
+
+  @Test
+  void canOnlyWriteTwice() throws JavabuilderException {
+    contentManager.writeToOutputFile("test.gif", new byte[10], "image/gif");
+    contentManager.writeToOutputFile("test2.wav", new byte[10], "audio/wav");
+    assertThrows(
+        UserInitiatedException.class,
+        () -> contentManager.writeToOutputFile("test3.txt", new byte[10], "text/plain"));
+  }
+
+  @Test
+  void writesToS3() throws JavabuilderException {
+    byte[] input = new byte[10];
+    contentManager.writeToOutputFile("test.txt", input, "text/plain");
+    String key = FAKE_SESSION_ID + "/test.txt";
+    verify(s3ClientMock)
+        .putObject(anyString(), anyString(), any(ByteArrayInputStream.class), any());
+  }
+
+  @Test
+  public void testGetUploadUrlReturnsGeneratedUrl() throws JavabuilderException {
+    final String fileName = "file1";
+    final String key = FAKE_SESSION_ID + "/" + fileName;
+    final String urlFileName = "/file/path?queryParams";
+    final URL presignedUrl = mock(URL.class);
+    when(presignedUrl.getFile()).thenReturn(urlFileName);
+    when(context.getRemainingTimeInMillis()).thenReturn(1000);
+    when(s3ClientMock.generatePresignedUrl(
+            eq(FAKE_BUCKET_NAME), eq(key), any(Date.class), eq(HttpMethod.PUT)))
+        .thenReturn(presignedUrl);
+
+    final String uploadUrl = contentManager.generateAssetUploadUrl(fileName);
+    assertEquals(FAKE_OUTPUT_URL + urlFileName, uploadUrl);
+    verify(s3ClientMock)
+        .generatePresignedUrl(eq(FAKE_BUCKET_NAME), eq(key), any(Date.class), eq(HttpMethod.PUT));
+  }
+
+  @Test
+  public void testGetUploadUrlThrowsExceptionForTooManyUploads() throws JavabuilderException {
+    final URL presignedUrl = mock(URL.class);
+    when(presignedUrl.getFile()).thenReturn("/file/path?queryParams");
+    when(context.getRemainingTimeInMillis()).thenReturn(1000);
+    when(s3ClientMock.generatePresignedUrl(
+            eq(FAKE_BUCKET_NAME), anyString(), any(Date.class), eq(HttpMethod.PUT)))
+        .thenReturn(presignedUrl);
+
+    // Upload limit is 20
+    for (int i = 0; i < 20; i++) {
+      contentManager.generateAssetUploadUrl("file");
+    }
+
+    final Exception exception =
+        assertThrows(
+            UserInitiatedException.class, () -> contentManager.generateAssetUploadUrl("file"));
+    assertEquals(UserInitiatedExceptionKey.TOO_MANY_UPLOADS.toString(), exception.getMessage());
+  }
+
+  @Test
+  public void testLoadFilesReturnsSourcesFromProjectData()
+      throws UserInitiatedException, InternalServerError {
+    when(projectData.getSources()).thenReturn(projectFiles);
+    assertSame(projectFiles, contentManager.loadFiles());
+  }
+
+  @Test
+  public void testGenerateAssetUrlReturnsUrlFromProjectData() {
+    final String filename = "file";
+    final String url = "url";
+    when(projectData.getAssetUrl(filename)).thenReturn(url);
+    assertEquals(url, contentManager.getAssetUrl(filename));
+  }
+
+  @Test
+  public void testVerifyAssetFileNameThrowsExceptionIfFileNotFound() {
+    final String filename = "file";
+    when(projectData.doesAssetUrlExist(anyString())).thenReturn(false);
+    final Exception actual =
+        assertThrows(
+            FileNotFoundException.class, () -> contentManager.verifyAssetFilename(filename));
+    assertEquals(filename, actual.getMessage());
+  }
+}

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/AWSContentManagerTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/AWSContentManagerTest.java
@@ -17,6 +17,7 @@ import java.util.Date;
 import org.code.protocol.JavabuilderException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class AWSContentManagerTest {
   private AmazonS3 s3ClientMock;
@@ -24,6 +25,7 @@ class AWSContentManagerTest {
   private Context context;
   private ProjectData projectData;
   private UserProjectFiles projectFiles;
+  private ArgumentCaptor<String> assetUrlCaptor;
 
   private static final String FAKE_BUCKET_NAME = "bucket-name";
   private static final String FAKE_SESSION_ID = "12345";
@@ -35,6 +37,7 @@ class AWSContentManagerTest {
     context = mock(Context.class);
     projectData = mock(ProjectData.class);
     projectFiles = mock(UserProjectFiles.class);
+    assetUrlCaptor = ArgumentCaptor.forClass(String.class);
     contentManager =
         new AWSContentManager(
             s3ClientMock, FAKE_BUCKET_NAME, FAKE_SESSION_ID, FAKE_OUTPUT_URL, context, projectData);
@@ -74,6 +77,9 @@ class AWSContentManagerTest {
     assertEquals(FAKE_OUTPUT_URL + urlFileName, uploadUrl);
     verify(s3ClientMock)
         .generatePresignedUrl(eq(FAKE_BUCKET_NAME), eq(key), any(Date.class), eq(HttpMethod.PUT));
+    // Verify that the URL was added to the project data's asset map
+    verify(projectData).addNewAssetUrl(eq(fileName), assetUrlCaptor.capture());
+    assertTrue(assetUrlCaptor.getValue().contains(key));
   }
 
   @Test


### PR DESCRIPTION
Adds the Lambda implementation of the ContentManager interface. Not really much new content here - the project data getter methods (loadFiles, getAssetUrl, verifyAssetFileName) are exactly the same as LocalContentManager, and the generateAssetUploadUrl/writeToOutputFile methods are pretty much copies from the existing methods in AWSFileManager. The only difference is how AWSContentManager fetches the JSON file (in `loadProjectDataIfNeeded()`). This also includes a few minor fixes to LocalContentManager & LocalContentManagerTest.

Testing - tested by manually seeding S3 bucket with a JSON payload and confirming that all the correct data is read out and parsed + unit tests.