### PR TITLE
Add configurable hourly and daily limit parameters to Javabuilder

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -25,6 +25,10 @@ STACK=${SUB_DOMAIN}
 PROVISIONED_CONCURRENT_EXECUTIONS=${PROVISIONED_CONCURRENT_EXECUTIONS-'1'}
 RESERVED_CONCURRENT_EXECUTIONS=${RESERVED_CONCURRENT_EXECUTIONS-'3'}
 
+# Default per-user limits to prevent javabuilder abuse.
+LIMIT_PER_HOUR=${LIMIT_PER_HOUR-'10'}
+LIMIT_PER_DAY=${LIMIT_PER_DAY-'40'}
+
 erb -T - template.yml.erb > template.yml
 TEMPLATE=template.yml
 OUTPUT_TEMPLATE=$(mktemp)
@@ -46,6 +50,8 @@ fi
 
 aws cloudformation deploy \
   --template-file ${OUTPUT_TEMPLATE} \
-  --parameter-overrides SubDomainName=$SUB_DOMAIN BaseDomainName=$BASE_DOMAIN BaseDomainNameHostedZonedID=$BASE_DOMAIN_HOSTED_ZONE_ID ProvisionedConcurrentExecutions=$PROVISIONED_CONCURRENT_EXECUTIONS ReservedConcurrentExecutions=$RESERVED_CONCURRENT_EXECUTIONS \
+  --parameter-overrides SubDomainName=$SUB_DOMAIN BaseDomainName=$BASE_DOMAIN BaseDomainNameHostedZonedID=$BASE_DOMAIN_HOSTED_ZONE_ID \
+    ProvisionedConcurrentExecutions=$PROVISIONED_CONCURRENT_EXECUTIONS ReservedConcurrentExecutions=$RESERVED_CONCURRENT_EXECUTIONS \
+    LimitPerHour=$LIMIT_PER_HOUR LimitPerDay=$LIMIT_PER_DAY \
   --stack-name ${STACK} \
   "$@"

--- a/template.yml.erb
+++ b/template.yml.erb
@@ -355,6 +355,9 @@ Resources:
 # a step we should take when we create our non-beta environment from scratch. At that point, we
 # should also update uses of HttpAPI and WebSocketAPI to be HttpApi and WebSocketApi, respectively,
 # to match the AWS standard elsewhere in this template. Example: "AWS::ApiGatewayV2::ApiMapping"
+#
+# Note: hourly and daily limit values provided to both authorizers here as environment variables,
+# but are only needed in the HTTP authorizer.
 <%{
   Http: {
     LambdaName: "Http",

--- a/template.yml.erb
+++ b/template.yml.erb
@@ -412,6 +412,8 @@ Resources:
             ZUbJMN3hMFIFP4smAtjkKqguLJPFdcMij7WFDjL5kPQpxuc4RSq97iXRODIBjW1B\n zdN9ZpGRA4MDOu3BtLC69PwoFrSULAzlUmC5fJIwpaXoRGZEYRMQThlJ9VsRGwTG\n
             JTJJ4dWJ2cw61prbeU/HVCWD8OaNumz9tQIDAQAB\n
             -----END RSA PUBLIC KEY-----'
+          limit_per_hour: !Ref LimitPerHour
+          limit_per_day: !Ref LimitPerDay
 
   <%=name%>AuthorizerPermission:
     Type: AWS::Lambda::Permission

--- a/template.yml.erb
+++ b/template.yml.erb
@@ -24,6 +24,17 @@ Parameters:
     Description: The amount of concurrency to allow for the BuildAndRunJavaProject Lambda.
     MinValue: 1
     Default: 3
+  LimitPerHour:
+    Type: Number
+    Description: The number of Javabuilder invocations allowed per user per hour.
+    MinValue: 1
+    Default: 10
+  LimitPerDay:
+    Type: Number
+    Description: The number of Javabuilder invocations allowed per user per day.
+    MinValue: 1
+    Default: 40
+
 <%
 JAVALAB_APP_TYPES = %w(
   Theater


### PR DESCRIPTION
Allows setting a limit per hour and limit per day parameter for Javabuilder, and passes that value to the authorizers as an environment variable (HTTP is the only one that actually needs it, but easier to pass to both WebSocket and HTTP). Values can be overridden by parameters passed in via the deploy script. Values are 10 per hour and 40 per day be default.

This PR does not actually implement any limits -- it just allows us to set the limit values. Part of preventing overuse of javabuilder work, details here:
- [Dev doc](https://docs.google.com/document/d/1A4dIzg6ZKRxZb3bcTSlEMU7YXDzgr21HN7dI9jIe0XM/edit#)
- [Jira item](https://codedotorg.atlassian.net/browse/JAVA-458)

## Testing story

I tested deploying without setting any explicit values in the deploy script call and saw environment variables being set for the HTTP authorizer appropriately. I deployed again withe explicit values as arguments, and saw those values reflected in the HTTP authorizer's environment variables.