### PR TITLE
Add s3-bucket parameter to deploy command

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -49,6 +49,7 @@ if [[ $(aws sts get-caller-identity --query Arn --output text) =~ "assumed-role/
 fi
 
 aws cloudformation deploy \
+  --s3-bucket ${TEMPLATE_BUCKET} \
   --template-file ${OUTPUT_TEMPLATE} \
   --parameter-overrides SubDomainName=$SUB_DOMAIN BaseDomainName=$BASE_DOMAIN BaseDomainNameHostedZonedID=$BASE_DOMAIN_HOSTED_ZONE_ID \
     ProvisionedConcurrentExecutions=$PROVISIONED_CONCURRENT_EXECUTIONS ReservedConcurrentExecutions=$RESERVED_CONCURRENT_EXECUTIONS \


### PR DESCRIPTION
We have started getting occasional errors on deploy that our template file is too large. This adds an s3-bucket to the deploy command (the same one we use for the `package` command) which allows us to use a larger template file.

I tested this change by deploying to my dev instance of Javabuilder.