### PR TITLE
Update output adapter for validation runs

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/BaseTestRunner.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/BaseTestRunner.java
@@ -7,6 +7,7 @@ import org.code.protocol.InternalErrorKey;
 import org.code.protocol.OutputAdapter;
 import org.code.protocol.StatusMessage;
 import org.code.protocol.StatusMessageKey;
+import org.code.validation.support.UserTestOutputAdapter;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.engine.discovery.ClassSelector;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
@@ -22,16 +23,19 @@ public class BaseTestRunner implements CodeRunner {
   private final JavabuilderTestExecutionListener listener;
   private final OutputAdapter outputAdapter;
   private final StatusMessageKey statusMessageKey;
+  private final boolean isValidation;
 
   public BaseTestRunner(
       List<JavaProjectFile> files,
       JavabuilderTestExecutionListener listener,
       OutputAdapter outputAdapter,
-      StatusMessageKey statusMessageKey) {
+      StatusMessageKey statusMessageKey,
+      boolean isValidation) {
     this.files = files;
     this.listener = listener;
     this.outputAdapter = outputAdapter;
     this.statusMessageKey = statusMessageKey;
+    this.isValidation = isValidation;
   }
 
   /**
@@ -44,6 +48,9 @@ public class BaseTestRunner implements CodeRunner {
   @Override
   public boolean run(URLClassLoader urlClassLoader)
       throws InternalServerError, UserInitiatedException {
+    if (outputAdapter instanceof UserTestOutputAdapter) {
+      ((UserTestOutputAdapter) outputAdapter).setIsValidation(this.isValidation);
+    }
     if (this.files.size() == 0) {
       return false;
     }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/BaseTestRunner.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/BaseTestRunner.java
@@ -29,12 +29,12 @@ public class BaseTestRunner implements CodeRunner {
       List<JavaProjectFile> files,
       JavabuilderTestExecutionListener listener,
       OutputAdapter outputAdapter,
-      StatusMessageKey statusMessageKey,
       boolean isValidation) {
     this.files = files;
     this.listener = listener;
     this.outputAdapter = outputAdapter;
-    this.statusMessageKey = statusMessageKey;
+    this.statusMessageKey =
+        isValidation ? StatusMessageKey.RUNNING_VALIDATION : StatusMessageKey.RUNNING_PROJECT_TESTS;
     this.isValidation = isValidation;
   }
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserTestRunner.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserTestRunner.java
@@ -2,7 +2,6 @@ package org.code.javabuilder;
 
 import java.util.List;
 import org.code.protocol.OutputAdapter;
-import org.code.protocol.StatusMessageKey;
 
 /** Runs all tests for a given set of Java files */
 public class UserTestRunner extends BaseTestRunner {
@@ -15,6 +14,6 @@ public class UserTestRunner extends BaseTestRunner {
       List<JavaProjectFile> javaFiles,
       JavabuilderTestExecutionListener listener,
       OutputAdapter outputAdapter) {
-    super(javaFiles, listener, outputAdapter, StatusMessageKey.RUNNING_PROJECT_TESTS, false);
+    super(javaFiles, listener, outputAdapter, false);
   }
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserTestRunner.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserTestRunner.java
@@ -15,6 +15,6 @@ public class UserTestRunner extends BaseTestRunner {
       List<JavaProjectFile> javaFiles,
       JavabuilderTestExecutionListener listener,
       OutputAdapter outputAdapter) {
-    super(javaFiles, listener, outputAdapter, StatusMessageKey.RUNNING_PROJECT_TESTS);
+    super(javaFiles, listener, outputAdapter, StatusMessageKey.RUNNING_PROJECT_TESTS, false);
   }
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ValidationRunner.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ValidationRunner.java
@@ -27,7 +27,7 @@ public class ValidationRunner extends BaseTestRunner {
       List<JavaProjectFile> projectFiles,
       JavabuilderTestExecutionListener listener,
       OutputAdapter outputAdapter) {
-    super(validationFiles, listener, outputAdapter, StatusMessageKey.RUNNING_VALIDATION);
+    super(validationFiles, listener, outputAdapter, StatusMessageKey.RUNNING_VALIDATION, true);
     this.projectFiles = projectFiles;
   }
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ValidationRunner.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ValidationRunner.java
@@ -27,7 +27,7 @@ public class ValidationRunner extends BaseTestRunner {
       List<JavaProjectFile> projectFiles,
       JavabuilderTestExecutionListener listener,
       OutputAdapter outputAdapter) {
-    super(validationFiles, listener, outputAdapter, StatusMessageKey.RUNNING_VALIDATION, true);
+    super(validationFiles, listener, outputAdapter, true);
     this.projectFiles = projectFiles;
   }
 

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/BaseTestRunnerTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/BaseTestRunnerTest.java
@@ -7,7 +7,6 @@ import java.net.URLClassLoader;
 import java.util.List;
 import org.code.protocol.InternalErrorKey;
 import org.code.protocol.OutputAdapter;
-import org.code.protocol.StatusMessageKey;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,12 +72,7 @@ public class BaseTestRunnerTest {
     launcherFactory = mockStatic(LauncherFactory.class);
 
     unitUnderTest =
-        new BaseTestRunner(
-            List.of(file1, file2),
-            listener,
-            mock(OutputAdapter.class),
-            StatusMessageKey.RUNNING_PROJECT_TESTS,
-            false);
+        new BaseTestRunner(List.of(file1, file2), listener, mock(OutputAdapter.class), false);
   }
 
   @AfterEach

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/BaseTestRunnerTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/BaseTestRunnerTest.java
@@ -77,7 +77,8 @@ public class BaseTestRunnerTest {
             List.of(file1, file2),
             listener,
             mock(OutputAdapter.class),
-            StatusMessageKey.RUNNING_PROJECT_TESTS);
+            StatusMessageKey.RUNNING_PROJECT_TESTS,
+            false);
   }
 
   @AfterEach


### PR DESCRIPTION
We need to set `isValidation` on `UserTestOutputAdapter` to true on validation runs and to false on user test runs. I missed adding this in the previous work to set up validation runs. This allows us to track neighborhood requests and hide system out messages from the end user when in a validation run, and still send system out messages on user test runs. 