### PR TITLE
Ensure AWS resources are cleaned up before System.exit

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMain.java
@@ -41,7 +41,8 @@ public class LocalMain {
             null,
             new LocalTempDirectoryManager(),
             localContentManager,
-            new LifecycleNotifier());
+            new LifecycleNotifier(),
+            new LocalSystemExitHelper());
     codeExecutionManager.execute();
   }
 }

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalSystemExitHelper.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalSystemExitHelper.java
@@ -1,6 +1,6 @@
 package dev.javabuilder;
 
-import org.code.protocol.SystemExitHelper;
+import org.code.javabuilder.SystemExitHelper;
 
 public class LocalSystemExitHelper implements SystemExitHelper {
 

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalSystemExitHelper.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalSystemExitHelper.java
@@ -1,0 +1,11 @@
+package dev.javabuilder;
+
+import org.code.protocol.SystemExitHelper;
+
+public class LocalSystemExitHelper implements SystemExitHelper {
+
+  @Override
+  public void exit(int status) {
+    // Currently nothing to clean up; no-op
+  }
+}

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -104,7 +104,8 @@ public class WebSocketServer {
                       compileList,
                       new LocalTempDirectoryManager(),
                       contentManager,
-                      lifecycleNotifier);
+                      lifecycleNotifier,
+                      new LocalSystemExitHelper());
               executionManager.execute();
               // Clean up session
               try {

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSSystemExitHelper.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSSystemExitHelper.java
@@ -7,7 +7,6 @@ import com.amazonaws.services.apigatewaymanagementapi.model.DeleteConnectionRequ
 import com.amazonaws.services.apigatewaymanagementapi.model.GoneException;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
-import org.code.protocol.SystemExitHelper;
 
 public class AWSSystemExitHelper implements SystemExitHelper {
   private final String connectionId;

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSSystemExitHelper.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSSystemExitHelper.java
@@ -1,0 +1,43 @@
+package org.code.javabuilder;
+
+import static org.code.protocol.LoggerNames.MAIN_LOGGER;
+
+import com.amazonaws.services.apigatewaymanagementapi.AmazonApiGatewayManagementApi;
+import com.amazonaws.services.apigatewaymanagementapi.model.DeleteConnectionRequest;
+import com.amazonaws.services.apigatewaymanagementapi.model.GoneException;
+import java.util.logging.Handler;
+import java.util.logging.Logger;
+import org.code.protocol.SystemExitHelper;
+
+public class AWSSystemExitHelper implements SystemExitHelper {
+  private final String connectionId;
+  private final AmazonApiGatewayManagementApi api;
+
+  public AWSSystemExitHelper(String connectionId, AmazonApiGatewayManagementApi api) {
+    this.connectionId = connectionId;
+    this.api = api;
+  }
+
+  @Override
+  public void exit(int status) {
+    this.cleanUpResources();
+    System.exit(status);
+  }
+
+  private void cleanUpResources() {
+    final DeleteConnectionRequest deleteConnectionRequest =
+        new DeleteConnectionRequest().withConnectionId(connectionId);
+    // Deleting the API Gateway connection should always be the last thing executed because the
+    // delete action cleans up the AWS resources associated with this lambda
+    try {
+      api.deleteConnection(deleteConnectionRequest);
+    } catch (GoneException e) {
+      // if the connection is already gone, we don't need to delete the connection.
+    }
+    // clean up log handler to avoid duplicate logs in future runs.
+    Handler[] allHandlers = Logger.getLogger(MAIN_LOGGER).getHandlers();
+    for (int i = 0; i < allHandlers.length; i++) {
+      Logger.getLogger(MAIN_LOGGER).removeHandler(allHandlers[i]);
+    }
+  }
+}

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeExecutionManager.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeExecutionManager.java
@@ -26,6 +26,7 @@ public class CodeExecutionManager {
   private final TempDirectoryManager tempDirectoryManager;
   private final LifecycleNotifier lifecycleNotifier;
   private final ContentManager contentManager;
+  private final SystemExitHelper systemExitHelper;
   private final CodeBuilderRunnableFactory codeBuilderRunnableFactory;
 
   private File tempFolder;
@@ -55,7 +56,8 @@ public class CodeExecutionManager {
       List<String> compileList,
       TempDirectoryManager tempDirectoryManager,
       ContentManager contentManager,
-      LifecycleNotifier lifecycleNotifier) {
+      LifecycleNotifier lifecycleNotifier,
+      SystemExitHelper systemExitHelper) {
     this(
         fileLoader,
         inputAdapter,
@@ -65,6 +67,7 @@ public class CodeExecutionManager {
         tempDirectoryManager,
         lifecycleNotifier,
         contentManager,
+        systemExitHelper,
         new CodeBuilderRunnableFactory());
   }
 
@@ -77,6 +80,7 @@ public class CodeExecutionManager {
       TempDirectoryManager tempDirectoryManager,
       LifecycleNotifier lifecycleNotifier,
       ContentManager contentManager,
+      SystemExitHelper systemExitHelper,
       CodeBuilderRunnableFactory codeBuilderRunnableFactory) {
     this.fileLoader = fileLoader;
     this.inputAdapter = inputAdapter;
@@ -86,6 +90,7 @@ public class CodeExecutionManager {
     this.tempDirectoryManager = tempDirectoryManager;
     this.lifecycleNotifier = lifecycleNotifier;
     this.contentManager = contentManager;
+    this.systemExitHelper = systemExitHelper;
     this.codeBuilderRunnableFactory = codeBuilderRunnableFactory;
     this.executionInProgress = false;
   }
@@ -184,7 +189,7 @@ public class CodeExecutionManager {
       // open. Force the JVM to quit in order to release the resources for the next use of the
       // container. Temporarily logging the exception for investigation purposes.
       LoggerUtils.logException(e);
-      System.exit(TEMP_DIRECTORY_CLEANUP_ERROR_CODE);
+      this.systemExitHelper.exit(TEMP_DIRECTORY_CLEANUP_ERROR_CODE);
     } finally {
       // Replace System in/out with original System in/out and destroy Global Protocol
       System.setIn(this.systemInputStream);

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -156,7 +156,8 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
             compileList,
             tempDirectoryManager,
             contentManager,
-            lifecycleNotifier);
+            lifecycleNotifier,
+            new AWSSystemExitHelper(connectionId, API_CLIENT));
 
     final Thread timeoutNotifierThread =
         createTimeoutThread(context, outputAdapter, codeExecutionManager, connectionId, API_CLIENT);

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/SystemExitHelper.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/SystemExitHelper.java
@@ -1,4 +1,4 @@
-package org.code.protocol;
+package org.code.javabuilder;
 
 /**
  * An object that can shut down the JVM in the case of abnormal exit. This allows us to perform any

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/CodeExecutionManagerTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/CodeExecutionManagerTest.java
@@ -54,6 +54,7 @@ class CodeExecutionManagerTest {
             tempDirectoryManager,
             lifecycleNotifier,
             contentManager,
+            mock(SystemExitHelper.class),
             codeBuilderRunnableFactory);
   }
 

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/SystemExitHelper.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/SystemExitHelper.java
@@ -1,0 +1,10 @@
+package org.code.protocol;
+
+/**
+ * An object that can shut down the JVM in the case of abnormal exit. This allows us to perform any
+ * final cleanup steps necessary rather than directly calling System.exit(). Accordingly, it is
+ * expected that this method may not return normally.
+ */
+public interface SystemExitHelper {
+  void exit(int status);
+}


### PR DESCRIPTION
Another quick fix to ensure that we always cleanup AWS resources before calling System.exit(). This is a bit of a one-off solution right now because the AWS cleanup code is copied between LambdaRequestHandler and the new AWSSystemExitHelper, but I figured this can help us work towards a more robust solution and also expose a place for us to add any necessary cleanup code in the case of an abnormal system exit.

Tested using dev lambda.