### PR TITLE
Integrate content manager, gated behind useDashboardSources flag

### DIFF
--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -51,7 +51,8 @@ def on_connect(event, context)
     :miniAppType => authorizer["mini_app_type"],
     :javabuilderSessionId => authorizer['sid'],
     :queueName => queue_name,
-    :executionType => authorizer['execution_type']
+    :executionType => authorizer['execution_type'],
+    :useDashboardSources => authorizer["use_dashboard_sources"]
   }
 
   response = nil

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
@@ -23,7 +23,15 @@ public class LocalMain {
     logger.setUseParentHandlers(false);
 
     GlobalProtocol.create(
-        outputAdapter, inputAdapter, "", "", "", new LocalFileManager(), new LifecycleNotifier());
+        outputAdapter,
+        inputAdapter,
+        "",
+        "",
+        "",
+        new LocalFileManager(),
+        new LifecycleNotifier(),
+        new LocalContentManager(),
+        true);
     CachedResources.create();
 
     // Create and invoke the code execution environment

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -61,6 +61,7 @@ public class WebSocketServer {
     final ExecutionType executionType =
         ExecutionType.valueOf(queryInput.getString("execution_type"));
     final String dashboardHostname = "http://" + queryInput.get("iss") + ":3000";
+    final boolean useDashboardSources = queryInput.getBoolean("use_dashboard_sources");
     final JSONObject options = new JSONObject(queryInput.getString("options"));
     final boolean useNeighborhood =
         JSONUtils.booleanFromJSONObjectMember(options, "useNeighborhood");
@@ -82,6 +83,7 @@ public class WebSocketServer {
       outputAdapter = new UserTestOutputAdapter(websocketOutputAdapter);
     }
     final LifecycleNotifier lifecycleNotifier = new LifecycleNotifier();
+    final LocalContentManager contentManager = new LocalContentManager();
     GlobalProtocol.create(
         outputAdapter,
         inputAdapter,
@@ -89,13 +91,17 @@ public class WebSocketServer {
         channelId,
         levelId,
         new LocalFileManager(),
-        lifecycleNotifier);
-    final UserProjectFileLoader fileLoader =
-        new UserProjectFileLoader(
-            GlobalProtocol.getInstance().generateSourcesUrl(),
-            levelId,
-            dashboardHostname,
-            useNeighborhood);
+        lifecycleNotifier,
+        contentManager,
+        useDashboardSources);
+    final ProjectFileLoader fileLoader =
+        useDashboardSources
+            ? new UserProjectFileLoader(
+                GlobalProtocol.getInstance().generateSourcesUrl(),
+                levelId,
+                dashboardHostname,
+                useNeighborhood)
+            : contentManager;
 
     // the code must be run in a thread so we can receive input messages
     Thread codeExecutor =
@@ -121,6 +127,7 @@ public class WebSocketServer {
             });
 
     codeExecutor.start();
+    System.out.println("Using dashboard sources: " + useDashboardSources);
   }
 
   @OnClose

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -127,7 +127,6 @@ public class WebSocketServer {
             });
 
     codeExecutor.start();
-    System.out.println("Using dashboard sources: " + useDashboardSources);
   }
 
   @OnClose

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -187,7 +187,6 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
 
     try {
       // start code build and block until completed
-      Logger.getLogger(MAIN_LOGGER).info("Using dashboard sources: " + useDashboardSources);
       codeExecutionManager.execute();
     } catch (Throwable e) {
       // All errors should be caught, but if for any reason we encounter an error here, make sure we

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/DelegatingAssetFileHelper.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/DelegatingAssetFileHelper.java
@@ -1,0 +1,40 @@
+package org.code.protocol;
+
+import java.io.FileNotFoundException;
+
+/**
+ * An {@link AssetFileHelper} that delegates to either the standard AssetFileHelper implementations
+ * of its methods, or to a {@link ContentManager}. Used to temporarily support two code paths.
+ */
+public class DelegatingAssetFileHelper extends AssetFileHelper {
+
+  private final ContentManager contentManager;
+  private final boolean useDashboardSources;
+
+  public DelegatingAssetFileHelper(
+      String dashboardHostname,
+      String channelId,
+      String levelId,
+      ContentManager contentManager,
+      boolean useDashboardSources) {
+    super(dashboardHostname, channelId, levelId);
+    this.contentManager = contentManager;
+    this.useDashboardSources = useDashboardSources;
+  }
+
+  @Override
+  public String generateAssetUrl(String filename) {
+    return this.useDashboardSources
+        ? super.generateAssetUrl(filename)
+        : this.contentManager.getAssetUrl(filename);
+  }
+
+  @Override
+  public void verifyAssetFilename(String filename) throws FileNotFoundException {
+    if (this.useDashboardSources) {
+      super.verifyAssetFilename(filename);
+    } else {
+      this.contentManager.verifyAssetFilename(filename);
+    }
+  }
+}

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/DelegatingFileManager.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/DelegatingFileManager.java
@@ -1,0 +1,62 @@
+package org.code.protocol;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * A {@link JavabuilderFileManager} that delegates to either an implementation configured to work
+ * with Dashboard or to a {@link ContentManager}. Used to temporarily support two code paths.
+ */
+public class DelegatingFileManager implements JavabuilderFileManager {
+
+  private final JavabuilderFileManager dashboardFileManager;
+  private final ContentManager contentManager;
+  private final boolean useDashboardSources;
+
+  public DelegatingFileManager(
+      JavabuilderFileManager dashboardFileManager,
+      ContentManager contentManager,
+      boolean useDashboardSources) {
+    this.dashboardFileManager = dashboardFileManager;
+    this.contentManager = contentManager;
+    this.useDashboardSources = useDashboardSources;
+  }
+
+  @Override
+  public String writeToFile(String filename, byte[] inputBytes, String contentType)
+      throws JavabuilderException {
+    return this.useDashboardSources
+        ? this.dashboardFileManager.writeToFile(filename, inputBytes, contentType)
+        : this.contentManager.writeToOutputFile(filename, inputBytes, contentType);
+  }
+
+  @Override
+  public String getUploadUrl(String filename) throws JavabuilderException {
+    return this.useDashboardSources
+        ? this.dashboardFileManager.getUploadUrl(filename)
+        : this.contentManager.generateAssetUploadUrl(filename);
+  }
+
+  @Override
+  public URL getFileUrl(String filename) throws FileNotFoundException {
+    if (this.useDashboardSources) {
+      return this.dashboardFileManager.getFileUrl(filename);
+    }
+
+    // If using ContentManager, the local file URL should have been added to the asset URL map, so
+    // we can request the asset URL for this file.
+    try {
+      return new URL(this.contentManager.getAssetUrl(filename));
+    } catch (MalformedURLException e) {
+      throw new FileNotFoundException(filename);
+    }
+  }
+
+  @Override
+  public void cleanUpTempDirectory(File tempFolder) throws IOException {
+    this.dashboardFileManager.cleanUpTempDirectory(tempFolder);
+  }
+}

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
@@ -47,15 +47,18 @@ public class GlobalProtocol {
       String channelId,
       String levelId,
       JavabuilderFileManager fileManager,
-      LifecycleNotifier lifecycleNotifier) {
+      LifecycleNotifier lifecycleNotifier,
+      ContentManager contentManager,
+      boolean useDashboardSources) {
     GlobalProtocol.protocolInstance =
         new GlobalProtocol(
             outputAdapter,
             new InputHandler(inputAdapter),
             dashboardHostname,
             channelId,
-            fileManager,
-            new AssetFileHelper(dashboardHostname, channelId, levelId),
+            new DelegatingFileManager(fileManager, contentManager, useDashboardSources),
+            new DelegatingAssetFileHelper(
+                dashboardHostname, channelId, levelId, contentManager, useDashboardSources),
             lifecycleNotifier);
   }
 

--- a/org-code-javabuilder/protocol/src/testFixtures/java/org/code/protocol/GlobalProtocolTestFactory.java
+++ b/org-code-javabuilder/protocol/src/testFixtures/java/org/code/protocol/GlobalProtocolTestFactory.java
@@ -15,6 +15,8 @@ public class GlobalProtocolTestFactory {
     private String levelId;
     private JavabuilderFileManager fileManager;
     private LifecycleNotifier lifecycleNotifier;
+    private ContentManager contentManager;
+    private boolean useDashboardSources;
 
     private Builder() {
       this.outputAdapter = mock(OutputAdapter.class);
@@ -24,6 +26,8 @@ public class GlobalProtocolTestFactory {
       this.levelId = "";
       this.fileManager = mock(JavabuilderFileManager.class);
       this.lifecycleNotifier = mock(LifecycleNotifier.class);
+      this.contentManager = mock(ContentManager.class);
+      this.useDashboardSources = true;
     }
 
     public Builder withOutputAdapter(OutputAdapter outputAdapter) {
@@ -61,6 +65,16 @@ public class GlobalProtocolTestFactory {
       return this;
     }
 
+    public Builder withContentManager(ContentManager contentManager) {
+      this.contentManager = contentManager;
+      return this;
+    }
+
+    public Builder withUseDashboardSources(boolean useDashboardSources) {
+      this.useDashboardSources = useDashboardSources;
+      return this;
+    }
+
     public void create() {
       GlobalProtocol.create(
           this.outputAdapter,
@@ -69,7 +83,9 @@ public class GlobalProtocolTestFactory {
           this.channelId,
           this.levelId,
           this.fileManager,
-          this.lifecycleNotifier);
+          this.lifecycleNotifier,
+          this.contentManager,
+          this.useDashboardSources);
     }
   }
 }


### PR DESCRIPTION
This change hooks up the ContentManager implementations to be used via GlobalProtocol. The logic to decide which code path to use (dashboard sources or S3/local sources) is abstracted behind two new classes, DelegatingAssetFileHelper and DelegatingFileManager and driven by the `useDashboardSources` flag that's sent from Javalab ([here](https://github.com/code-dot-org/code-dot-org/blob/d98116605c7ce08abbdc96ca6c0098df7dab9977/apps/src/javalab/JavabuilderConnection.js#L62)). This is so that external callers (Image, AudioUtils, Stage, Board, etc) don't have to change to any method contracts. Once we're fully migrated to the new code path, we can remove these abstractions and clean up the APIs a bit.

JIRA: https://codedotorg.atlassian.net/browse/JAVA-449

Testing: tested the following scenarios end-to-end and confirmed that projects execute successfully
- localhost Dashboard -> localhost Javabuilder (both using dashboard sources and not using dashboard sources)
- staging Dashboard -> deployed Javabuilder via Postman w/ prototype API Gateway (using dashboard sources)
- localhost Dashboard -> deployed Javabuilder w/ prototype API Gateway (not using dashboard sources). This worked successfully for Neighborhood, Console, Playground, and Theater projects that only use prompter images 🎉 