### PR TITLE
Fetch project data on initialization

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalContentManager.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalContentManager.java
@@ -12,16 +12,15 @@ import org.code.javabuilder.*;
 import org.code.protocol.ContentManager;
 import org.code.protocol.InternalErrorKey;
 import org.code.protocol.JavabuilderException;
-import org.code.protocol.LoggerUtils;
 import org.json.JSONException;
 
 public class LocalContentManager implements ContentManager, ProjectFileLoader {
   private static final String SERVER_URL_FORMAT = "http://localhost:8080/%s/%s";
 
-  private ProjectData projectData;
+  private final ProjectData projectData;
 
-  public LocalContentManager() {
-    this.projectData = null;
+  public LocalContentManager() throws InternalServerError {
+    this.projectData = this.loadProjectData();
   }
 
   // Used for testing
@@ -31,29 +30,16 @@ public class LocalContentManager implements ContentManager, ProjectFileLoader {
 
   @Override
   public UserProjectFiles loadFiles() throws InternalServerError, UserInitiatedException {
-    this.loadProjectDataIfNeeded();
     return this.projectData.getSources();
   }
 
   @Override
   public String getAssetUrl(String filename) {
-    try {
-      this.loadProjectDataIfNeeded();
-    } catch (InternalServerError e) {
-      // We should only hit this exception if we try to load an asset URL before source code has
-      // been loaded, which should only be in the the case of manual testing. Log this exception but
-      // don't throw to preserve the method contract.
-      // Note / TODO: Once we fully migrate away from Dashboard sources, we can remove the
-      // loadProjectDataIfNeeded() call here and this exception handling.
-      LoggerUtils.logException(e);
-      return null;
-    }
     return this.projectData.getAssetUrl(filename);
   }
 
   @Override
   public String generateAssetUploadUrl(String filename) throws InternalServerError {
-    this.loadProjectDataIfNeeded();
     final String uploadUrl = String.format(SERVER_URL_FORMAT, DIRECTORY, filename);
     // The URL to GET this asset once it is uploaded will be the same as the upload
     // URL since it points to the same location on the local file server. Add this
@@ -76,35 +62,20 @@ public class LocalContentManager implements ContentManager, ProjectFileLoader {
 
   @Override
   public void verifyAssetFilename(String filename) throws FileNotFoundException {
-    try {
-      // We should only hit this exception if we try to verify an asset before source code has
-      // been loaded, which should only be in the the case of manual testing. Log this exception but
-      // convert to a FileNotFoundException to preserve the method contract.
-      // Note / TODO: Once we fully migrate away from Dashboard sources, we can remove the
-      // loadProjectDataIfNeeded() call here and this exception handling.
-      this.loadProjectDataIfNeeded();
-    } catch (InternalServerError e) {
-      throw new FileNotFoundException("Error loading data");
-    }
     if (!this.projectData.doesAssetUrlExist(filename)) {
       throw new FileNotFoundException(filename);
     }
   }
 
-  // TODO: Project JSON data loading is deferred because it will not exist if we are
-  // still using dashboard sources. Once we stop using dashboard sources, this step
-  // can probably just happen immediately in the constructor.
-  private void loadProjectDataIfNeeded() throws InternalServerError {
-    if (this.projectData == null) {
-      final Path sourcesPath =
-          Paths.get(
-              System.getProperty("java.io.tmpdir"), DIRECTORY, ProjectData.PROJECT_DATA_FILE_NAME);
-      try {
-        this.projectData = new ProjectData(Files.readString(sourcesPath));
-      } catch (IOException | JSONException e) {
-        // Error reading JSON file from local storage
-        throw new InternalServerError(InternalErrorKey.INTERNAL_EXCEPTION, e);
-      }
+  private ProjectData loadProjectData() throws InternalServerError {
+    final Path sourcesPath =
+        Paths.get(
+            System.getProperty("java.io.tmpdir"), DIRECTORY, ProjectData.PROJECT_DATA_FILE_NAME);
+    try {
+      return new ProjectData(Files.readString(sourcesPath));
+    } catch (IOException | JSONException e) {
+      // Error reading JSON file from local storage
+      throw new InternalServerError(InternalErrorKey.INTERNAL_EXCEPTION, e);
     }
   }
 }

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
@@ -21,14 +21,22 @@ public class LocalMain {
     // turn off the default console logger
     logger.setUseParentHandlers(false);
 
+    final LocalContentManager localContentManager;
+    try {
+      localContentManager = new LocalContentManager();
+    } catch (InternalServerError e) {
+      System.out.println("Error loading data");
+      return;
+    }
+
     GlobalProtocol.create(
-        outputAdapter, inputAdapter, new LifecycleNotifier(), new LocalContentManager());
+        outputAdapter, inputAdapter, new LifecycleNotifier(), localContentManager);
     CachedResources.create();
 
     // Create and invoke the code execution environment
     CodeExecutionManager codeExecutionManager =
         new CodeExecutionManager(
-            new LocalContentManager(),
+            localContentManager,
             GlobalProtocol.getInstance().getInputHandler(),
             outputAdapter,
             ExecutionType.RUN,

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -82,7 +82,17 @@ public class WebSocketServer {
       outputAdapter = new UserTestOutputAdapter(websocketOutputAdapter);
     }
     final LifecycleNotifier lifecycleNotifier = new LifecycleNotifier();
-    final LocalContentManager contentManager = new LocalContentManager();
+    final LocalContentManager contentManager;
+    try {
+      contentManager = new LocalContentManager();
+    } catch (InternalServerError e) {
+      // Log the error
+      LoggerUtils.logError(e);
+
+      // This affected the user. Let's tell them about it.
+      outputAdapter.sendMessage(e.getExceptionMessage());
+      return;
+    }
     GlobalProtocol.create(outputAdapter, inputAdapter, lifecycleNotifier, contentManager);
 
     // the code must be run in a thread so we can receive input messages

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSContentManager.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSContentManager.java
@@ -17,7 +17,7 @@ import java.util.Date;
 import org.code.protocol.ContentManager;
 import org.code.protocol.InternalErrorKey;
 import org.code.protocol.JavabuilderException;
-import org.code.protocol.LoggerUtils;
+import org.json.JSONException;
 
 public class AWSContentManager implements ContentManager, ProjectFileLoader {
   // Temporary limit on writes to S3 per session until we can more fully limit usage.
@@ -43,8 +43,16 @@ public class AWSContentManager implements ContentManager, ProjectFileLoader {
       String bucketName,
       String javabuilderSessionId,
       String contentBucketUrl,
-      Context context) {
-    this(s3Client, bucketName, javabuilderSessionId, contentBucketUrl, context, null);
+      Context context)
+      throws InternalServerError {
+    this.bucketName = bucketName;
+    this.s3Client = s3Client;
+    this.javabuilderSessionId = javabuilderSessionId;
+    this.contentBucketUrl = contentBucketUrl;
+    this.context = context;
+    this.projectData = this.loadProjectData();
+    this.writes = 0;
+    this.uploads = 0;
   }
 
   AWSContentManager(
@@ -66,23 +74,11 @@ public class AWSContentManager implements ContentManager, ProjectFileLoader {
 
   @Override
   public UserProjectFiles loadFiles() throws InternalServerError, UserInitiatedException {
-    this.loadProjectDataIfNeeded();
     return this.projectData.getSources();
   }
 
   @Override
   public String getAssetUrl(String filename) {
-    try {
-      this.loadProjectDataIfNeeded();
-    } catch (InternalServerError e) {
-      // We should only hit this exception if we try to load an asset URL before source code has
-      // been loaded, which should only be in the the case of manual testing. Log this exception but
-      // don't throw to preserve the method contract.
-      // Note / TODO: Once we fully migrate away from Dashboard sources, we can remove the
-      // loadProjectDataIfNeeded() call here and this exception handling.
-      LoggerUtils.logException(e);
-      return null;
-    }
     return this.projectData.getAssetUrl(filename);
   }
 
@@ -144,16 +140,6 @@ public class AWSContentManager implements ContentManager, ProjectFileLoader {
 
   @Override
   public void verifyAssetFilename(String filename) throws FileNotFoundException {
-    try {
-      // We should only hit this exception if we try to verify an asset before source code has
-      // been loaded, which should only be in the the case of manual testing. Log this exception but
-      // convert to a FileNotFoundException to preserve the method contract.
-      // Note / TODO: Once we fully migrate away from Dashboard sources, we can remove the
-      // loadProjectDataIfNeeded() call here and this exception handling.
-      this.loadProjectDataIfNeeded();
-    } catch (InternalServerError e) {
-      throw new FileNotFoundException("Error loading data");
-    }
     if (!this.projectData.doesAssetUrlExist(filename)) {
       throw new FileNotFoundException(filename);
     }
@@ -167,14 +153,7 @@ public class AWSContentManager implements ContentManager, ProjectFileLoader {
     return this.javabuilderSessionId + "/" + filename;
   }
 
-  // TODO: Project JSON data loading is deferred because it will not exist if we are
-  // still using dashboard sources. Once we stop using dashboard sources, this step
-  // can probably just happen immediately in the constructor.
-  private void loadProjectDataIfNeeded() throws InternalServerError {
-    if (this.projectData != null) {
-      return;
-    }
-
+  private ProjectData loadProjectData() throws InternalServerError {
     final String key = this.generateKey(ProjectData.PROJECT_DATA_FILE_NAME);
     final S3Object sourcesS3Object;
 
@@ -186,8 +165,8 @@ public class AWSContentManager implements ContentManager, ProjectFileLoader {
 
     try (final S3ObjectInputStream inputStream = sourcesS3Object.getObjectContent()) {
       final String jsonString = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
-      this.projectData = new ProjectData(jsonString);
-    } catch (IOException e) {
+      return new ProjectData(jsonString);
+    } catch (JSONException | IOException e) {
       // Error reading JSON file from S3
       throw new InternalServerError(InternalErrorKey.INTERNAL_EXCEPTION, e);
     }


### PR DESCRIPTION
Final cleanup/refactor 🎉 (at least for now) - this moves project data initialization to the ContentManager constructors now that we're no longer supporting dashboard sources.

Tested with local dashboard against local Javabuilder and deployed Javabuilder. 