### PR TITLE
System.exit if there is an error cleaning the temp directory

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaErrorCodes.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaErrorCodes.java
@@ -1,0 +1,9 @@
+package org.code.javabuilder;
+
+public final class LambdaErrorCodes {
+  private LambdaErrorCodes() {
+    throw new UnsupportedOperationException("Instantation of constants class not allowed.");
+  }
+
+  public static final int TEMP_DIRECTORY_CLEANUP_ERROR_CODE = 10;
+}


### PR DESCRIPTION
Quick fix to address a live issue where student code can create too many open files can prevent the lambda container from working for subsequent executions. The fix here is to `System.exit` if we hit any issues cleaning up the temp directory, just to ensure that we're starting from a clean slate on the next invocation.

Tested on dev lambda using a project that opens new files in an infinitely recursing loop. The project still hits an error when running, but subsequent runs don't hit the previous "Too many open files" error, and if the infinite loop is removed, the project executes normally.

Note that in this project, we sometimes see this error: `"java.lang.NoClassDefFoundError: org/code/javabuilder/UserInitiatedExceptionKey"` instead of "Too many open files". My suspicion is that our class loader can't load this file due to too many files being opened, but with this fix at least every new invocation starts with the container reset, and when the infinite loop is removed, we don't see any indication that files are still open.

Test project here: https://studio.code.org/projects/javalab/dOcffp0xW8cD7dtqB5zEe44IdrreBXV7cP9z-vY8n-g

More details in Slack here: https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1648671242620549