### PR TITLE
Move internal Theater classes to support package

### DIFF
--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
@@ -9,6 +9,8 @@ import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.code.media.Image;
 import org.code.protocol.*;
+import org.code.theater.support.TheaterMessage;
+import org.code.theater.support.TheaterSignalKey;
 
 public class Prompter {
   private static final AtomicInteger FILE_INDEX = new AtomicInteger(0);

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -14,6 +14,7 @@ import org.code.media.Color;
 import org.code.media.Font;
 import org.code.media.Image;
 import org.code.protocol.*;
+import org.code.theater.support.*;
 
 public class Stage {
   private final BufferedImage image;

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/support/ExceptionKeys.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/support/ExceptionKeys.java
@@ -1,4 +1,4 @@
-package org.code.theater;
+package org.code.theater.support;
 
 public enum ExceptionKeys {
   DUPLICATE_PLAY_COMMAND,

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/support/GifWriter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/support/GifWriter.java
@@ -1,4 +1,4 @@
-package org.code.theater;
+package org.code.theater.support;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
@@ -15,7 +15,7 @@ import org.code.protocol.InternalServerRuntimeError;
  * Writer to generate a gif from a set of images. The gif will be stored in the given
  * ByteArrayOutputStream.
  */
-class GifWriter {
+public class GifWriter {
   private ImageWriter writer;
   private ImageWriteParam params;
   private ImageOutputStream imageOutputStream;

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/support/InstrumentSampleLoader.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/support/InstrumentSampleLoader.java
@@ -1,12 +1,13 @@
-package org.code.theater;
+package org.code.theater.support;
 
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import org.code.theater.Instrument;
 
-class InstrumentSampleLoader {
+public class InstrumentSampleLoader {
 
   private static Map<Instrument, Map<Integer, String>> generateInstrumentFileMap() {
     final Map<Integer, String> pianoMap = new HashMap<>();
@@ -31,7 +32,7 @@ class InstrumentSampleLoader {
   // Map of Instrument -> Map of note value (int) -> file path / name
   private final Map<Instrument, Map<Integer, String>> instrumentFileMap;
 
-  protected InstrumentSampleLoader() {
+  public InstrumentSampleLoader() {
     this(InstrumentSampleLoader.generateInstrumentFileMap());
   }
 
@@ -47,7 +48,7 @@ class InstrumentSampleLoader {
    * @param note
    * @return filename of sample, or null if no sample is found.
    */
-  String getSampleFilePath(Instrument instrument, int note) {
+  public String getSampleFilePath(Instrument instrument, int note) {
     if (!instrumentFileMap.containsKey(instrument)) {
       System.out.printf("No notes available for instrument %s%n", instrument);
       return null;

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/support/TheaterMessage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/support/TheaterMessage.java
@@ -1,11 +1,11 @@
-package org.code.theater;
+package org.code.theater.support;
 
 import java.util.HashMap;
 import org.code.protocol.ClientMessage;
 import org.code.protocol.ClientMessageType;
 
 public class TheaterMessage extends ClientMessage {
-  TheaterMessage(TheaterSignalKey key, HashMap<String, String> detail) {
+  public TheaterMessage(TheaterSignalKey key, HashMap<String, String> detail) {
     super(ClientMessageType.THEATER, key.toString(), detail);
   }
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/support/TheaterProgressPublisher.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/support/TheaterProgressPublisher.java
@@ -1,4 +1,4 @@
-package org.code.theater;
+package org.code.theater.support;
 
 import java.util.HashMap;
 import org.code.protocol.*;
@@ -7,7 +7,7 @@ import org.code.protocol.*;
  * Publishes progress updates to the {@link OutputAdapter} while Theater projects are being
  * generated
  */
-class TheaterProgressPublisher {
+public class TheaterProgressPublisher {
   private static final double UPDATE_TIME_S = 5.0;
   private static final double MAX_TIME_S = 120.0;
 

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/support/TheaterRuntimeException.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/support/TheaterRuntimeException.java
@@ -1,13 +1,13 @@
-package org.code.theater;
+package org.code.theater.support;
 
 import org.code.protocol.JavabuilderRuntimeException;
 
 public class TheaterRuntimeException extends JavabuilderRuntimeException {
-  protected TheaterRuntimeException(ExceptionKeys key) {
+  public TheaterRuntimeException(ExceptionKeys key) {
     super(key);
   }
 
-  protected TheaterRuntimeException(ExceptionKeys key, Throwable cause) {
+  public TheaterRuntimeException(ExceptionKeys key, Throwable cause) {
     super(key, cause);
   }
 

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/support/TheaterSignalKey.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/support/TheaterSignalKey.java
@@ -1,4 +1,4 @@
-package org.code.theater;
+package org.code.theater.support;
 
 public enum TheaterSignalKey {
   // This message contains the url to a visual element

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/PrompterTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/PrompterTest.java
@@ -10,6 +10,8 @@ import java.net.URL;
 import java.util.List;
 import org.code.media.Image;
 import org.code.protocol.*;
+import org.code.theater.support.TheaterMessage;
+import org.code.theater.support.TheaterSignalKey;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
@@ -16,6 +16,7 @@ import org.code.media.Font;
 import org.code.media.FontStyle;
 import org.code.media.Image;
 import org.code.protocol.*;
+import org.code.theater.support.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/support/GifWriterTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/support/GifWriterTest.java
@@ -1,4 +1,4 @@
-package org.code.theater;
+package org.code.theater.support;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/support/InstrumentSampleLoaderTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/support/InstrumentSampleLoaderTest.java
@@ -1,9 +1,10 @@
-package org.code.theater;
+package org.code.theater.support;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.code.theater.Instrument;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/support/TheaterProgressPublisherTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/support/TheaterProgressPublisherTest.java
@@ -1,4 +1,4 @@
-package org.code.theater;
+package org.code.theater.support;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;


### PR DESCRIPTION
Quick prefactor for the next set of Theater v2 work. This moves all internal Theater classes (everything except Scene, Theater, Prompter, Instrument, and Stage) into the `support` package. The only code changes here are making a few constructors/methods public so that non-support classes can access them.

Tested that Theater still runs correctly.