### PR TITLE
Remove unused useDashboardSources param

### DIFF
--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -49,8 +49,7 @@ def on_connect(event, context)
     :miniAppType => authorizer["mini_app_type"],
     :javabuilderSessionId => authorizer['sid'],
     :queueName => queue_name,
-    :executionType => authorizer['execution_type'],
-    :useDashboardSources => authorizer["use_dashboard_sources"]
+    :executionType => authorizer['execution_type']
   }
 
   response = nil


### PR DESCRIPTION
Removes the now unused `useDashboardSources` param from the api gateway proxy function. This will allow us to remove this param from the authentication payload sent from dashboard as well.

Testing: tested with localhost dashboard against deployed Javabuilder.