### PR TITLE
Allow lambdas to create, read, update javabuilder dynamodb tables

### DIFF
--- a/iam.yml
+++ b/iam.yml
@@ -61,9 +61,15 @@ Resources:
                   - "xray:PutTraceSegments"
                   - "xray:PutTelemetryRecords"
                 Resource: '*'
+              - Effect: Allow
+                Action:
+                  - 'dynamodb:PutItem'
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*"
       ManagedPolicyArns:
         # Authorizer
         # Currently doesn't require any permissions beyond logging.
+        # ^^ needs to read/write from dynamodb, so not totally true any more.
 
         # Invoke and relay messages to Project Lambda.
         - "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess"

--- a/iam.yml
+++ b/iam.yml
@@ -63,7 +63,9 @@ Resources:
                 Resource: '*'
               - Effect: Allow
                 Action:
+                  - 'dynamodb:GetItem'
                   - 'dynamodb:PutItem'
+                  - 'dynamodb:UpdateItem'
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_tokens"
       ManagedPolicyArns:

--- a/iam.yml
+++ b/iam.yml
@@ -61,6 +61,8 @@ Resources:
                   - "xray:PutTraceSegments"
                   - "xray:PutTelemetryRecords"
                 Resource: '*'
+
+              # Authorizer lambdas need to create, read, and update dynamodb records for throttling.
               - Effect: Allow
                 Action:
                   - 'dynamodb:GetItem'
@@ -72,10 +74,6 @@ Resources:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_teacher_associated_requests"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_blocked_users"
       ManagedPolicyArns:
-        # Authorizer
-        # Currently doesn't require any permissions beyond logging.
-        # ^^ needs to read/write from dynamodb, so not totally true any more.
-
         # Invoke and relay messages to Project Lambda.
         - "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess"
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"

--- a/iam.yml
+++ b/iam.yml
@@ -68,6 +68,9 @@ Resources:
                   - 'dynamodb:UpdateItem'
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_tokens"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_user_requests"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_teacher_associated_requests"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_blocked_users"
       ManagedPolicyArns:
         # Authorizer
         # Currently doesn't require any permissions beyond logging.

--- a/iam.yml
+++ b/iam.yml
@@ -65,7 +65,7 @@ Resources:
                 Action:
                   - 'dynamodb:PutItem'
                 Resource:
-                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*"
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_tokens"
       ManagedPolicyArns:
         # Authorizer
         # Currently doesn't require any permissions beyond logging.


### PR DESCRIPTION
Allow the lambda execution role to create, read, and update DynamoDB records for tables named with javabuilder-specific suffixes. Must be merged and deployed [before this PR is deployed](https://github.com/code-dot-org/javabuilder/pull/251).

## Testing story

I've tested the `_tokens` table permission, but added in the other tables as well so that we don't need infra to deploy the IAM stack repeatedly as we work on throttling.