### PR TITLE
Rename S3 bucket

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -75,8 +75,8 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     final String dashboardHostname = "https://" + lambdaInput.get("iss");
     final JSONObject options = new JSONObject(lambdaInput.get("options"));
     final String javabuilderSessionId = lambdaInput.get("javabuilderSessionId");
-    final String outputBucketName = System.getenv("OUTPUT_BUCKET_NAME");
-    final String getOutputUrl = System.getenv("GET_OUTPUT_URL");
+    final String contentBucketName = System.getenv("CONTENT_BUCKET_NAME");
+    final String contentBucketUrl = System.getenv("CONTENT_BUCKET_URL");
     final boolean useDashboardSources =
         Boolean.parseBoolean(lambdaInput.get("useDashboardSources"));
     final boolean useNeighborhood =
@@ -112,7 +112,8 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
 
     final AmazonS3 s3Client = AmazonS3ClientBuilder.standard().build();
     final AWSFileManager fileManager =
-        new AWSFileManager(s3Client, outputBucketName, javabuilderSessionId, getOutputUrl, context);
+        new AWSFileManager(
+            s3Client, contentBucketName, javabuilderSessionId, contentBucketUrl, context);
     final LifecycleNotifier lifecycleNotifier = new LifecycleNotifier();
     OutputAdapter outputAdapter = awsOutputAdapter;
     if (executionType == ExecutionType.TEST) {
@@ -121,7 +122,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
 
     final AWSContentManager contentManager =
         new AWSContentManager(
-            s3Client, outputBucketName, javabuilderSessionId, getOutputUrl, context);
+            s3Client, contentBucketName, javabuilderSessionId, contentBucketUrl, context);
 
     // TODO: Move common setup steps into CodeExecutionManager#onPreExecute
     GlobalProtocol.create(

--- a/template.yml.erb
+++ b/template.yml.erb
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Transform: AWS::Serverless-2016-10-31
-Description: Provision an instance of the Javabuilder service. Empty the OutputBucket before deleting this Stack.
+Description: Provision an instance of the Javabuilder service. Empty the ContentBucket before deleting this Stack.
 Parameters:
   BaseDomainName:
     Type: String
@@ -328,14 +328,14 @@ Resources:
       Environment:
         Variables:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/change_runtime_directory
-          OUTPUT_BUCKET_NAME: !Ref OutputBucket
-          GET_OUTPUT_URL: !Sub "https://${OutputDomain}"
+          CONTENT_BUCKET_NAME: !Ref ContentBucket
+          CONTENT_BUCKET_URL: !Sub "https://${ContentDomain}"
 <%end -%>
 
-  OutputBucket:
+  ContentBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !If [IsDevCondition, !Sub "cdo-dev-${SubDomainName}-output", !Sub "cdo-${SubDomainName}-output"]
+      BucketName: !If [IsDevCondition, !Sub "cdo-dev-${SubDomainName}-content", !Sub "cdo-${SubDomainName}-content"]
       CorsConfiguration:
         CorsRules:
           - AllowedMethods: [GET, PUT]
@@ -351,44 +351,44 @@ Resources:
             Status: Enabled
             ExpirationInDays: 1
 
-  OutputBucketPolicy:
+  ContentBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
-      Bucket: !Ref OutputBucket
+      Bucket: !Ref ContentBucket
       PolicyDocument:
         Statement:
         - Action: ['s3:GetObject']
           Effect: Allow
-          Resource: !Sub "arn:aws:s3:::${OutputBucket}/*"
+          Resource: !Sub "arn:aws:s3:::${ContentBucket}/*"
           Principal: '*'
 
-  OutputAPICertificate:
+  ContentAPICertificate:
     Type: AWS::CertificateManager::Certificate
     Properties:
-      DomainName: !Sub "${SubDomainName}-output.${BaseDomainName}"
+      DomainName: !Sub "${SubDomainName}-content.${BaseDomainName}"
       ValidationMethod: DNS
       DomainValidationOptions:
-        - DomainName: !Sub "${SubDomainName}-output.${BaseDomainName}"
+        - DomainName: !Sub "${SubDomainName}-content.${BaseDomainName}"
           HostedZoneId: !Ref BaseDomainNameHostedZonedID
 
-  OutputDomain:
+  ContentDomain:
     Type: AWS::Route53::RecordSet
     Properties:
       HostedZoneName: !Sub "${BaseDomainName}."
-      Name: !Sub "${SubDomainName}-output.${BaseDomainName}"
+      Name: !Sub "${SubDomainName}-content.${BaseDomainName}"
       Type: A
       AliasTarget:
-        DNSName: !GetAtt OutputCDN.DomainName
+        DNSName: !GetAtt ContentCDN.DomainName
         HostedZoneId: Z2FDTNDATAQYW2 # static ID for cloudfront aliases
 
-  OutputCDN:
+  ContentCDN:
     Type: AWS::CloudFront::Distribution
     Properties:
       DistributionConfig:
         Enabled: true
-        Aliases: [!Sub "${SubDomainName}-output.${BaseDomainName}"]
+        Aliases: [!Sub "${SubDomainName}-content.${BaseDomainName}"]
         ViewerCertificate:
-          AcmCertificateArn: !Ref OutputAPICertificate
+          AcmCertificateArn: !Ref ContentAPICertificate
           MinimumProtocolVersion: TLSv1
           SslSupportMethod: sni-only
         CustomErrorResponses:
@@ -398,13 +398,13 @@ Resources:
         # Logging:
         #   Bucket: !Ref LogBucket
         #   IncludeCookies: false
-        #   Prefix: !Sub "${SubDomainName}-output.${BaseDomainName}"
+        #   Prefix: !Sub "${SubDomainName}-content.${BaseDomainName}"
         Origins:
-          - Id: OutputBucket
-            DomainName: !GetAtt OutputBucket.DomainName
+          - Id: ContentBucket
+            DomainName: !GetAtt ContentBucket.DomainName
             S3OriginConfig: {}
         DefaultCacheBehavior:
-          TargetOriginId: OutputBucket
+          TargetOriginId: ContentBucket
           AllowedMethods: [DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT]
           Compress: true
           DefaultTTL: 0


### PR DESCRIPTION
This renames the Javabuilder S3 bucket from cdo-javabuilder-output to cdo-javabuilder-content to more accurately reflect its use. Note: this PR should NOT be merged until this [policy change PR](https://github.com/code-dot-org/javabuilder/pull/220) has been merged AND deployed in the production account (see this [Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1645815922432079) for details).

Testing pending updating the policy in the dev account and testing the name change on a deployed instance (will update this once testing is complete).