### PR TITLE
Update Javabuilder READMEs to include decoupled Javabuilder updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ To connect with an adhoc:
    [How to Provision an adhoc Environment](https://docs.google.com/document/d/1nWeQEmEQF1B2l93JTQPyeRpLEFzCzY5NdgJ8kgprcDk/edit)
    document.
 1. Navigate to any Java Lab level, for example:
-       http://\<your-adhoc-name\>.cdn-code.org/projects/javalab/new
+       http://<your-adhoc-name\>.cdn-code.org/projects/javalab/new
 1. Click the "Run" button
 
 _NOTE: Currently, Javabuilder still relies on Dashboard to fetch assets when needed (for example, in Theater

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ To connect your dev instance with Java Lab (Code Studio client) running on your 
 
 1. In the code-dot-org repo, edit the `javabuilder_url` value in
    [cdo.rb](https://github.com/code-dot-org/code-dot-org/blob/665a45210d556b4c3d82d6ad2434617c8e2e5ea1/lib/cdo.rb#L127)
-   to point to your local dev deployment (this will typically be wss://javabuilder-\<your name\>.dev-code.org).
+   to point to your local dev deployment (this will typically be wss://javabuilder-<your name\>.dev-code.org).
 1. Edit the `javabuilder_upload_url` value in
    [cdo.rb](https://github.com/code-dot-org/code-dot-org/blob/665a45210d556b4c3d82d6ad2434617c8e2e5ea1/lib/cdo.rb#L137)
-   to point to your local dev HTTP upload API (this will typically be https://javabuilder-\<your name\>-http.dev-code.org/seedsources/sources.json).
+   to point to your local dev HTTP upload API (this will typically be https://javabuilder-<your name\>-http.dev-code.org/seedsources/sources.json).
 1. Launch dashboard using the instructions here:
    https://github.com/code-dot-org/code-dot-org/blob/staging/SETUP.md#overview
 1. Navigate to any Java Lab level, for example:

--- a/org-code-javabuilder/README.md
+++ b/org-code-javabuilder/README.md
@@ -100,14 +100,10 @@ _Note: non-Java files used or created by the program (for example `grid.txt` in 
 Neighborhood) will be added to the root of the repo. In production, the runtime directory
 is changed to the tmp directory, so cleanup of these files is not necessary there._
 
-### Developing with AWS
-For development purposes, you generally shouldn't need a dev deploy of Javabuilder. See
-the 
-[repo-level README](https://github.com/code-dot-org/javabuilder/blob/main/README.md#dev-deploy-of-javabuilder)
-for instructions on when a dev deploy of Javabuilder is required and how to carry out
-such a deployment.
+### Developing in isolation (DEPRECATED)
 
-### Developing in isolation
+Note: `LocalMain` will removed soon. Use the above method to develop Javabuilder.
+
 To run Javabuilder in isolation, run the `LocalMain` class from you Java IDE. This will
 exercise the compile and run logic in isolation. Javabuilder will execute the program in
 src/main/resources/main.json. You can update which file is used from 


### PR DESCRIPTION
Updates the main Javabuilder and org-code-javabuilder READMEs to account for updates after the decoupled Javabuilder work. Note: use the "rich diff" option for better viewing.