### PR TITLE
IAM updates to create DynamoDB tables

### DIFF
--- a/iam.yml
+++ b/iam.yml
@@ -161,10 +161,7 @@ Resources:
                 Action:
                   - 'dynamodb:CreateTable'
                 Resource:
-                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_blocked_users"
-                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_tokens"
-                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_user_requests"
-                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_teacher_associated_requests"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*"
   JavabuilderCodeBuildRole:
     Type: AWS::IAM::Role
     Properties:

--- a/iam.yml
+++ b/iam.yml
@@ -157,6 +157,14 @@ Resources:
                   - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/apigateway/*"
                   - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/apigateway/"
                   - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/apigateway/*:log-stream:*"
+              - Effect: Allow
+                Action:
+                  - 'dynamodb:CreateTable'
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_blocked_users"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_tokens"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_user_requests"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_teacher_associated_requests"
   JavabuilderCodeBuildRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
Updates to IAM template to allow creating DynamoDB tables for preventing overuse of Javabuilder work. Needs to be merged before merging [updates to Javabuilder template that create new DynamoDB tables](https://github.com/code-dot-org/javabuilder/pull/229).

Part of preventing overuse of Javabuilder work:
- [Dev doc](https://docs.google.com/document/d/1A4dIzg6ZKRxZb3bcTSlEMU7YXDzgr21HN7dI9jIe0XM/edit#)
- [JIRA item](https://codedotorg.atlassian.net/browse/JAVA-458)

## Testing story

This hasn't really been tested, since my account in our dev AWS account is in the "Developer" group. which has superuser permissions. I've [reached out to infrastructure](https://codedotorg.slack.com/archives/C03CK49G9/p1646941303619749) to see how I should test this change.