### PR TITLE
Allow null channel ID

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -56,7 +56,8 @@ public class WebSocketServer {
 
     final String connectionId = "LocalhostWebSocketConnection";
     final String levelId = queryInput.getString("level_id");
-    final String channelId = queryInput.getString("channel_id");
+    final String channelId =
+        queryInput.has("channel_id") ? queryInput.getString("channel_id") : "noneProvided";
     final String miniAppType = queryInput.getString("mini_app_type");
     final ExecutionType executionType =
         ExecutionType.valueOf(queryInput.getString("execution_type"));

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -69,7 +69,8 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     final String queueUrl = lambdaInput.get("queueUrl");
     final String queueName = lambdaInput.get("queueName");
     final String levelId = lambdaInput.get("levelId");
-    final String channelId = lambdaInput.get("channelId");
+    final String channelId =
+        lambdaInput.get("channelId") == null ? "noneProvided" : lambdaInput.get("channelId");
     final String miniAppType = lambdaInput.get("miniAppType");
     final ExecutionType executionType = ExecutionType.valueOf(lambdaInput.get("executionType"));
     final String dashboardHostname = "https://" + lambdaInput.get("iss");


### PR DESCRIPTION
A channel ID is no longer required to run Javabuilder -- handling the case where a channel ID is not provided. Putting in a placeholder string if one is not provided, such that other code (eg, logging) that still uses a channel ID can function as-is.

## Testing story

I was able to run a Javalab project locally where I removed the channel ID attribute from the token sent to Javabuilder. Also was able to run projects without assets in deployed javabuilder.