### PR TITLE
Stub asset file requests for localhost Dashboard and integration tests

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -61,8 +61,6 @@ public class WebSocketServer {
     final String miniAppType = queryInput.getString("mini_app_type");
     final ExecutionType executionType =
         ExecutionType.valueOf(queryInput.getString("execution_type"));
-    // TODO: dashboardHostname is currently unused but may be needed for stubbing asset files
-    final String dashboardHostname = "http://" + queryInput.get("iss") + ":3000";
     final JSONObject options = new JSONObject(queryInput.getString("options"));
     final List<String> compileList = JSONUtils.listFromJSONObjectMember(options, "compileList");
 
@@ -73,7 +71,6 @@ public class WebSocketServer {
     this.logger.setUseParentHandlers(false);
 
     Properties.setConnectionId(connectionId);
-    Properties.setIsDashboardLocalhost(true);
 
     websocketOutputAdapter = new WebSocketOutputAdapter(session);
     inputAdapter = new WebSocketInputAdapter();

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -73,6 +73,7 @@ public class WebSocketServer {
     this.logger.setUseParentHandlers(false);
 
     Properties.setConnectionId(connectionId);
+    Properties.setIsDashboardLocalhost(true);
 
     websocketOutputAdapter = new WebSocketOutputAdapter(session);
     inputAdapter = new WebSocketInputAdapter();

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSContentManager.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSContentManager.java
@@ -17,6 +17,7 @@ import java.util.Date;
 import org.code.protocol.ContentManager;
 import org.code.protocol.InternalErrorKey;
 import org.code.protocol.JavabuilderException;
+import org.code.protocol.Properties;
 import org.json.JSONException;
 
 public class AWSContentManager implements ContentManager {
@@ -35,6 +36,7 @@ public class AWSContentManager implements ContentManager {
   private final String contentBucketUrl;
   private final Context context;
   private final ProjectData projectData;
+  private final AssetFileStubber assetFileStubber;
   private int writes;
   private int uploads;
 
@@ -51,6 +53,7 @@ public class AWSContentManager implements ContentManager {
     this.contentBucketUrl = contentBucketUrl;
     this.context = context;
     this.projectData = this.loadProjectData();
+    this.assetFileStubber = new AssetFileStubber();
     this.writes = 0;
     this.uploads = 0;
   }
@@ -61,13 +64,15 @@ public class AWSContentManager implements ContentManager {
       String javabuilderSessionId,
       String contentBucketUrl,
       Context context,
-      ProjectData projectData) {
+      ProjectData projectData,
+      AssetFileStubber assetFileStubber) {
     this.bucketName = bucketName;
     this.s3Client = s3Client;
     this.javabuilderSessionId = javabuilderSessionId;
     this.contentBucketUrl = contentBucketUrl;
     this.context = context;
     this.projectData = projectData;
+    this.assetFileStubber = assetFileStubber;
     this.writes = 0;
     this.uploads = 0;
   }
@@ -78,6 +83,9 @@ public class AWSContentManager implements ContentManager {
 
   @Override
   public String getAssetUrl(String filename) {
+    if (Properties.isDashboardLocalhost() || Properties.isIntegrationTest()) {
+      return this.assetFileStubber.getStubAssetUrl(filename);
+    }
     return this.projectData.getAssetUrl(filename);
   }
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSContentManager.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSContentManager.java
@@ -90,11 +90,11 @@ public class AWSContentManager implements ContentManager {
       return null;
     }
 
-    // If this asset file refers to a Dashboard URL, and Javabuilder was invoked by a Dashboard
-    // server running localhost or running an integration test, Javabuilder won't be able access
-    // this file. Use a stubbed file URL instead.
+    // If this asset file refers to a Dashboard URL, and Javabuilder cannot access Dashboard for
+    // assets or running an integration test, Javabuilder won't be able access this file. Use a
+    // stubbed file URL instead.
     if (this.isUrlFromDashboard(url)
-        && (Properties.isDashboardLocalhost() || Properties.isIntegrationTest())) {
+        && (!Properties.canAccessDashboardAssets() || Properties.isIntegrationTest())) {
       return this.assetFileStubber.getStubAssetUrl(filename);
     }
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AssetFileStubber.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AssetFileStubber.java
@@ -1,0 +1,50 @@
+package org.code.javabuilder;
+
+import static org.code.protocol.LoggerNames.MAIN_LOGGER;
+
+import java.util.logging.Logger;
+
+public class AssetFileStubber {
+  private static final String[] IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif"};
+  private static final String[] AUDIO_EXTENSIONS = {".wav"};
+  private static final String STUB_IMAGE_FILE_NAME = "sampleImageBeach.jpg";
+  private static final String STUB_AUDIO_FILE_NAME = "beatbox.wav";
+
+  private final String stubImageUrl;
+  private final String stubAudioUrl;
+
+  public AssetFileStubber() {
+    stubImageUrl = getClass().getClassLoader().getResource(STUB_IMAGE_FILE_NAME).toString();
+    stubAudioUrl = getClass().getClassLoader().getResource(STUB_AUDIO_FILE_NAME).toString();
+    System.out.printf(
+        "Generated stubbed URLs for image: %s and audio: %s\n", stubImageUrl, stubAudioUrl);
+  }
+
+  public String getStubAssetUrl(String filename) {
+    System.out.println("Stubbing asset file: " + filename);
+    if (this.matchesExtension(filename, IMAGE_EXTENSIONS)) {
+      System.out.printf("Returning stubbed URL %s\n", stubImageUrl);
+      return stubImageUrl;
+    }
+
+    if (this.matchesExtension(filename, AUDIO_EXTENSIONS)) {
+      System.out.printf("Returning stubbed URL %s\n", stubAudioUrl);
+      return stubAudioUrl;
+    }
+
+    System.out.println("Unknown extension; returning null");
+    Logger.getLogger(MAIN_LOGGER)
+        .warning(String.format("Unknown file %s. Cannot provide stubbed asset URL.", filename));
+    return null;
+  }
+
+  private boolean matchesExtension(String filename, String[] extensions) {
+    for (String extension : extensions) {
+      if (filename.toLowerCase().endsWith(extension)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AssetFileStubber.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AssetFileStubber.java
@@ -4,6 +4,11 @@ import static org.code.protocol.LoggerNames.MAIN_LOGGER;
 
 import java.util.logging.Logger;
 
+/**
+ * Generates URLs for local, static asset files that can be used to stub asset file requests when
+ * URLs cannot be accessed, notably in the cases where asset URLs point to Dashboard running on
+ * localhost, or during an integration test.
+ */
 public class AssetFileStubber {
   private static final String[] IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif"};
   private static final String[] AUDIO_EXTENSIONS = {".wav"};
@@ -16,23 +21,23 @@ public class AssetFileStubber {
   public AssetFileStubber() {
     stubImageUrl = getClass().getClassLoader().getResource(STUB_IMAGE_FILE_NAME).toString();
     stubAudioUrl = getClass().getClassLoader().getResource(STUB_AUDIO_FILE_NAME).toString();
-    System.out.printf(
-        "Generated stubbed URLs for image: %s and audio: %s\n", stubImageUrl, stubAudioUrl);
+  }
+
+  // Visible for testing
+  AssetFileStubber(String stubImageUrl, String stubAudioUrl) {
+    this.stubImageUrl = stubImageUrl;
+    this.stubAudioUrl = stubAudioUrl;
   }
 
   public String getStubAssetUrl(String filename) {
-    System.out.println("Stubbing asset file: " + filename);
     if (this.matchesExtension(filename, IMAGE_EXTENSIONS)) {
-      System.out.printf("Returning stubbed URL %s\n", stubImageUrl);
       return stubImageUrl;
     }
 
     if (this.matchesExtension(filename, AUDIO_EXTENSIONS)) {
-      System.out.printf("Returning stubbed URL %s\n", stubAudioUrl);
       return stubAudioUrl;
     }
 
-    System.out.println("Unknown extension; returning null");
     Logger.getLogger(MAIN_LOGGER)
         .warning(String.format("Unknown file %s. Cannot provide stubbed asset URL.", filename));
     return null;
@@ -44,7 +49,6 @@ public class AssetFileStubber {
         return true;
       }
     }
-
     return false;
   }
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/DashboardConstants.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/DashboardConstants.java
@@ -1,0 +1,10 @@
+package org.code.javabuilder;
+
+public final class DashboardConstants {
+  private DashboardConstants() {
+    throw new UnsupportedOperationException("Instantiation of constants class is not allowed.");
+  }
+
+  public static final String DASHBOARD_LOCALHOST_URL = "https://localhost-studio.code.org";
+  public static final String DASHBOARD_DOMAIN_SUFFIX = "studio.code.org";
+}

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/DashboardConstants.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/DashboardConstants.java
@@ -5,6 +5,6 @@ public final class DashboardConstants {
     throw new UnsupportedOperationException("Instantiation of constants class is not allowed.");
   }
 
-  public static final String DASHBOARD_LOCALHOST_URL = "https://localhost-studio.code.org";
+  public static final String DASHBOARD_LOCALHOST_DOMAIN = "localhost-studio.code.org";
   public static final String DASHBOARD_DOMAIN_SUFFIX = "studio.code.org";
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -1,5 +1,6 @@
 package org.code.javabuilder;
 
+import static org.code.javabuilder.DashboardConstants.DASHBOARD_LOCALHOST_URL;
 import static org.code.protocol.InternalErrorKey.INTERNAL_EXCEPTION;
 import static org.code.protocol.LoggerNames.MAIN_LOGGER;
 
@@ -53,8 +54,6 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
           .build();
   private static final AmazonSQS SQS_CLIENT = AmazonSQSClientBuilder.defaultClient();
   private static final AmazonS3 S3_CLIENT = AmazonS3ClientBuilder.standard().build();
-
-  private static final String DASHBOARD_LOCALHOST_URL = "https://localhost-studio.code.org";
 
   public LambdaRequestHandler() {
     // create CachedResources once for the entire container.

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -1,6 +1,6 @@
 package org.code.javabuilder;
 
-import static org.code.javabuilder.DashboardConstants.DASHBOARD_LOCALHOST_URL;
+import static org.code.javabuilder.DashboardConstants.DASHBOARD_LOCALHOST_DOMAIN;
 import static org.code.protocol.InternalErrorKey.INTERNAL_EXCEPTION;
 import static org.code.protocol.LoggerNames.MAIN_LOGGER;
 
@@ -85,7 +85,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     final String miniAppType = lambdaInput.get("miniAppType");
     final ExecutionType executionType = ExecutionType.valueOf(lambdaInput.get("executionType"));
     // TODO: dashboardHostname is currently unused but may be needed for stubbing asset files
-    final String dashboardHostname = "https://" + lambdaInput.get("iss");
+    final String dashboardHostname = lambdaInput.get("iss");
     final JSONObject options = new JSONObject(lambdaInput.get("options"));
     final String javabuilderSessionId = lambdaInput.get("javabuilderSessionId");
     final List<String> compileList = JSONUtils.listFromJSONObjectMember(options, "compileList");
@@ -103,7 +103,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     // turn off the default console logger
     logger.setUseParentHandlers(false);
     Properties.setConnectionId(connectionId);
-    Properties.setIsDashboardLocalhost(dashboardHostname.equals(DASHBOARD_LOCALHOST_URL));
+    Properties.setIsDashboardLocalhost(dashboardHostname.equals(DASHBOARD_LOCALHOST_DOMAIN));
 
     // Create user-program output handlers
     final AWSOutputAdapter awsOutputAdapter = new AWSOutputAdapter(connectionId, API_CLIENT);

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -54,6 +54,8 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
   private static final AmazonSQS SQS_CLIENT = AmazonSQSClientBuilder.defaultClient();
   private static final AmazonS3 S3_CLIENT = AmazonS3ClientBuilder.standard().build();
 
+  private static final String DASHBOARD_LOCALHOST_URL = "https://localhost-studio.code.org";
+
   public LambdaRequestHandler() {
     // create CachedResources once for the entire container.
     // This will only be called once in the initial creation of the lambda instance.
@@ -102,6 +104,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     // turn off the default console logger
     logger.setUseParentHandlers(false);
     Properties.setConnectionId(connectionId);
+    Properties.setIsDashboardLocalhost(dashboardHostname.equals(DASHBOARD_LOCALHOST_URL));
 
     // Create user-program output handlers
     final AWSOutputAdapter awsOutputAdapter = new AWSOutputAdapter(connectionId, API_CLIENT);

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -102,7 +102,8 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     // turn off the default console logger
     logger.setUseParentHandlers(false);
     Properties.setConnectionId(connectionId);
-    Properties.setIsDashboardLocalhost(dashboardHostname.equals(DASHBOARD_LOCALHOST_DOMAIN));
+    // Dashboard assets are only accessible if the dashboard domain is not localhost
+    Properties.setCanAccessDashboardAssets(!dashboardHostname.equals(DASHBOARD_LOCALHOST_DOMAIN));
 
     // Create user-program output handlers
     final AWSOutputAdapter awsOutputAdapter = new AWSOutputAdapter(connectionId, API_CLIENT);

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -84,7 +84,6 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
         lambdaInput.get("channelId") == null ? "noneProvided" : lambdaInput.get("channelId");
     final String miniAppType = lambdaInput.get("miniAppType");
     final ExecutionType executionType = ExecutionType.valueOf(lambdaInput.get("executionType"));
-    // TODO: dashboardHostname is currently unused but may be needed for stubbing asset files
     final String dashboardHostname = lambdaInput.get("iss");
     final JSONObject options = new JSONObject(lambdaInput.get("options"));
     final String javabuilderSessionId = lambdaInput.get("javabuilderSessionId");

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/AWSContentManagerTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/AWSContentManagerTest.java
@@ -24,7 +24,7 @@ class AWSContentManagerTest {
   private AWSContentManager contentManager;
   private Context context;
   private ProjectData projectData;
-  private UserProjectFiles projectFiles;
+  private AssetFileStubber assetFileStubber;
   private ArgumentCaptor<String> assetUrlCaptor;
 
   private static final String FAKE_BUCKET_NAME = "bucket-name";
@@ -36,11 +36,17 @@ class AWSContentManagerTest {
     s3ClientMock = mock(AmazonS3.class);
     context = mock(Context.class);
     projectData = mock(ProjectData.class);
-    projectFiles = mock(UserProjectFiles.class);
+    assetFileStubber = mock(AssetFileStubber.class);
     assetUrlCaptor = ArgumentCaptor.forClass(String.class);
     contentManager =
         new AWSContentManager(
-            s3ClientMock, FAKE_BUCKET_NAME, FAKE_SESSION_ID, FAKE_OUTPUT_URL, context, projectData);
+            s3ClientMock,
+            FAKE_BUCKET_NAME,
+            FAKE_SESSION_ID,
+            FAKE_OUTPUT_URL,
+            context,
+            projectData,
+            assetFileStubber);
   }
 
   @Test
@@ -56,7 +62,6 @@ class AWSContentManagerTest {
   void writesToS3() throws JavabuilderException {
     byte[] input = new byte[10];
     contentManager.writeToOutputFile("test.txt", input, "text/plain");
-    String key = FAKE_SESSION_ID + "/test.txt";
     verify(s3ClientMock)
         .putObject(anyString(), anyString(), any(ByteArrayInputStream.class), any());
   }

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/AWSContentManagerTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/AWSContentManagerTest.java
@@ -129,7 +129,7 @@ class AWSContentManagerTest {
 
   @Test
   public void testGenerateAssetUrlReturnsStubbedUrlWhenNeeded() {
-    Properties.setIsDashboardLocalhost(true);
+    Properties.setCanAccessDashboardAssets(false);
 
     final String filename = "file";
     final String actualUrl = "staging-studio.code.org/file.wav";
@@ -141,12 +141,12 @@ class AWSContentManagerTest {
     verify(projectData).getAssetUrl(filename);
     verify(assetFileStubber).getStubAssetUrl(filename);
 
-    Properties.setIsDashboardLocalhost(false);
+    Properties.setCanAccessDashboardAssets(true);
   }
 
   @Test
   public void testGenerateAssetUrlDoesNotReturnStubUrlIfNotDashboard() {
-    Properties.setIsDashboardLocalhost(true);
+    Properties.setCanAccessDashboardAssets(false);
 
     final String filename = "file";
     final String actualUrl = "cdo-javabuilderbeta-content/file.wav";
@@ -156,6 +156,6 @@ class AWSContentManagerTest {
     verify(projectData).getAssetUrl(filename);
     verify(assetFileStubber, never()).getStubAssetUrl(anyString());
 
-    Properties.setIsDashboardLocalhost(false);
+    Properties.setCanAccessDashboardAssets(true);
   }
 }

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/AssetFileStubberTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/AssetFileStubberTest.java
@@ -1,0 +1,37 @@
+package org.code.javabuilder;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AssetFileStubberTest {
+
+  private static final String IMAGE_URL = "file:/image.jpg";
+  private static final String AUDIO_URL = "file:/audio.wav";
+
+  private AssetFileStubber unitUnderTest;
+
+  @BeforeEach
+  public void setUp() {
+    unitUnderTest = new AssetFileStubber(IMAGE_URL, AUDIO_URL);
+  }
+
+  @Test
+  public void testReturnsImageUrlForImageFile() {
+    final String[] files = {"file.jpg", "file.jpeg", "file.png", "file.gif"};
+    for (String file : files) {
+      assertEquals(IMAGE_URL, unitUnderTest.getStubAssetUrl(file));
+    }
+  }
+
+  @Test
+  public void testReturnsAudioUrlForAudioFile() {
+    assertEquals(AUDIO_URL, unitUnderTest.getStubAssetUrl("file.wav"));
+  }
+
+  @Test
+  public void testReturnsNullForUnknownFileType() {
+    assertNull(unitUnderTest.getStubAssetUrl("file.pdf"));
+  }
+}

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/Properties.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/Properties.java
@@ -16,8 +16,8 @@ public class Properties {
     return Properties.connectionId;
   }
 
-  public static void setCanAccessDashboardAssets(boolean isDashboardLocalhost) {
-    Properties.CAN_ACCESS_DASHBOARD_ASSETS = isDashboardLocalhost;
+  public static void setCanAccessDashboardAssets(boolean canAccessDashboardAssets) {
+    Properties.CAN_ACCESS_DASHBOARD_ASSETS = canAccessDashboardAssets;
   }
 
   public static boolean canAccessDashboardAssets() {

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/Properties.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/Properties.java
@@ -3,8 +3,8 @@ package org.code.protocol;
 public class Properties {
   /** The connection ID for the current session */
   private static String connectionId = "localhost";
-  /** If the client invoking Javabuilder is the Dashboard service running on localhost */
-  private static boolean DASHBOARD_LOCALHOST = false;
+  /** If Javabuilder can access assets from the Dashboard service that invoked it */
+  private static boolean CAN_ACCESS_DASHBOARD_ASSETS = true;
   /** Whether Javabuilder is running an integration test */
   private static boolean IS_INTEGRATION_TEST = false;
 
@@ -16,12 +16,12 @@ public class Properties {
     return Properties.connectionId;
   }
 
-  public static void setIsDashboardLocalhost(boolean isDashboardLocalhost) {
-    Properties.DASHBOARD_LOCALHOST = isDashboardLocalhost;
+  public static void setCanAccessDashboardAssets(boolean isDashboardLocalhost) {
+    Properties.CAN_ACCESS_DASHBOARD_ASSETS = isDashboardLocalhost;
   }
 
-  public static boolean isDashboardLocalhost() {
-    return Properties.DASHBOARD_LOCALHOST;
+  public static boolean canAccessDashboardAssets() {
+    return Properties.CAN_ACCESS_DASHBOARD_ASSETS;
   }
 
   public static void setIsIntegrationTest(boolean isIntegrationTest) {

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/Properties.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/Properties.java
@@ -1,7 +1,12 @@
 package org.code.protocol;
 
 public class Properties {
+  /** The connection ID for the current session */
   private static String connectionId = "localhost";
+  /** If the client invoking Javabuilder is the Dashboard service running on localhost */
+  private static boolean DASHBOARD_LOCALHOST = false;
+  /** Whether Javabuilder is running an integration test */
+  private static boolean IS_INTEGRATION_TEST = false;
 
   public static void setConnectionId(String connectionId) {
     Properties.connectionId = connectionId;
@@ -9,5 +14,21 @@ public class Properties {
 
   public static String getConnectionId() {
     return Properties.connectionId;
+  }
+
+  public static void setIsDashboardLocalhost(boolean isDashboardLocalhost) {
+    Properties.DASHBOARD_LOCALHOST = isDashboardLocalhost;
+  }
+
+  public static boolean isDashboardLocalhost() {
+    return Properties.DASHBOARD_LOCALHOST;
+  }
+
+  public static void setIsIntegrationTest(boolean isIntegrationTest) {
+    Properties.IS_INTEGRATION_TEST = isIntegrationTest;
+  }
+
+  public static boolean isIntegrationTest() {
+    return Properties.IS_INTEGRATION_TEST;
   }
 }


### PR DESCRIPTION
This adds functionality to stub asset file requests on deployed/prod Javabuilder when running against localhost Dashboard or running integration tests, when those are set up. This is needed because asset URLs sent from Javalab point to Dashboard and if Dashboard is running on localhost on a developer's machine, deployed/prod Javabuilder cannot access these URLs. In the case of integration tests, we also want a way to run tests against a deployed instance of Javabuilder without needing a dashboard server running. I went ahead and used sampleImageBeach.jpg and beatbox.wav as stub files since these were already checked into the repo.

JIRA: https://codedotorg.atlassian.net/browse/JAVA-454

Tested with localhost dashboard + deployed Javabuilder.