### PR TITLE
Allow DynamoDB Query

### DIFF
--- a/iam.yml
+++ b/iam.yml
@@ -68,6 +68,7 @@ Resources:
                   - 'dynamodb:GetItem'
                   - 'dynamodb:PutItem'
                   - 'dynamodb:UpdateItem'
+                  - 'dynamodb:Query'
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_tokens"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_user_requests"


### PR DESCRIPTION
One more update to IAM permissions for throttling -- allow Queries of DynamoDB tables:

https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/DynamoDB/Client.html#query-instance_method