### PR TITLE
Remove old bucket permissions from IAM template

### DIFF
--- a/iam.yml
+++ b/iam.yml
@@ -39,12 +39,6 @@ Resources:
                   - "cloudformation:DescribeStacks"
                 Resource: '*'
 
-              # TODO: Remove this once Javabuilder has changed its bucket name
-              - Effect: Allow
-                Action:
-                  - 's3:PutObject'
-                Resource: 'arn:aws:s3:::cdo-*javabuilder*-output/*'
-
               # BuildAndRunJavaProject Lambda needs to put objects to the content bucket.
               - Effect: Allow
                 Action:
@@ -143,12 +137,6 @@ Resources:
                   - "s3:GetObject"
                 Resource:
                   - !Sub "arn:aws:s3:::${TemplateBucket}/*"
-              # TODO: Remove this once Javabuilder has changed its bucket name
-              - Effect: Allow
-                Action:
-                  - "s3:*"
-                Resource:
-                  - !Sub "arn:aws:s3:::cdo-*javabuilder*-output"
               - Effect: Allow
                 Action:
                   - "s3:*"


### PR DESCRIPTION
Cleanup step following https://github.com/code-dot-org/javabuilder/pull/220 and https://github.com/code-dot-org/javabuilder/pull/221. This removes permissions on the old bucket name (*output*) now that Javabuilder has been updated to reference the new bucket name.

https://codedotorg.atlassian.net/browse/JAVA-440

Tested in dev account with dev Javabuilder instance.