### PR TITLE
Only allow one instance of GlobalProtocol to be created per session

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalContentManager.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalContentManager.java
@@ -14,7 +14,7 @@ import org.code.protocol.InternalErrorKey;
 import org.code.protocol.JavabuilderException;
 import org.json.JSONException;
 
-public class LocalContentManager implements ContentManager, ProjectFileLoader {
+public class LocalContentManager implements ContentManager {
   private static final String SERVER_URL_FORMAT = "http://localhost:8080/%s/%s";
 
   private final ProjectData projectData;
@@ -28,9 +28,8 @@ public class LocalContentManager implements ContentManager, ProjectFileLoader {
     this.projectData = projectData;
   }
 
-  @Override
-  public UserProjectFiles loadFiles() throws InternalServerError, UserInitiatedException {
-    return this.projectData.getSources();
+  public ProjectFileLoader getProjectFileLoader() {
+    return this.projectData;
   }
 
   @Override

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
@@ -29,19 +29,18 @@ public class LocalMain {
       return;
     }
 
-    GlobalProtocol.create(
-        outputAdapter, inputAdapter, new LifecycleNotifier(), localContentManager);
     CachedResources.create();
 
     // Create and invoke the code execution environment
     CodeExecutionManager codeExecutionManager =
         new CodeExecutionManager(
-            localContentManager,
-            GlobalProtocol.getInstance().getInputHandler(),
+            localContentManager.getProjectFileLoader(),
+            inputAdapter,
             outputAdapter,
             ExecutionType.RUN,
             null,
             new LocalTempDirectoryManager(),
+            localContentManager,
             new LifecycleNotifier());
     codeExecutionManager.execute();
   }

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -93,20 +93,19 @@ public class WebSocketServer {
       outputAdapter.sendMessage(e.getExceptionMessage());
       return;
     }
-    GlobalProtocol.create(outputAdapter, inputAdapter, lifecycleNotifier, contentManager);
-
     // the code must be run in a thread so we can receive input messages
     Thread codeExecutor =
         new Thread(
             () -> {
               final CodeExecutionManager executionManager =
                   new CodeExecutionManager(
-                      contentManager,
-                      GlobalProtocol.getInstance().getInputHandler(),
+                      contentManager.getProjectFileLoader(),
+                      inputAdapter,
                       outputAdapter,
                       executionType,
                       compileList,
                       new LocalTempDirectoryManager(),
+                      contentManager,
                       lifecycleNotifier);
               executionManager.execute();
               // Clean up session

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSContentManager.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSContentManager.java
@@ -19,7 +19,7 @@ import org.code.protocol.InternalErrorKey;
 import org.code.protocol.JavabuilderException;
 import org.json.JSONException;
 
-public class AWSContentManager implements ContentManager, ProjectFileLoader {
+public class AWSContentManager implements ContentManager {
   // Temporary limit on writes to S3 per session until we can more fully limit usage.
   // The only file writing should be during Theater, and there should only be two per session
   // (theater image and theater audio).
@@ -34,7 +34,7 @@ public class AWSContentManager implements ContentManager, ProjectFileLoader {
   private final String javabuilderSessionId;
   private final String contentBucketUrl;
   private final Context context;
-  private ProjectData projectData;
+  private final ProjectData projectData;
   private int writes;
   private int uploads;
 
@@ -72,9 +72,8 @@ public class AWSContentManager implements ContentManager, ProjectFileLoader {
     this.uploads = 0;
   }
 
-  @Override
-  public UserProjectFiles loadFiles() throws InternalServerError, UserInitiatedException {
-    return this.projectData.getSources();
+  public ProjectFileLoader getProjectFileLoader() {
+    return this.projectData;
   }
 
   @Override

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -124,9 +124,6 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
       return onInitializationError("error loading data", e, outputAdapter, connectionId);
     }
 
-    // TODO: Move common setup steps into CodeExecutionManager#onPreExecute
-    GlobalProtocol.create(outputAdapter, inputAdapter, lifecycleNotifier, contentManager);
-
     // manually set font configuration file since there is no font configuration on a lambda.
     java.util.Properties props = System.getProperties();
     // /opt is the folder all layer files go into.
@@ -145,12 +142,13 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
 
     final CodeExecutionManager codeExecutionManager =
         new CodeExecutionManager(
-            contentManager,
-            GlobalProtocol.getInstance().getInputHandler(),
+            contentManager.getProjectFileLoader(),
+            inputAdapter,
             outputAdapter,
             executionType,
             compileList,
             tempDirectoryManager,
+            contentManager,
             lifecycleNotifier);
 
     final Thread timeoutNotifierThread =

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ProjectData.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ProjectData.java
@@ -19,7 +19,7 @@ import org.json.JSONObject;
  * }
  * </pre>
  */
-public class ProjectData {
+public class ProjectData implements ProjectFileLoader {
   public static final String PROJECT_DATA_FILE_NAME = "sources.json";
   // Expected JSON keys
   private static final String SOURCES_KEY = "sources";
@@ -41,7 +41,8 @@ public class ProjectData {
     this.projectFileParser = projectFileParser;
   }
 
-  public UserProjectFiles getSources() throws InternalServerError, UserInitiatedException {
+  @Override
+  public UserProjectFiles loadFiles() throws InternalServerError, UserInitiatedException {
     if (!this.jsonData.has(SOURCES_KEY)
         || !this.jsonData.getJSONObject(SOURCES_KEY).has(MAIN_JSON_KEY)) {
       throw new InternalServerError(

--- a/org-code-javabuilder/lib/src/test/java/dev/javabuilder/LocalContentManagerTest.java
+++ b/org-code-javabuilder/lib/src/test/java/dev/javabuilder/LocalContentManagerTest.java
@@ -7,7 +7,6 @@ import dev.javabuilder.util.TempDirectoryUtils;
 import java.io.FileNotFoundException;
 import org.code.javabuilder.InternalServerError;
 import org.code.javabuilder.ProjectData;
-import org.code.javabuilder.UserInitiatedException;
 import org.code.javabuilder.UserProjectFiles;
 import org.code.protocol.JavabuilderException;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,13 +24,6 @@ class LocalContentManagerTest {
     projectData = mock(ProjectData.class);
     projectFiles = mock(UserProjectFiles.class);
     unitUnderTest = new LocalContentManager(projectData);
-  }
-
-  @Test
-  public void testLoadFilesReturnsSourcesFromProjectData()
-      throws UserInitiatedException, InternalServerError {
-    when(projectData.getSources()).thenReturn(projectFiles);
-    assertSame(projectFiles, unitUnderTest.loadFiles());
   }
 
   @Test

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/AWSContentManagerTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/AWSContentManagerTest.java
@@ -103,13 +103,6 @@ class AWSContentManagerTest {
   }
 
   @Test
-  public void testLoadFilesReturnsSourcesFromProjectData()
-      throws UserInitiatedException, InternalServerError {
-    when(projectData.getSources()).thenReturn(projectFiles);
-    assertSame(projectFiles, contentManager.loadFiles());
-  }
-
-  @Test
   public void testGenerateAssetUrlReturnsUrlFromProjectData() {
     final String filename = "file";
     final String url = "url";

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/CodeExecutionManagerTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/CodeExecutionManagerTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 class CodeExecutionManagerTest {
   private ProjectFileLoader fileLoader;
-  private InputHandler inputHandler;
+  private InputAdapter inputAdapter;
   private OutputAdapter outputAdapter;
   private ExecutionType executionType;
   private List<String> compileList;
@@ -24,12 +24,13 @@ class CodeExecutionManagerTest {
   private LifecycleNotifier lifecycleNotifier;
   private CodeBuilderRunnableFactory codeBuilderRunnableFactory;
   private CodeBuilderRunnable codeBuilderRunnable;
+  private ContentManager contentManager;
   private CodeExecutionManager unitUnderTest;
 
   @BeforeEach
   public void setUp() {
     fileLoader = mock(ProjectFileLoader.class);
-    inputHandler = mock(InputHandler.class);
+    inputAdapter = mock(InputAdapter.class);
     outputAdapter = mock(OutputAdapter.class);
     executionType = ExecutionType.RUN;
     compileList = mock(List.class);
@@ -37,25 +38,22 @@ class CodeExecutionManagerTest {
     lifecycleNotifier = mock(LifecycleNotifier.class);
     codeBuilderRunnableFactory = mock(CodeBuilderRunnableFactory.class);
     codeBuilderRunnable = mock(CodeBuilderRunnable.class);
+    contentManager = mock(ContentManager.class);
 
     when(codeBuilderRunnableFactory.createCodeBuilderRunnable(
             eq(fileLoader), eq(outputAdapter), any(File.class), eq(executionType), eq(compileList)))
         .thenReturn(codeBuilderRunnable);
 
-    GlobalProtocolTestFactory.builder()
-        .withOutputAdapter(outputAdapter)
-        .withLifecycleNotifier(lifecycleNotifier)
-        .create();
-
     unitUnderTest =
         new CodeExecutionManager(
             fileLoader,
-            inputHandler,
+            inputAdapter,
             outputAdapter,
             executionType,
             compileList,
             tempDirectoryManager,
             lifecycleNotifier,
+            contentManager,
             codeBuilderRunnableFactory);
   }
 

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/ProjectDataTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/ProjectDataTest.java
@@ -40,11 +40,11 @@ class ProjectDataTest {
   @Test
   public void testGetSourcesThrowsExceptionIfSourcesOrMainJsonMissing() {
     unitUnderTest = new ProjectData("{}", projectFileParser);
-    Exception actual = assertThrows(InternalServerError.class, () -> unitUnderTest.getSources());
+    Exception actual = assertThrows(InternalServerError.class, () -> unitUnderTest.loadFiles());
     assertEquals(InternalErrorKey.INTERNAL_EXCEPTION.toString(), actual.getMessage());
 
     unitUnderTest = new ProjectData("{ 'sources': {} }", projectFileParser);
-    actual = assertThrows(InternalServerError.class, () -> unitUnderTest.getSources());
+    actual = assertThrows(InternalServerError.class, () -> unitUnderTest.loadFiles());
     assertEquals(InternalErrorKey.INTERNAL_EXCEPTION.toString(), actual.getMessage());
   }
 
@@ -54,7 +54,7 @@ class ProjectDataTest {
     when(projectFileParser.parseFileJson(MAIN_JSON_CONTENT)).thenReturn(projectFiles);
     doNothing().when(projectFiles).addTextFile(textProjectFileCaptor.capture());
 
-    assertSame(projectFiles, unitUnderTest.getSources());
+    assertSame(projectFiles, unitUnderTest.loadFiles());
     verify(projectFileParser).parseFileJson(MAIN_JSON_CONTENT);
     assertEquals(MAZE_FILE_CONTENT, textProjectFileCaptor.getValue().getFileContents());
   }

--- a/org-code-javabuilder/media/src/test/java/org/code/media/AudioUtilsTest.java
+++ b/org-code-javabuilder/media/src/test/java/org/code/media/AudioUtilsTest.java
@@ -54,6 +54,7 @@ class AudioUtilsTest {
 
   @AfterEach
   public void tearDown() {
+    GlobalProtocolTestFactory.tearDown();
     audioSystem.close();
   }
 

--- a/org-code-javabuilder/media/src/test/java/org/code/media/ImageTest.java
+++ b/org-code-javabuilder/media/src/test/java/org/code/media/ImageTest.java
@@ -8,6 +8,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import org.code.protocol.ContentManager;
 import org.code.protocol.GlobalProtocolTestFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -18,6 +19,11 @@ public class ImageTest {
   public void setUp() {
     contentManager = mock(ContentManager.class);
     GlobalProtocolTestFactory.builder().withContentManager(contentManager).create();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
@@ -30,6 +30,7 @@ public class PainterTest {
   @AfterEach
   public void tearDown() {
     System.setOut(standardOut);
+    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
@@ -9,6 +9,7 @@ import org.code.media.Color;
 import org.code.media.Font;
 import org.code.media.FontStyle;
 import org.code.protocol.*;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -30,6 +31,11 @@ class BoardTest {
 
     GlobalProtocolTestFactory.builder().withContentManager(contentManager).create();
     unitUnderTest = new Board(playgroundMessageHandler, inputHandler, contentManager);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/ImageItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/ImageItemTest.java
@@ -33,6 +33,7 @@ public class ImageItemTest {
   @AfterEach
   public void tearDown() {
     messageHandlerMockedStatic.close();
+    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/ItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/ItemTest.java
@@ -31,6 +31,7 @@ public class ItemTest {
   @AfterEach
   public void tearDown() {
     messageHandlerMockedStatic.close();
+    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
@@ -35,6 +35,7 @@ public class TextItemTest {
   @AfterEach
   public void tearDown() {
     messageHandlerMockedStatic.close();
+    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
@@ -36,6 +36,11 @@ public class GlobalProtocol {
       InputAdapter inputAdapter,
       LifecycleNotifier lifecycleNotifier,
       ContentManager contentManager) {
+    if (GlobalProtocol.protocolInstance != null) {
+      throw new InternalServerRuntimeError(
+          InternalErrorKey.INTERNAL_EXCEPTION,
+          new Exception("Tried to create GlobalProtocol instance when one already exists."));
+    }
     GlobalProtocol.protocolInstance =
         new GlobalProtocol(
             outputAdapter, new InputHandler(inputAdapter), lifecycleNotifier, contentManager);
@@ -47,6 +52,16 @@ public class GlobalProtocol {
     }
 
     return GlobalProtocol.protocolInstance;
+  }
+
+  public static void destroy() {
+    if (GlobalProtocol.protocolInstance == null) {
+      throw new InternalServerRuntimeError(
+          InternalErrorKey.INTERNAL_EXCEPTION,
+          new Exception("Tried to destroy GlobalProtocol instance when one does not exist."));
+    }
+
+    GlobalProtocol.protocolInstance = null;
   }
 
   public ContentManager getContentManager() {

--- a/org-code-javabuilder/protocol/src/testFixtures/java/org/code/protocol/GlobalProtocolTestFactory.java
+++ b/org-code-javabuilder/protocol/src/testFixtures/java/org/code/protocol/GlobalProtocolTestFactory.java
@@ -7,6 +7,10 @@ public class GlobalProtocolTestFactory {
     return new Builder();
   }
 
+  public static void tearDown() {
+    GlobalProtocol.destroy();
+  }
+
   public static class Builder {
     private OutputAdapter outputAdapter;
     private InputAdapter inputAdapter;

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
@@ -78,6 +78,7 @@ public class StageTest {
   @AfterEach
   public void tearDown() {
     System.setOut(standardOut);
+    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/support/TheaterPlayerTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/support/TheaterPlayerTest.java
@@ -10,6 +10,7 @@ import org.code.protocol.InternalErrorKey;
 import org.code.protocol.InternalServerRuntimeError;
 import org.code.protocol.LifecycleNotifier;
 import org.code.theater.support.TheaterPlayer.ConcertCreatorFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,6 +33,11 @@ class TheaterPlayerTest {
     actions = new ArrayList<>();
 
     unitUnderTest = new TheaterPlayer(concertCreatorFactory);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test

--- a/org-code-javabuilder/validation/src/test/java/org/code/validation/support/NeighborhoodTrackerTest.java
+++ b/org-code-javabuilder/validation/src/test/java/org/code/validation/support/NeighborhoodTrackerTest.java
@@ -9,6 +9,7 @@ import org.code.protocol.ClientMessageType;
 import org.code.protocol.GlobalProtocolTestFactory;
 import org.code.validation.ClientMessageHelper;
 import org.code.validation.PainterLog;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -21,6 +22,11 @@ class NeighborhoodTrackerTest {
     GlobalProtocolTestFactory.builder().create();
     World.setInstance(new World(GRID_SIZE));
     unitUnderTest = new NeighborhoodTracker();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test


### PR DESCRIPTION
This change prevents multiple GlobalProtocol instances from being created in a single session. This wasn't really affecting us in production before, but in theory, the GlobalProtocol instance could be created multiple times which can lead to weird side effects since it's a very commonly used singleton across the service. Thanks to our class loader checks, this technically wouldn't be possible to do in student code, but there was still the possibility we could accidentally reset the instance internally, so this allows us to guard against that.

To accomplish this, GlobalProtocol.create() now happens in the onPreExecute() method in CodeExecutionManager, and the instance is destroyed (via GlobalProtocol.destroy()) in the onPostExecute() method.

I also did a small refactor to have the ProjectData class implement the ProjectFileLoader interface rather than the various ContentManagers. This is just because, without this refactor, we'd have to pass ContentManager into CodeExecutionManager twice (once as a ContentManager and once as a ProjectFileLoader) which just felt a little wonky - plus, the ContentManagers just call ProjectData directly to load source files so it wasn't a huge change to have ProjectData implement the interface instead. I think there is still some more cleanup we can do here and possibly eliminate the ProjectFileLoader interface entirely but there are some caveats with that which make it less straightforward than anticipated.

JIRA: https://codedotorg.atlassian.net/browse/JAVA-220

Testing: local + deployed instance