### PR TITLE
Add new bucket name to IAM template

### DIFF
--- a/iam.yml
+++ b/iam.yml
@@ -39,11 +39,17 @@ Resources:
                   - "cloudformation:DescribeStacks"
                 Resource: '*'
 
-              # BuildAndRunJavaProject Lambda needs to put objects to the output bucket.
+              # TODO: Remove this once Javabuilder has changed its bucket name
               - Effect: Allow
                 Action:
                   - 's3:PutObject'
                 Resource: 'arn:aws:s3:::cdo-*javabuilder*-output/*'
+
+              # BuildAndRunJavaProject Lambda needs to put objects to the content bucket.
+              - Effect: Allow
+                Action:
+                  - 's3:PutObject'
+                Resource: 'arn:aws:s3:::cdo-*javabuilder*-content/*'
 
               # All Lambdas need logging permissions.
               - Effect: Allow
@@ -137,11 +143,17 @@ Resources:
                   - "s3:GetObject"
                 Resource:
                   - !Sub "arn:aws:s3:::${TemplateBucket}/*"
+              # TODO: Remove this once Javabuilder has changed its bucket name
               - Effect: Allow
                 Action:
                   - "s3:*"
                 Resource:
                   - !Sub "arn:aws:s3:::cdo-*javabuilder*-output"
+              - Effect: Allow
+                Action:
+                  - "s3:*"
+                Resource:
+                  - !Sub "arn:aws:s3:::cdo-*javabuilder*-content"
               - Effect: Allow
                 Action:
                   - "iam:PassRole"


### PR DESCRIPTION
First step of renaming the Javabuilder S3 bucket from cdo-javabuilder-output to cdo-javabuilder-content. This updates the IAM permissions to grant access to the new bucket name.

JIRA: https://codedotorg.atlassian.net/browse/JAVA-440