### PR TITLE
Improve cold boot time of the lambdas

### DIFF
--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -39,10 +39,8 @@ def on_connect(event, context)
 
   # -- Create Lambda for this session --
   lambda_client = Aws::Lambda::Client.new(region: region)
-  api_endpoint = get_api_endpoint(event, context)
   payload = {
     :queueUrl => sqs_queue.queue_url,
-    :apiEndpoint => api_endpoint,
     :connectionId => request_context["connectionId"],
     :levelId => authorizer["level_id"],
     :options => authorizer["options"],

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeExecutionManager.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeExecutionManager.java
@@ -10,8 +10,6 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.logging.Logger;
 import org.code.protocol.*;
-import org.code.protocol.LoggerUtils.ClearStatus;
-import org.code.protocol.LoggerUtils.SessionTime;
 
 /**
  * Manages the execution of code in a project. When started, it performs the necessary pre-execution
@@ -164,9 +162,7 @@ public class CodeExecutionManager {
     GlobalProtocol.getInstance().cleanUpResources();
     try {
       // Clear temp folder
-      LoggerUtils.sendDiskSpaceUpdate(SessionTime.END_SESSION, ClearStatus.BEFORE_CLEAR);
       this.fileManager.cleanUpTempDirectory(this.tempFolder);
-      LoggerUtils.sendDiskSpaceUpdate(SessionTime.END_SESSION, ClearStatus.AFTER_CLEAR);
       // Close custom input/output streams
       this.overrideInputStream.close();
       this.overrideOutputStream.close();

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -46,7 +46,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
   private static final String API_ENDPOINT = System.getenv("API_ENDPOINT");
   private final AmazonApiGatewayManagementApi API;
   private final AmazonSQS SQS_CLIENT;
-  final AmazonS3 S3_CLIENT;
+  private final AmazonS3 S3_CLIENT;
 
   public LambdaRequestHandler() {
     // create CachedResources once for the entire container.

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/util/FileUtils.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/util/FileUtils.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
-import org.code.protocol.LoggerUtils;
 
 /** Convenience methods for handling file operations */
 public final class FileUtils {
@@ -28,6 +27,5 @@ public final class FileUtils {
 
   public static void recursivelyClearDirectory(Path directory) throws IOException {
     Files.walk(directory).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
-    LoggerUtils.sendClearedDirectoryLog(directory);
   }
 }

--- a/template.yml.erb
+++ b/template.yml.erb
@@ -483,6 +483,7 @@ Resources:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/change_runtime_directory
           CONTENT_BUCKET_NAME: !Ref ContentBucket
           CONTENT_BUCKET_URL: !Sub "https://${ContentDomain}"
+          API_ENDPOINT: !GetAtt WebSocketAPI.ApiEndpoint
 <%end -%>
 
   ContentBucket:

--- a/template.yml.erb
+++ b/template.yml.erb
@@ -34,6 +34,10 @@ Parameters:
     Description: The number of Javabuilder invocations allowed per user per day.
     MinValue: 1
     Default: 40
+  StageName:
+    Type: String
+    Description: The default stage name in the API Gateway APIs
+    Default: Prod
 <%
 JAVALAB_APP_TYPES = %w(
   Theater
@@ -159,8 +163,8 @@ Resources:
       # Using AutoDeploy rather than a Deployment resource (as we do with the WebSocket API) because
       # the Deployment resource doesn't seem to work with HTTP APIs.
       AutoDeploy: true
-      StageName: Prod
-      Description: Prod Stage
+      StageName: !Sub "${StageName}"
+      Description: The stage to deploy
       ApiId: !Ref HttpAPI
       DefaultRouteSettings:
         DetailedMetricsEnabled: true
@@ -294,8 +298,8 @@ Resources:
   WebSocketStage:
     Type: AWS::ApiGatewayV2::Stage
     Properties:
-      StageName: Prod
-      Description: Prod Stage
+      StageName: !Sub "${StageName}"
+      Description: The stage to deploy
       DeploymentId: !Ref WebSocketDeployment
       ApiId: !Ref WebSocketAPI
       DefaultRouteSettings:
@@ -483,7 +487,9 @@ Resources:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/change_runtime_directory
           CONTENT_BUCKET_NAME: !Ref ContentBucket
           CONTENT_BUCKET_URL: !Sub "https://${ContentDomain}"
-          API_ENDPOINT: !GetAtt WebSocketAPI.ApiEndpoint
+          API_ENDPOINT: !Sub
+            - "https://${ApiId}.execute-api.${AWS::Region}.amazonaws.com/${StageName}"
+            - ApiId: !Ref WebSocketAPI
 <%end -%>
 
   ContentBucket:


### PR DESCRIPTION
This is an update to move some expensive one-time steps to the initialization phase of the lambda. This allows us to take advantage of our [provisioned concurrency](https://docs.aws.amazon.com/lambda/latest/dg/provisioned-concurrency.html) in order to decrease our cold boot times.

On the Neighborhood and Console lambdas, cold boot times decreased from ~18s to ~9s
On the Theater lambda, cold boot times decreased from ~5s to ~3s

We may not be able to optimize our cold boot times much further than this because it appears that AWS Lambda only allows for a [10s initialization phase](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html). This is not widely publicized and may change. I haven't verified this myself, so it's worth checking if we can use more initialization time. If we can, we definitely should as we have another ~8s of time we can improve on the smaller lambdas.

Note: The theater lambda has more than 3x the RAM of the other two lambdas, and therefore is expected to execute faster.

Note: This only improves the "cold boot" time for the lambda. This is the time it takes to set up a new lambda container the first time it is used. Both before and after this change, the non-cold boot run time for the Theater lambda running a "Hello World" program is ~0.5s and for the other two is ~0.75s. 

As part of this change, I also went ahead and removed the disk space logs, which were very verbose. I kept the "disk space report" log which we use to track disk space issues in Cloud Watch.

As a follow-up change, I'd like to add some sort of time report, similar to the disk space report, which records the amount of time we spend doing various pieces of work so we can track performance metrics separately from the time the user's project runs. [JAVA-499](https://codedotorg.atlassian.net/browse/JAVA-499)

As an additional follow-up, we should look into using the Java "Ahead of Time" compiler to [optimize specifically for AWS Lambda](https://www.baeldung.com/ahead-of-time-compilation). [JAVA-497](https://codedotorg.atlassian.net/browse/JAVA-497)

We may also be able further improve performance by assigning provisioned concurrency to the auxiliary lambdas (such as the authorizer lambdas) and move some steps to their init phase as well. The cold boot time for all of these combined appears to be around 5s (from watching my wrist watch) whereas the later runs are closer to 1s. We may see less improvement from adding provisioned concurrency here since these lambdas are used by all project types and therefore are used more often and cold boot less often. [JAVA-500](https://codedotorg.atlassian.net/browse/JAVA-500)

Finally, here's a potentially helpful [slack conversation](https://codedotorg.slack.com/archives/C03CK49G9/p1647459220180329) that contributed to this change.