### PR TITLE
Create classes for playing scenes

### DIFF
--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
@@ -24,6 +24,7 @@ public class ClientMessageDetailKeys {
   public static final String UPLOAD_URL = "uploadUrl";
   public static final String PROGRESS_TIME = "progressTime";
   public static final String TOTAL_TIME = "totalTime";
+  public static final String URL = "url";
 
   // Exception specific
   public static final String CONNECTION_ID = "connectionId";

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Scene.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Scene.java
@@ -1,5 +1,7 @@
 package org.code.theater;
 
+import static org.code.theater.support.Constants.THEATER_HEIGHT;
+import static org.code.theater.support.Constants.THEATER_WIDTH;
 import static org.code.theater.support.DrawImageAction.UNSPECIFIED;
 
 import java.io.FileNotFoundException;
@@ -9,9 +11,6 @@ import org.code.media.*;
 import org.code.theater.support.*;
 
 public class Scene {
-  private static final int SCENE_WIDTH = 400;
-  private static final int SCENE_HEIGHT = 400;
-
   // Visible for testing
   static final Font DEFAULT_FONT = Font.SANS;
   static final FontStyle DEFAULT_FONT_STYLE = FontStyle.NORMAL;
@@ -44,12 +43,12 @@ public class Scene {
 
   /** Returns the width of the theater canvas. */
   public final int getWidth() {
-    return SCENE_WIDTH;
+    return THEATER_WIDTH;
   }
 
   /** Returns the height of the theater canvas. */
   public final int getHeight() {
-    return SCENE_HEIGHT;
+    return THEATER_HEIGHT;
   }
 
   /**

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -428,6 +428,7 @@ public class Stage {
 
   /** Plays the instructions. */
   public void play() {
+    TheaterPlayer.getInstance().onStagePlay();
     if (this.hasPlayed) {
       throw new TheaterRuntimeException(ExceptionKeys.DUPLICATE_PLAY_COMMAND);
     } else {

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Theater.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Theater.java
@@ -1,6 +1,20 @@
 package org.code.theater;
 
+import java.util.ArrayList;
+import java.util.List;
+import org.code.theater.support.SceneAction;
+import org.code.theater.support.TheaterPlayer;
+
 public final class Theater {
   public static final Stage stage = new Stage();
   public static final Prompter prompter = new Prompter();
+
+  public static void play(Scene... scenes) {
+    final List<SceneAction> allActions = new ArrayList<>();
+    for (Scene scene : scenes) {
+      allActions.addAll(scene.getActions());
+    }
+
+    TheaterPlayer.getInstance().play(allActions);
+  }
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/support/ConcertCreator.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/support/ConcertCreator.java
@@ -249,7 +249,6 @@ public class ConcertCreator implements AutoCloseable {
   @Override
   public void close() {
     if (!this.hasClosed) {
-      System.out.println("Closing ConcertCreator!");
       this.gifWriter.close();
       this.audioWriter.close();
       this.hasClosed = true;

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/support/ConcertCreator.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/support/ConcertCreator.java
@@ -1,0 +1,258 @@
+package org.code.theater.support;
+
+import static org.code.protocol.AllowedFileNames.THEATER_AUDIO_NAME;
+import static org.code.protocol.AllowedFileNames.THEATER_IMAGE_NAME;
+import static org.code.protocol.ClientMessageDetailKeys.URL;
+import static org.code.theater.support.Constants.THEATER_HEIGHT;
+import static org.code.theater.support.Constants.THEATER_WIDTH;
+import static org.code.theater.support.DrawImageAction.UNSPECIFIED;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.util.HashMap;
+import java.util.List;
+import org.code.media.AudioWriter;
+import org.code.media.Color;
+import org.code.media.FontHelper;
+import org.code.protocol.*;
+import org.code.theater.Instrument;
+
+/**
+ * Creates and publishes a "concert" (the output of a student's Theater project) from a list of
+ * {@link SceneAction}s. A concert consists of a GIF file and an audio file. This class implements
+ * {@link AutoCloseable} so image and audio resources are always released if an exception is thrown.
+ */
+public class ConcertCreator implements AutoCloseable {
+  private final BufferedImage image;
+  private final OutputAdapter outputAdapter;
+  private final JavabuilderFileManager fileManager;
+  private final GifWriter gifWriter;
+  private final ByteArrayOutputStream imageOutputStream;
+  private final GraphicsHelper graphicsHelper;
+  private final ByteArrayOutputStream audioOutputStream;
+  private final AudioWriter audioWriter;
+  private final InstrumentSampleLoader instrumentSampleLoader;
+  private final TheaterProgressPublisher progressPublisher;
+  private boolean hasClosed;
+
+  public ConcertCreator() {
+    this(
+        new BufferedImage(THEATER_WIDTH, THEATER_HEIGHT, BufferedImage.TYPE_INT_RGB),
+        new GifWriter.Factory(),
+        new AudioWriter.Factory(),
+        new GraphicsHelper.Factory(),
+        new InstrumentSampleLoader(),
+        new TheaterProgressPublisher(),
+        GlobalProtocol.getInstance().getOutputAdapter(),
+        GlobalProtocol.getInstance().getFileManager());
+  }
+
+  // Visible for testing
+  ConcertCreator(
+      BufferedImage image,
+      GifWriter.Factory gifWriterFactory,
+      AudioWriter.Factory audioWriterFactory,
+      GraphicsHelper.Factory graphicsHelperFactory,
+      InstrumentSampleLoader instrumentSampleLoader,
+      TheaterProgressPublisher progressPublisher,
+      OutputAdapter outputAdapter,
+      JavabuilderFileManager fileManager) {
+    this.imageOutputStream = new ByteArrayOutputStream();
+    this.audioOutputStream = new ByteArrayOutputStream();
+
+    this.image = image;
+    this.gifWriter = gifWriterFactory.createGifWriter(this.imageOutputStream);
+    this.audioWriter = audioWriterFactory.createAudioWriter(this.audioOutputStream);
+    this.graphicsHelper =
+        graphicsHelperFactory.createGraphicsHelper(this.image.createGraphics(), new FontHelper());
+    this.instrumentSampleLoader = instrumentSampleLoader;
+    this.progressPublisher = progressPublisher;
+    this.outputAdapter = outputAdapter;
+    this.fileManager = fileManager;
+    this.hasClosed = false;
+
+    // set up the image for drawing (set a white background and black stroke/fill)
+    this.graphicsHelper.clear(Color.WHITE);
+
+    System.setProperty("java.awt.headless", "true");
+  }
+
+  /**
+   * Creates the concert content from the provided list of {@link SceneAction}s and publishes the
+   * generated file URLs using the {@link OutputAdapter}
+   *
+   * @param actions from which to create the concert
+   */
+  public void publishConcert(List<SceneAction> actions) {
+    for (SceneAction action : actions) {
+      switch (action.getType()) {
+        case CLEAR_SCENE:
+          this.graphicsHelper.clear(((ClearSceneAction) action).getColor());
+          break;
+        case PLAY_SOUND:
+          this.audioWriter.writeAudioSamples(((PlaySoundAction) action).getSamples());
+          break;
+        case PLAY_NOTE:
+          final PlayNoteAction playNoteAction = (PlayNoteAction) action;
+          this.playNote(
+              playNoteAction.getInstrument(),
+              playNoteAction.getNote(),
+              playNoteAction.getSeconds());
+          break;
+        case PAUSE:
+          this.pause(((PauseAction) action).getSeconds());
+          break;
+        case DRAW_IMAGE:
+          final DrawImageAction drawImageAction = (DrawImageAction) action;
+          final int width, height;
+          if (drawImageAction.getSize() != UNSPECIFIED) {
+            // If the "size" value was provided, we need to scale the height proportionally.
+            width = drawImageAction.getSize();
+            final int imageHeight = drawImageAction.getImage().getHeight();
+            final int imageWidth = drawImageAction.getImage().getWidth();
+            height = (int) ((double) imageHeight * ((double) width / (double) imageWidth));
+          } else {
+            width = drawImageAction.getWidth();
+            height = drawImageAction.getHeight();
+          }
+          this.graphicsHelper.drawImage(
+              drawImageAction.getImage().getBufferedImage(),
+              drawImageAction.getX(),
+              drawImageAction.getY(),
+              width,
+              height,
+              drawImageAction.getRotation());
+          break;
+        case DRAW_TEXT:
+          final DrawTextAction drawTextAction = (DrawTextAction) action;
+          this.graphicsHelper.drawText(
+              drawTextAction.getText(),
+              drawTextAction.getX(),
+              drawTextAction.getY(),
+              drawTextAction.getColor(),
+              drawTextAction.getFont(),
+              drawTextAction.getFontStyle(),
+              drawTextAction.getHeight(),
+              drawTextAction.getRotation());
+          break;
+        case DRAW_LINE:
+          final DrawLineAction drawLineAction = (DrawLineAction) action;
+          this.graphicsHelper.setStrokeWidth(drawLineAction.getStrokeWidth());
+          this.graphicsHelper.drawLine(
+              drawLineAction.getColor(),
+              drawLineAction.getStartX(),
+              drawLineAction.getStartY(),
+              drawLineAction.getEndX(),
+              drawLineAction.getEndY());
+          break;
+        case DRAW_POLYGON:
+          final DrawPolygonAction drawPolygonAction = (DrawPolygonAction) action;
+          this.graphicsHelper.setStrokeWidth(drawPolygonAction.getStrokeWidth());
+          this.graphicsHelper.drawRegularPolygon(
+              drawPolygonAction.getX(),
+              drawPolygonAction.getY(),
+              drawPolygonAction.getSides(),
+              drawPolygonAction.getRadius(),
+              drawPolygonAction.getStrokeColor(),
+              drawPolygonAction.getFillColor());
+          break;
+        case DRAW_SHAPE:
+          final DrawShapeAction drawShapeAction = (DrawShapeAction) action;
+          this.graphicsHelper.setStrokeWidth(drawShapeAction.getStrokeWidth());
+          this.graphicsHelper.drawShape(
+              drawShapeAction.getPoints(),
+              drawShapeAction.isClosed(),
+              drawShapeAction.getStrokeColor(),
+              drawShapeAction.getFillColor());
+          break;
+        case DRAW_ELLIPSE:
+          final DrawEllipseAction drawEllipseAction = (DrawEllipseAction) action;
+          this.graphicsHelper.setStrokeWidth(drawEllipseAction.getStrokeWidth());
+          this.graphicsHelper.drawEllipse(
+              drawEllipseAction.getX(),
+              drawEllipseAction.getY(),
+              drawEllipseAction.getWidth(),
+              drawEllipseAction.getHeight(),
+              drawEllipseAction.getStrokeColor(),
+              drawEllipseAction.getFillColor());
+          break;
+        case DRAW_RECTANGLE:
+          final DrawRectangleAction drawRectangleAction = (DrawRectangleAction) action;
+          this.graphicsHelper.setStrokeWidth(drawRectangleAction.getStrokeWidth());
+          this.graphicsHelper.drawRectangle(
+              drawRectangleAction.getX(),
+              drawRectangleAction.getY(),
+              drawRectangleAction.getWidth(),
+              drawRectangleAction.getHeight(),
+              drawRectangleAction.getStrokeColor(),
+              drawRectangleAction.getFillColor());
+          break;
+        default:
+          break;
+      }
+    }
+
+    this.writeImageAndAudioToFile();
+  }
+
+  private void playNote(Instrument instrument, int note, double noteLength) {
+    final String sampleFilePath = instrumentSampleLoader.getSampleFilePath(instrument, note);
+    if (sampleFilePath == null) {
+      return;
+    }
+
+    try {
+      this.audioWriter.writeAudioFromLocalFile(sampleFilePath, noteLength);
+    } catch (FileNotFoundException e) {
+      System.out.printf("Could not play instrument: %s at note: %s%n", instrument, note);
+    }
+  }
+
+  private void pause(double seconds) {
+    this.gifWriter.writeToGif(this.image, (int) (Math.max(seconds, 0.1) * 1000));
+    this.audioWriter.addDelay(Math.max(seconds, 0.1));
+    this.progressPublisher.onPause(seconds);
+  }
+
+  private void writeImageAndAudioToFile() {
+    this.progressPublisher.onPlay(this.audioWriter.getTotalAudioLength());
+    this.gifWriter.writeToGif(this.image, 0);
+    this.audioWriter.writeToAudioStream();
+
+    // We must call close() before write so that the streams are flushed.
+    this.close();
+
+    try {
+      String imageUrl =
+          this.fileManager.writeToFile(
+              THEATER_IMAGE_NAME, this.imageOutputStream.toByteArray(), "image/gif");
+      String audioUrl =
+          this.fileManager.writeToFile(
+              THEATER_AUDIO_NAME, this.audioOutputStream.toByteArray(), "audio/wav");
+
+      HashMap<String, String> imageMessage = new HashMap<>();
+      imageMessage.put(URL, imageUrl);
+      this.outputAdapter.sendMessage(new TheaterMessage(TheaterSignalKey.VISUAL_URL, imageMessage));
+
+      HashMap<String, String> audioMessage = new HashMap<>();
+      audioMessage.put(URL, audioUrl);
+      this.outputAdapter.sendMessage(new TheaterMessage(TheaterSignalKey.AUDIO_URL, audioMessage));
+    } catch (JavabuilderException e) {
+      // we should not hit this (caused by too many file writes)
+      // in normal execution as it is only called via play,
+      // and play can only be called once.
+      throw new InternalServerRuntimeError(InternalErrorKey.INTERNAL_RUNTIME_EXCEPTION, e);
+    }
+  }
+
+  @Override
+  public void close() {
+    if (!this.hasClosed) {
+      System.out.println("Closing ConcertCreator!");
+      this.gifWriter.close();
+      this.audioWriter.close();
+      this.hasClosed = true;
+    }
+  }
+}

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/support/Constants.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/support/Constants.java
@@ -1,0 +1,6 @@
+package org.code.theater.support;
+
+public final class Constants {
+  public static final int THEATER_WIDTH = 400;
+  public static final int THEATER_HEIGHT = 400;
+}

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/support/GraphicsHelper.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/support/GraphicsHelper.java
@@ -1,0 +1,167 @@
+package org.code.theater.support;
+
+import static org.code.theater.support.Constants.THEATER_HEIGHT;
+import static org.code.theater.support.Constants.THEATER_WIDTH;
+
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+import org.code.media.Color;
+import org.code.media.Font;
+import org.code.media.FontHelper;
+import org.code.media.FontStyle;
+
+/**
+ * Helper class for various {@link Graphics2D} operations (drawing images, lines, shapes, text, etc)
+ */
+class GraphicsHelper {
+  public static class Factory {
+    public GraphicsHelper createGraphicsHelper(Graphics2D graphics, FontHelper fontHelper) {
+      return new GraphicsHelper(graphics, fontHelper);
+    }
+  }
+
+  private final Graphics2D graphics;
+  private final FontHelper fontHelper;
+
+  public GraphicsHelper(Graphics2D graphics, FontHelper fontHelper) {
+    this.graphics = graphics;
+    this.fontHelper = fontHelper;
+  }
+
+  public void clear(Color color) {
+    this.graphics.setBackground(Color.convertToAWTColor(color));
+    // clearRect resets the background with the new color
+    this.graphics.clearRect(0, 0, THEATER_WIDTH, THEATER_HEIGHT);
+  }
+
+  public void drawImage(BufferedImage image, int x, int y, int width, int height, double degrees) {
+    if (degrees != 0) {
+      AffineTransform transform = new AffineTransform();
+      double widthScale = (double) width / image.getWidth();
+      double heightScale = (double) height / image.getHeight();
+      // create a transform that moves the location of the image to (x,y), rotates around
+      // the top left corner of the image and scales the image to width and height
+      // Note: order of transforms is important, do not reorder these calls
+      transform.translate(x, y);
+      transform.rotate(Math.toRadians(degrees), 0, 0);
+      transform.scale(widthScale, heightScale);
+      this.graphics.drawImage(image, transform, null);
+    } else {
+      this.graphics.drawImage(image, x, y, width, height, null);
+    }
+  }
+
+  public void drawText(
+      String text,
+      int x,
+      int y,
+      Color color,
+      Font font,
+      FontStyle fontStyle,
+      int height,
+      double rotation) {
+    AffineTransform originalTransform = this.graphics.getTransform();
+    if (rotation != 0) {
+      this.graphics.rotate(Math.toRadians(rotation), x, y);
+    }
+    java.awt.Font sizedFont = this.fontHelper.getFont(font, fontStyle).deriveFont((float) height);
+    this.graphics.setFont(sizedFont);
+    this.graphics.setColor(Color.convertToAWTColor(color));
+    this.graphics.drawString(text, x, y);
+    if (rotation != 0) {
+      // reset to original transform if we rotated
+      this.graphics.setTransform(originalTransform);
+    }
+  }
+
+  public void drawLine(Color strokeColor, int startX, int startY, int endX, int endY) {
+    this.graphics.setColor(Color.convertToAWTColor(strokeColor));
+    this.graphics.drawLine(startX, startY, endX, endY);
+  }
+
+  public void drawRegularPolygon(
+      int x, int y, int sides, int radius, Color strokeColor, Color fillColor) {
+    if (strokeColor == null && fillColor == null) {
+      return;
+    }
+    Polygon polygon = new Polygon();
+    double theta = 2 * Math.PI / sides;
+    for (int i = 0; i < sides; i++) {
+      int xCoordinate = (int) (Math.cos(theta * i) * radius) + x;
+      int yCoordinate = (int) (Math.sin(theta * i) * radius) + y;
+      polygon.addPoint(xCoordinate, yCoordinate);
+    }
+    if (strokeColor != null) {
+      this.graphics.setColor(Color.convertToAWTColor(strokeColor));
+      this.graphics.drawPolygon(polygon);
+    }
+    if (fillColor != null) {
+      this.graphics.setColor(Color.convertToAWTColor(fillColor));
+      this.graphics.fillPolygon(polygon);
+    }
+  }
+
+  public void drawShape(int[] points, boolean close, Color strokeColor, Color fillColor) {
+    // points should contain an even number of values to represent (x,y) coordinates
+    // We need at least 4 points to draw a single line
+    if (points.length % 2 != 0 || points.length < 4) {
+      throw new TheaterRuntimeException(ExceptionKeys.INVALID_SHAPE);
+    }
+    if (close) {
+      if (strokeColor == null && fillColor == null) {
+        return;
+      }
+      // For a closed shape, use draw/fill shape functions
+      int numPoints = points.length / 2;
+      int[] xPoints = new int[numPoints];
+      int[] yPoints = new int[numPoints];
+      // split points into x and y arrays
+      for (int i = 0; i < points.length - 1; i += 2) {
+        xPoints[i / 2] = points[i];
+        yPoints[i / 2] = points[i + 1];
+      }
+      if (strokeColor != null) {
+        this.graphics.setColor(Color.convertToAWTColor(strokeColor));
+        this.graphics.drawPolygon(xPoints, yPoints, numPoints);
+      }
+      if (fillColor != null) {
+        this.graphics.setColor(Color.convertToAWTColor(fillColor));
+        this.graphics.fillPolygon(xPoints, yPoints, numPoints);
+      }
+    } else if (strokeColor != null) {
+      // For an open shape, draw as a series of lines
+      this.graphics.setColor(Color.convertToAWTColor(strokeColor));
+      for (int i = 0; i <= points.length - 4; i += 2) {
+        this.graphics.drawLine(points[i], points[i + 1], points[i + 2], points[i + 3]);
+      }
+    }
+  }
+
+  public void drawEllipse(int x, int y, int width, int height, Color strokeColor, Color fillColor) {
+    if (fillColor != null) {
+      this.graphics.setColor(Color.convertToAWTColor(fillColor));
+      this.graphics.fillOval(x, y, width, height);
+    }
+    if (strokeColor != null) {
+      this.graphics.setColor(Color.convertToAWTColor(strokeColor));
+      this.graphics.drawOval(x, y, width, height);
+    }
+  }
+
+  public void drawRectangle(
+      int x, int y, int width, int height, Color strokeColor, Color fillColor) {
+    if (fillColor != null) {
+      this.graphics.setColor(Color.convertToAWTColor(fillColor));
+      this.graphics.fillRect(x, y, width, height);
+    }
+    if (strokeColor != null) {
+      this.graphics.setColor(Color.convertToAWTColor(strokeColor));
+      this.graphics.drawRect(x, y, width, height);
+    }
+  }
+
+  public void setStrokeWidth(double width) {
+    this.graphics.setStroke(new BasicStroke((float) width));
+  }
+}

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/support/TheaterPlayer.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/support/TheaterPlayer.java
@@ -1,0 +1,67 @@
+package org.code.theater.support;
+
+import java.util.List;
+import org.code.protocol.GlobalProtocol;
+import org.code.protocol.LifecycleListener;
+
+/**
+ * Plays a Theater concert with the provided list of {@link SceneAction}s, using a {@link
+ * ConcertCreator}. As this class is only meant to be used as a singleton, it manages the global
+ * Theater state to ensure that a concert is only played once per session, and that the flag is
+ * reset when execution ends.
+ */
+public class TheaterPlayer implements LifecycleListener {
+  private static final TheaterPlayer instance = new TheaterPlayer();
+
+  public static TheaterPlayer getInstance() {
+    return instance;
+  }
+
+  // Factory for ease of testing
+  static class ConcertCreatorFactory {
+    public ConcertCreator create() {
+      return new ConcertCreator();
+    }
+  }
+
+  private final ConcertCreatorFactory concertCreatorFactory;
+  private boolean hasPlayed;
+
+  private TheaterPlayer() {
+    this(new ConcertCreatorFactory());
+  }
+
+  // Visible only for testing
+  TheaterPlayer(ConcertCreatorFactory concertCreatorFactory) {
+    this.concertCreatorFactory = concertCreatorFactory;
+    this.hasPlayed = false;
+    GlobalProtocol.getInstance().registerLifecycleListener(this);
+  }
+
+  public void play(List<SceneAction> actions) {
+    if (this.hasPlayed) {
+      throw new TheaterRuntimeException(ExceptionKeys.DUPLICATE_PLAY_COMMAND);
+    }
+
+    this.hasPlayed = true;
+    try (final ConcertCreator concertCreator = this.concertCreatorFactory.create()) {
+      concertCreator.publishConcert(actions);
+    }
+  }
+
+  // Temporary method while we support both versions of the Theater API (Stage and Scene)
+  // to ensure that only one play command is called per project. When Stage is deleted,
+  // remove this method.
+  public void onStagePlay() {
+    if (this.hasPlayed) {
+      throw new TheaterRuntimeException(ExceptionKeys.DUPLICATE_PLAY_COMMAND);
+    }
+
+    this.hasPlayed = true;
+  }
+
+  @Override
+  public void onExecutionEnded() {
+    this.hasPlayed = false;
+  }
+}

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
@@ -63,6 +63,9 @@ public class StageTest {
     instrumentSampleLoader = mock(InstrumentSampleLoader.class);
     progressPublisher = mock(TheaterProgressPublisher.class);
 
+    // Reset before each test
+    TheaterPlayer.getInstance().onExecutionEnded();
+
     s =
         new Stage(
             bufferedImage,

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/support/ConcertCreatorTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/support/ConcertCreatorTest.java
@@ -1,0 +1,280 @@
+package org.code.theater.support;
+
+import static org.code.protocol.AllowedFileNames.THEATER_AUDIO_NAME;
+import static org.code.protocol.AllowedFileNames.THEATER_IMAGE_NAME;
+import static org.code.protocol.ClientMessageDetailKeys.URL;
+import static org.code.theater.support.DrawImageAction.UNSPECIFIED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.awt.image.BufferedImage;
+import java.io.FileNotFoundException;
+import java.util.List;
+import org.code.media.*;
+import org.code.protocol.CachedResources;
+import org.code.protocol.JavabuilderException;
+import org.code.protocol.JavabuilderFileManager;
+import org.code.protocol.OutputAdapter;
+import org.code.theater.Instrument;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ConcertCreatorTest {
+
+  private BufferedImage image;
+  private GifWriter gifWriter;
+  private AudioWriter audioWriter;
+  private GraphicsHelper graphicsHelper;
+  private InstrumentSampleLoader instrumentSampleLoader;
+  private TheaterProgressPublisher theaterProgressPublisher;
+  private OutputAdapter outputAdapter;
+  private JavabuilderFileManager fileManager;
+  private ArgumentCaptor<TheaterMessage> theaterMessageCaptor;
+  private ConcertCreator unitUnderTest;
+
+  @BeforeEach
+  public void setUp() {
+    CachedResources.create();
+    image = mock(BufferedImage.class);
+    gifWriter = mock(GifWriter.class);
+    audioWriter = mock(AudioWriter.class);
+    graphicsHelper = mock(GraphicsHelper.class);
+    instrumentSampleLoader = mock(InstrumentSampleLoader.class);
+    theaterProgressPublisher = mock(TheaterProgressPublisher.class);
+    outputAdapter = mock(OutputAdapter.class);
+    fileManager = mock(JavabuilderFileManager.class);
+    theaterMessageCaptor = ArgumentCaptor.forClass(TheaterMessage.class);
+
+    final GifWriter.Factory gifWriterFactory = mock(GifWriter.Factory.class);
+    when(gifWriterFactory.createGifWriter(any())).thenReturn(gifWriter);
+    final AudioWriter.Factory audioWriterFactory = mock(AudioWriter.Factory.class);
+    when(audioWriterFactory.createAudioWriter(any())).thenReturn(audioWriter);
+    final GraphicsHelper.Factory graphicsHelperFactory = mock(GraphicsHelper.Factory.class);
+    when(graphicsHelperFactory.createGraphicsHelper(any(), any())).thenReturn(graphicsHelper);
+
+    unitUnderTest =
+        new ConcertCreator(
+            image,
+            gifWriterFactory,
+            audioWriterFactory,
+            graphicsHelperFactory,
+            instrumentSampleLoader,
+            theaterProgressPublisher,
+            outputAdapter,
+            fileManager);
+  }
+
+  @Test
+  public void testClearScene() {
+    final ClearSceneAction action = new ClearSceneAction(Color.BEIGE);
+    unitUnderTest.publishConcert(List.of(action));
+    verify(graphicsHelper).clear(action.getColor());
+  }
+
+  @Test
+  public void testPlaySound() {
+    final double[] samples = {1.0, 0.0, 1.0, 0.0};
+    final PlaySoundAction action = new PlaySoundAction(samples);
+    unitUnderTest.publishConcert(List.of(action));
+    verify(audioWriter).writeAudioSamples(samples);
+  }
+
+  @Test
+  public void testPlayNoteDoesNothingWhenFileNotFound() throws FileNotFoundException {
+    when(instrumentSampleLoader.getSampleFilePath(any(Instrument.class), anyInt()))
+        .thenReturn(null);
+
+    final PlayNoteAction action = new PlayNoteAction(Instrument.PIANO, 60, 1);
+    unitUnderTest.publishConcert(List.of(action));
+
+    verify(instrumentSampleLoader).getSampleFilePath(Instrument.PIANO, 60);
+    verify(audioWriter, never()).writeAudioFromLocalFile(anyString(), anyDouble());
+  }
+
+  @Test
+  public void testPlayNoteCallsAudioWriterIfFileExists() throws FileNotFoundException {
+    final String testSampleFile = "test.wav";
+    final int note = 60;
+    final double seconds = 2.0;
+    when(instrumentSampleLoader.getSampleFilePath(any(Instrument.class), eq(note)))
+        .thenReturn(testSampleFile);
+
+    final PlayNoteAction action = new PlayNoteAction(Instrument.PIANO, note, seconds);
+    unitUnderTest.publishConcert(List.of(action));
+
+    verify(instrumentSampleLoader).getSampleFilePath(Instrument.PIANO, note);
+    verify(audioWriter).writeAudioFromLocalFile(testSampleFile, seconds);
+    verify(audioWriter, never()).addDelay(anyDouble());
+  }
+
+  @Test
+  public void testPause() {
+    final double pauseTime = 15.0;
+    final PauseAction action = new PauseAction(pauseTime);
+    unitUnderTest.publishConcert(List.of(action));
+
+    verify(gifWriter).writeToGif(image, (int) pauseTime * 1000);
+    verify(audioWriter).addDelay(pauseTime);
+    verify(theaterProgressPublisher).onPause(pauseTime);
+  }
+
+  @Test
+  public void testDrawImageWithWidthAndHeight() {
+    final BufferedImage bufferedImage = mock(BufferedImage.class);
+    final Image image = mock(Image.class);
+    when(image.getBufferedImage()).thenReturn(bufferedImage);
+    final DrawImageAction action = new DrawImageAction(image, 10, 10, UNSPECIFIED, 100, 100, 45.0);
+
+    unitUnderTest.publishConcert(List.of(action));
+
+    verify(graphicsHelper)
+        .drawImage(
+            bufferedImage,
+            action.getX(),
+            action.getY(),
+            action.getWidth(),
+            action.getHeight(),
+            action.getRotation());
+  }
+
+  @Test
+  public void testDrawImageWithSize() {
+    final BufferedImage bufferedImage = mock(BufferedImage.class);
+    final Image image = mock(Image.class);
+    when(image.getBufferedImage()).thenReturn(bufferedImage);
+    final int originalWidth = 100;
+    final int originalHeight = 200;
+    final int desiredSize = 50;
+    final int expectedHeight = 100; // Height should scale based on size
+    when(image.getWidth()).thenReturn(originalWidth);
+    when(image.getHeight()).thenReturn(originalHeight);
+
+    final DrawImageAction action =
+        new DrawImageAction(image, 10, 10, desiredSize, UNSPECIFIED, UNSPECIFIED, 90.0);
+
+    unitUnderTest.publishConcert(List.of(action));
+
+    verify(graphicsHelper)
+        .drawImage(
+            bufferedImage,
+            action.getX(),
+            action.getY(),
+            desiredSize,
+            expectedHeight,
+            action.getRotation());
+  }
+
+  @Test
+  public void testDrawText() {
+    final DrawTextAction action =
+        new DrawTextAction("text", 50, 50, 100.0, 100, Font.SERIF, FontStyle.ITALIC, Color.BLUE);
+    unitUnderTest.publishConcert(List.of(action));
+    verify(graphicsHelper)
+        .drawText(
+            action.getText(),
+            action.getX(),
+            action.getY(),
+            action.getColor(),
+            action.getFont(),
+            action.getFontStyle(),
+            action.getHeight(),
+            action.getRotation());
+  }
+
+  @Test
+  public void testDrawPolygon() {
+    final DrawPolygonAction action =
+        new DrawPolygonAction(10, 10, 5, 100, Color.RED, Color.GREEN, 5.0);
+    unitUnderTest.publishConcert(List.of(action));
+    verify(graphicsHelper).setStrokeWidth(action.getStrokeWidth());
+    verify(graphicsHelper)
+        .drawRegularPolygon(
+            action.getX(),
+            action.getY(),
+            action.getSides(),
+            action.getRadius(),
+            action.getStrokeColor(),
+            action.getFillColor());
+  }
+
+  @Test
+  public void testDrawShape() {
+    final int[] points = {1, 1, 10, 10};
+    final DrawShapeAction action = new DrawShapeAction(points, false, Color.IVORY, Color.LIME, 1.0);
+    unitUnderTest.publishConcert(List.of(action));
+    verify(graphicsHelper).setStrokeWidth(action.getStrokeWidth());
+    verify(graphicsHelper)
+        .drawShape(
+            action.getPoints(), action.isClosed(), action.getStrokeColor(), action.getFillColor());
+  }
+
+  @Test
+  public void testDrawEllipse() {
+    final DrawEllipseAction action =
+        new DrawEllipseAction(20, 20, 100, 100, Color.CHOCOLATE, Color.INDIGO, 10.0);
+    unitUnderTest.publishConcert(List.of(action));
+    verify(graphicsHelper).setStrokeWidth(action.getStrokeWidth());
+    verify(graphicsHelper)
+        .drawEllipse(
+            action.getX(),
+            action.getY(),
+            action.getWidth(),
+            action.getHeight(),
+            action.getStrokeColor(),
+            action.getFillColor());
+  }
+
+  @Test
+  public void testDrawRectangle() {
+    final DrawRectangleAction action =
+        new DrawRectangleAction(20, 20, 100, 100, Color.CHOCOLATE, Color.INDIGO, 10.0);
+    unitUnderTest.publishConcert(List.of(action));
+    verify(graphicsHelper).setStrokeWidth(action.getStrokeWidth());
+    verify(graphicsHelper)
+        .drawRectangle(
+            action.getX(),
+            action.getY(),
+            action.getWidth(),
+            action.getHeight(),
+            action.getStrokeColor(),
+            action.getFillColor());
+  }
+
+  @Test
+  public void testWritesOutputFilesAndClosesStreams() throws JavabuilderException {
+    final double length = 10.0;
+    when(audioWriter.getTotalAudioLength()).thenReturn(length);
+
+    final String imageUrl = "imageUrl";
+    final String audioUrl = "audioUrl";
+    when(fileManager.writeToFile(eq(THEATER_IMAGE_NAME), any(), any())).thenReturn(imageUrl);
+    when(fileManager.writeToFile(eq(THEATER_AUDIO_NAME), any(), any())).thenReturn(audioUrl);
+    doNothing().when(outputAdapter).sendMessage(theaterMessageCaptor.capture());
+
+    unitUnderTest.publishConcert(List.of());
+
+    verify(theaterProgressPublisher).onPlay(length);
+    verify(gifWriter).writeToGif(image, 0);
+    verify(audioWriter).writeToAudioStream();
+    verify(gifWriter).close();
+    verify(audioWriter).close();
+
+    final TheaterMessage imageMessage = theaterMessageCaptor.getAllValues().get(0);
+    assertEquals(imageUrl, imageMessage.getDetail().get(URL));
+
+    final TheaterMessage audioMessage = theaterMessageCaptor.getAllValues().get(1);
+    assertEquals(audioUrl, audioMessage.getDetail().get(URL));
+  }
+
+  @Test
+  public void testDoesNotCloseTwice() {
+    unitUnderTest.publishConcert(List.of());
+    unitUnderTest.close();
+
+    // Should have only closed once
+    verify(gifWriter, times(1)).close();
+    verify(audioWriter, times(1)).close();
+  }
+}

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/support/GraphicsHelperTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/support/GraphicsHelperTest.java
@@ -1,0 +1,146 @@
+package org.code.theater.support;
+
+import static org.code.theater.support.Constants.THEATER_HEIGHT;
+import static org.code.theater.support.Constants.THEATER_WIDTH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+import org.code.media.Color;
+import org.code.media.Font;
+import org.code.media.FontHelper;
+import org.code.media.FontStyle;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GraphicsHelperTest {
+
+  private Graphics2D graphics;
+  private FontHelper fontHelper;
+  private GraphicsHelper unitUnderTest;
+
+  @BeforeEach
+  public void setUp() {
+    graphics = mock(Graphics2D.class);
+    fontHelper = mock(FontHelper.class);
+    unitUnderTest = new GraphicsHelper(graphics, fontHelper);
+  }
+
+  @Test
+  void clearSetsBackgroundAndClears() {
+    unitUnderTest.clear(Color.BLACK);
+    verify(graphics).setBackground(Color.convertToAWTColor(Color.BLACK));
+    verify(graphics).clearRect(0, 0, THEATER_WIDTH, THEATER_HEIGHT);
+  }
+
+  @Test
+  void drawLineDrawsLine() {
+    final int startX = 10;
+    final int startY = 20;
+    final int endX = 100;
+    final int endY = 200;
+    unitUnderTest.drawLine(Color.BLUE, startX, startY, endX, endY);
+    verify(graphics).setColor(Color.convertToAWTColor(Color.BLUE));
+    verify(graphics).drawLine(startX, startY, endX, endY);
+  }
+
+  @Test
+  void removingStrokeAndFillPreventsShapeDrawing() {
+    unitUnderTest.drawRegularPolygon(0, 0, 5, 100, null, null);
+    verify(graphics, never()).drawPolygon(any());
+    verify(graphics, never()).fillPolygon(any());
+  }
+
+  @Test
+  void removingStrokeStillCallsFill() {
+    unitUnderTest.drawEllipse(5, 5, 100, 100, null, Color.BLACK);
+    verify(graphics, never()).drawOval(5, 5, 100, 100);
+    verify(graphics).fillOval(5, 5, 100, 100);
+  }
+
+  @Test
+  void removingFillStillCallsStroke() {
+    unitUnderTest.drawEllipse(5, 5, 100, 100, Color.BLACK, null);
+    verify(graphics, never()).fillOval(5, 5, 100, 100);
+    verify(graphics).drawOval(5, 5, 100, 100);
+  }
+
+  @Test
+  void drawOpenShapeDrawsLines() {
+    unitUnderTest.drawShape(new int[] {0, 0, 25, 30, 0, 100}, false, Color.BLACK, Color.INDIGO);
+    verify(graphics, times(2)).drawLine(anyInt(), anyInt(), anyInt(), anyInt());
+  }
+
+  @Test
+  void drawClosedShapeDrawsAndFillsShape() {
+    unitUnderTest.drawShape(new int[] {0, 0, 25, 30, 0, 100}, true, Color.BLACK, Color.RED);
+    int[] xPoints = new int[] {0, 25, 0};
+    int[] yPoints = new int[] {0, 30, 100};
+    verify(graphics).drawPolygon(xPoints, yPoints, 3);
+    verify(graphics).fillPolygon(xPoints, yPoints, 3);
+  }
+
+  @Test
+  void throwsExceptionOnInvalidShape() {
+    int[] tooFewPoints = new int[] {1, 0};
+    int[] oddNumberOfPoints = new int[] {0, 0, 1, 1, 2};
+    verifyInvalidShapeThrowsException(unitUnderTest, tooFewPoints, false);
+    verifyInvalidShapeThrowsException(unitUnderTest, oddNumberOfPoints, true);
+  }
+
+  @Test
+  void drawImageWithRotationCreatesTransform() {
+    unitUnderTest.drawImage(mock(BufferedImage.class), 0, 300, 50, 75, 90);
+    verify(graphics).drawImage(any(BufferedImage.class), any(AffineTransform.class), any());
+  }
+
+  @Test
+  void drawImageWithoutRotationDoesNotCreateTransform() {
+    unitUnderTest.drawImage(mock(BufferedImage.class), 0, 300, 50, 75, 0);
+    verify(graphics)
+        .drawImage(any(BufferedImage.class), anyInt(), anyInt(), anyInt(), anyInt(), any());
+  }
+
+  @Test
+  void drawTextWithoutRotationDrawsTextCorrectly() {
+    final java.awt.Font awtFont = mock(java.awt.Font.class);
+    when(fontHelper.getFont(any(), any())).thenReturn(awtFont);
+    when(awtFont.deriveFont(anyFloat())).thenReturn(awtFont);
+    unitUnderTest.drawText("hello", 0, 0, Color.BLUE, Font.SANS, FontStyle.BOLD, 12, 0);
+    verify(graphics).drawString("hello", 0, 0);
+    verify(graphics).setFont(awtFont);
+    // verify we never rotate
+    verify(graphics, never()).rotate(anyDouble(), anyDouble(), anyDouble());
+  }
+
+  @Test
+  void drawTextWithRotationDrawsTextCorrectly() {
+    final java.awt.Font awtFont = mock(java.awt.Font.class);
+    when(fontHelper.getFont(any(), any())).thenReturn(awtFont);
+    when(awtFont.deriveFont(anyFloat())).thenReturn(awtFont);
+    unitUnderTest.drawText("hello world", 50, 150, Color.BLUE, Font.SANS, FontStyle.BOLD, 12, 95);
+    verify(graphics).drawString("hello world", 50, 150);
+    double radians = Math.toRadians(95);
+    // verify we rotated correctly
+    verify(graphics).rotate(radians, 50, 150);
+    // verify we reset the transform
+    verify(graphics).setTransform(any());
+  }
+
+  private void verifyInvalidShapeThrowsException(
+      GraphicsHelper graphicsHelper, int[] points, boolean close) {
+    Exception exception =
+        assertThrows(
+            TheaterRuntimeException.class,
+            () -> {
+              graphicsHelper.drawShape(points, close, Color.BLACK, Color.BLACK);
+            });
+    String expectedMessage = ExceptionKeys.INVALID_SHAPE.toString();
+    assertEquals(exception.getMessage(), expectedMessage);
+  }
+}

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/support/TheaterPlayerTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/support/TheaterPlayerTest.java
@@ -1,0 +1,78 @@
+package org.code.theater.support;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.code.protocol.GlobalProtocolTestFactory;
+import org.code.protocol.InternalErrorKey;
+import org.code.protocol.InternalServerRuntimeError;
+import org.code.protocol.LifecycleNotifier;
+import org.code.theater.support.TheaterPlayer.ConcertCreatorFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TheaterPlayerTest {
+
+  private ConcertCreator concertCreator;
+  private LifecycleNotifier lifecycleNotifier;
+  private List<SceneAction> actions;
+  private TheaterPlayer unitUnderTest;
+
+  @BeforeEach
+  public void setUp() {
+    final ConcertCreatorFactory concertCreatorFactory = mock(ConcertCreatorFactory.class);
+    concertCreator = mock(ConcertCreator.class);
+    when(concertCreatorFactory.create()).thenReturn(concertCreator);
+
+    lifecycleNotifier = mock(LifecycleNotifier.class);
+    GlobalProtocolTestFactory.builder().withLifecycleNotifier(lifecycleNotifier).create();
+
+    actions = new ArrayList<>();
+
+    unitUnderTest = new TheaterPlayer(concertCreatorFactory);
+  }
+
+  @Test
+  public void testRegistersLifecycleListener() {
+    verify(lifecycleNotifier).registerListener(unitUnderTest);
+  }
+
+  @Test
+  public void testPublishesConcertOnPlay() {
+    unitUnderTest.play(actions);
+    verify(concertCreator).publishConcert(actions);
+  }
+
+  @Test
+  public void testThrowsExceptionIfPlayCalledMoreThanOnce() {
+    unitUnderTest.play(actions);
+    final Exception actual =
+        assertThrows(TheaterRuntimeException.class, () -> unitUnderTest.play(actions));
+    assertEquals(ExceptionKeys.DUPLICATE_PLAY_COMMAND.toString(), actual.getMessage());
+  }
+
+  @Test
+  public void testCleansUpConcertCreatorIfExceptionThrown() {
+    doThrow(new InternalServerRuntimeError(InternalErrorKey.INTERNAL_EXCEPTION))
+        .when(concertCreator)
+        .publishConcert(actions);
+    try {
+      unitUnderTest.play(actions);
+    } catch (InternalServerRuntimeError e) {
+      // expected
+      verify(concertCreator).close();
+    }
+  }
+
+  @Test
+  public void testExecutionEndedResetsHasPlayed() {
+    unitUnderTest.play(actions);
+    assertThrows(TheaterRuntimeException.class, () -> unitUnderTest.play(actions));
+
+    unitUnderTest.onExecutionEnded();
+
+    assertDoesNotThrow(() -> unitUnderTest.play(actions));
+  }
+}


### PR DESCRIPTION
Second part of the Theater API v2 update. This adds the classes necessary for playing scenes by collecting actions and generating output. This is mostly just copying over the existing code from `Stage`, but broken into a couple different classes to help modularize things a bit.

- `ConcertCreator` is the main class that reads the list of `SceneAction`s, generates the output, writes the files, and sends messages via the output adapter. For audio commands, it invokes the AudioWriter/InstrumentLoader APIs directly and for drawing commands it delegates to `GraphicsHelper`. Also, because this just an instantiable class (as opposed to a singleton like Stage), we can have it implement `AutoCloseable` and use it in a try-with-resources block to make sure we always release resources if any exception is thrown.
- `GraphicsHelper` is where all the drawing logic happens, again just copied over from stage. This class deals with drawing shapes, lines, text, images, etc.
- `TheaterPlayer` is a singleton class that creates a new `ConcertCreator` and publishes the output. This is kind of a middle layer between the static `Theater` and the non-static, instantiable `ConcertCreator` - the main reason this class exists is because we need a way to track the global state of if `play` has been called or not, and then reset that state when execution ends. It didn't feel as clean to just store this state on a static variable in `Theater` that we keep setting and unsetting, so I opted to create this small class instead, which lets us hook into the LifecycleNotifier, and allows both ConcertCreator and Theater to not have to be concerned with if play has been called already or not.
- - This class also has a temporary `onStagePlay()` method that we call from Stage to prevent both Stage.play() and Theater.play(scenes) from being called in a project. Once stage has been deleted, we can get rid of this.
- `Theater` now has a `play(Scene ...scenes)` method so it can be called with one or multiple `Scenes`. However, if we do want explicit `playScene(Scene scene)` and `playScenes(Scene[] scenes)` methods, that's an easy switch.

JIRA: https://codedotorg.atlassian.net/browse/JAVA-487

Testing: tested locally with both Theater v1 and v2 commands. Confirmed that all drawing and sound APIs work as intended, and that using both v1 and v2 in conjunction results in an error.