### PR TITLE
Prevent null pointer exception in compiler error generation

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserCodeCompiler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserCodeCompiler.java
@@ -1,9 +1,12 @@
 package org.code.javabuilder;
 
+import static org.code.protocol.LoggerNames.MAIN_LOGGER;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.*;
+import java.util.logging.Logger;
 import javax.tools.*;
 import javax.tools.JavaCompiler.CompilationTask;
 import org.code.javabuilder.util.JarUtils;
@@ -137,6 +140,13 @@ public class UserCodeCompiler {
    * @return compiler error String
    */
   private String getCompilerError(Diagnostic<? extends JavaFileObject> diagnostic) {
+    if (diagnostic.getSource() == null || diagnostic.getLineNumber() == Diagnostic.NOPOS) {
+      Logger.getLogger(MAIN_LOGGER)
+          .warning(
+              "Falling back to default compiler error, diagnostic source was null or line number was -1. Diagnostic error code is "
+                  + diagnostic.getCode());
+      return diagnostic.toString();
+    }
     // Subtract 1 from the line number to account for our auto-import
     long lineNumber = diagnostic.getLineNumber() - 1;
     String diagnosticMessage = diagnostic.getMessage(Locale.US);


### PR DESCRIPTION
We are seeing occasional null pointer exceptions due to [diagnostic.getSource()](https://github.com/code-dot-org/javabuilder/blob/5a949622aabac7e608aeed57c87c883a05c57e9d/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserCodeCompiler.java#L154) being null. I have not been able to reproduce this on my own, so I added a check for a null source or -1 line number (which I learned can also be the case based on the [docs](https://docs.oracle.com/en/java/javase/11/docs/api/java.compiler/javax/tools/Diagnostic.html#getLineNumber()). If we hit one of these cases, log a warning and return the default compiler error. We can then hopefully get more insight into why this is happening based on the warning we log.