### PR TITLE
Throttling: add checks for user- and classroom-level limits

### DIFF
--- a/javabuilder-authorizer/http_authorizer_function.rb
+++ b/javabuilder-authorizer/http_authorizer_function.rb
@@ -41,7 +41,7 @@ def get_token_status(context, token_payload, origin)
   puts TokenStatus::USER_OVER_HOURLY_LIMIT if validator.user_over_hourly_limit?
   puts TokenStatus::USER_OVER_DAILY_LIMIT if validator.user_over_daily_limit?
   puts TokenStatus::TEACHERS_OVER_HOURLY_LIMIT if validator.teachers_over_hourly_limit?
-  validator.log_token
+  validator.log_requests
   validator.mark_token_as_vetted
 
   TokenStatus::VALID_HTTP

--- a/javabuilder-authorizer/http_authorizer_function.rb
+++ b/javabuilder-authorizer/http_authorizer_function.rb
@@ -34,15 +34,7 @@ end
 
 def get_token_status(token_payload, origin, region)
   validator = TokenValidator.new(token_payload, origin, region)
-
-  return validator.error_message unless validator.log_token
-  return validator.error_message if validator.user_blocked?
-  return validator.error_message if validator.teachers_blocked?
-  return validator.error_message if validator.user_over_hourly_limit?
-  return validator.error_message if validator.user_over_daily_limit?
-  return validator.error_message if validator.teachers_over_hourly_limit?
-  validator.log_requests
-  return validator.mark_token_as_vetted
+  validator.validate
 end
 
 # ARN is of the format arn:aws:lambda:{region}:{account_id}:function:{lambda_name}

--- a/javabuilder-authorizer/jwt_helper.rb
+++ b/javabuilder-authorizer/jwt_helper.rb
@@ -2,14 +2,14 @@ module JwtHelper
   # Verify the token with the appropriate public key (dependant on the
   # environment the request came from), and checks the token has not
   # expired and its issue time is not in the future.
-  def decode_token(token, origin)
+  def decode_token(token, standardized_origin)
     return false unless token
     begin
       return JWT.decode(
         token,
         # Temporarily choose the key based on the client origin rather than the
         # resource until we have environment-specific Javabuilders set up.
-        get_public_key(origin),
+        get_public_key(standardized_origin),
         true,
         verify_iat: true, # verify issued at time is valid
         algorithm: 'RS256'
@@ -63,24 +63,24 @@ module JwtHelper
   # arn:aws:execute-api:region:account-id:api-id/stage-name/$connect
   # We only care about stage--that tells us the environment (development, staging, etc.)
   # def get_public_key(route_arn)
-  def get_public_key(origin)
+  def get_public_key(standardized_origin)
     # Temporarily choose the key based on the client origin rather than the
     # route_arn until we have environment-specific Javabuilders set up.
     # tmp = route_arn.split(':')
     # api_gateway_arn = tmp[5].split('/')
     # stage_name = api_gateway_arn[1]
     stage_name = ""
-    if origin == "localhost-studio.code.org"
+    if standardized_origin == "localhost-studio.code.org"
       stage_name = "development"
-    elsif origin == "staging-studio.code.org"
+    elsif standardized_origin == "staging-studio.code.org"
       stage_name = "staging"
-    elsif origin == "levelbuilder-studio.code.org"
+    elsif standardized_origin == "levelbuilder-studio.code.org"
       stage_name = "levelbuilder"
-    elsif origin == "test-studio.code.org"
+    elsif standardized_origin == "test-studio.code.org"
       stage_name = "test"
-    elsif origin == "studio.code.org"
+    elsif standardized_origin == "studio.code.org"
       stage_name = "production"
-    elsif origin.start_with?("adhoc-") && origin.end_with?("-studio.cdn-code.org")
+    elsif standardized_origin.start_with?("adhoc-") && standardized_origin.end_with?("-studio.cdn-code.org")
       stage_name = "adhoc"
     end
     # End of temporary code

--- a/javabuilder-authorizer/jwt_helper.rb
+++ b/javabuilder-authorizer/jwt_helper.rb
@@ -50,6 +50,10 @@ module JwtHelper
     auth_response
   end
 
+  def get_standardized_origin(origin)
+    origin.delete_prefix("https://").delete_prefix("http://").delete_suffix(":3000")
+  end
+
   private
 
   # Load the JWT public key from the appropriate environment variable
@@ -65,19 +69,18 @@ module JwtHelper
     # tmp = route_arn.split(':')
     # api_gateway_arn = tmp[5].split('/')
     # stage_name = api_gateway_arn[1]
-    standardized_origin = origin.delete_prefix("https://").delete_prefix("http://").delete_suffix(":3000")
     stage_name = ""
-    if standardized_origin == "localhost-studio.code.org"
+    if origin == "localhost-studio.code.org"
       stage_name = "development"
-    elsif standardized_origin == "staging-studio.code.org"
+    elsif origin == "staging-studio.code.org"
       stage_name = "staging"
-    elsif standardized_origin == "levelbuilder-studio.code.org"
+    elsif origin == "levelbuilder-studio.code.org"
       stage_name = "levelbuilder"
-    elsif standardized_origin == "test-studio.code.org"
+    elsif origin == "test-studio.code.org"
       stage_name = "test"
-    elsif standardized_origin == "studio.code.org"
+    elsif origin == "studio.code.org"
       stage_name = "production"
-    elsif standardized_origin.start_with?("adhoc-") && standardized_origin.end_with?("-studio.cdn-code.org")
+    elsif origin.start_with?("adhoc-") && origin.end_with?("-studio.cdn-code.org")
       stage_name = "adhoc"
     end
     # End of temporary code

--- a/javabuilder-authorizer/token_status.rb
+++ b/javabuilder-authorizer/token_status.rb
@@ -4,6 +4,18 @@ module TokenStatus
   VALID_HTTP = 'valid_http'.freeze
   # Token provided to HTTP authorizer has already been used
   ALREADY_EXISTS = 'already_exists'.freeze
+  # User has been blocked for violating hourly or daily throttle limits
+  USER_BLOCKED = 'user_blocked'.freeze
+  # All of a user's teachers (or the teacher themselves, if the user is a teacher)
+  # has been blocked for violating hourly throttle limits
+  TEACHERS_BLOCKED = 'teachers_blocked'.freeze
+  # User has reached the hourly limit for Javabuilder requests.
+  USER_OVER_HOURLY_LIMIT = 'user_over_hourly_limit'.freeze
+  # User has reached the daily limit for Javabuilder requests.
+  USER_OVER_DAILY_LIMIT = 'user_over_daily_limit'.freeze
+  # All of a user's teachers (or the teacher themselves, if the user is a teacher)
+  # has reached the hourly limit for Javabuilder requests for a classroom.
+  TEACHERS_OVER_HOURLY_LIMIT = 'teachers_over_hourly_limit'.freeze
 
   ### Token statuses used in websocket authorizer (second step in token validation)
   # Token was validated by websocket authorizer

--- a/javabuilder-authorizer/token_validator.rb
+++ b/javabuilder-authorizer/token_validator.rb
@@ -165,7 +165,7 @@ class TokenValidator
   # TO DO: return actual error status instead of valid HTTP
   # when we actually want to throttle.
   def error_message
-    "TOKEN VALIDATION ERROR: #{@status} user_id: #{@user_id} verified_teachers: #{@verified_teachers} token_id: #{@token_id}"
+    puts "TOKEN VALIDATION ERROR: #{@status} user_id: #{@user_id} verified_teachers: #{@verified_teachers} token_id: #{@token_id}"
     TokenStatus::VALID_HTTP
   end
 

--- a/javabuilder-authorizer/token_validator.rb
+++ b/javabuilder-authorizer/token_validator.rb
@@ -1,0 +1,197 @@
+require_relative 'token_status'
+
+class TokenValidator
+  ONE_HOUR_SECONDS = 60 * 60
+  ONE_DAY_SECONDS = 24 * 60 * 60
+  TOKEN_RECORD_TTL_SECONDS = 120 # 2 minutes
+  USER_REQUEST_RECORD_TTL_SECONDS = 24 * 60 * 60 # One day
+  TEACHER_ASSOCIATED_REQUEST_TTL_SECONDS = 2 * 60 * 60 # 2 hours
+
+  def initialize(payload, origin, region)
+    @token_id = payload['sid']
+    @user_id = payload['uid']
+    @verified_teachers = payload['verified_teachers']
+
+    @origin = origin
+    @client = Aws::DynamoDB::Client.new(region: region)
+  end
+
+  def log_token
+    begin
+      ttl = Time.now.to_i + TOKEN_RECORD_TTL_SECONDS
+      @client.put_item(
+        table_name: ENV['token_status_table'],
+        item: {
+          token_id: @token_id,
+          ttl: ttl
+        },
+        condition_expression: 'attribute_not_exists(token_id)'
+      )
+    rescue Aws::DynamoDB::Errors::ConditionalCheckFailedException
+      puts "TOKEN VALIDATION ERROR: #{TokenStatus::ALREADY_EXISTS} token_id: #{@token_id}"
+      # return false
+      return true
+    end
+
+    true
+  end
+
+  def user_blocked?
+    response = @client.get_item(
+      table_name: ENV['blocked_users_table'],
+      key: {user_id: blocked_users_user_id}
+    )
+
+    !!response.item
+  end
+
+  # update vs craete
+  def teachers_blocked?
+    block = true
+    @verified_teachers.split(',').each do |teacher_id|
+      response = @client.get_item(
+        table_name: ENV['blocked_users_table'],
+        key: {user_id: blocked_users_section_owner_id(teacher_id)}
+      )
+      block = false unless response.item
+    end
+
+    block
+  end
+
+  def user_over_hourly_limit?
+    # also check daily limit?
+    response = @client.query(
+      table_name: ENV['user_requests_table'],
+      key_condition_expression: "user_id = :user_id AND issued_at > :one_hour_ago",
+      expression_attribute_values: {
+        ":user_id" => "#{@origin}##{@user_id}",
+        ":one_hour_ago" => Time.now.to_i - ONE_HOUR_SECONDS
+      }
+    )
+
+    # I think you'd never need to paginate, because you'd be throttled
+    # I guess this might not be true in the 24 hour case where we're not throttling
+    # iterate if response.last_evaluated_key?
+    deny = response.count > ENV['limit_per_hour'].to_i
+    if deny
+      # logging is kind of gross, looks like
+      # [{"ttl"=>0.1648766446e10, "user_id"=>"611", "issued_at"=>0.1648680046e10}, {...
+      @client.put_item(
+        table_name: ENV['blocked_users_table'],
+        item: {
+          user_id: blocked_users_user_id,
+          request_log: response.items.to_s,
+          reason: TokenStatus::USER_OVER_HOURLY_LIMIT
+        }
+      )
+      # deny / return?
+    end
+
+    deny
+  end
+
+  def user_over_daily_limit?
+    response = @client.query(
+      table_name: ENV['user_requests_table'],
+      key_condition_expression: "user_id = :user_id AND issued_at > :one_day_ago",
+      expression_attribute_values: {
+        ":user_id" => "#{@origin}##{@user_id}",
+        ":one_day_ago" => Time.now.to_i - ONE_DAY_SECONDS
+      }
+    )
+
+    # I think you'd never need to paginate, because you'd be throttled
+    # I guess this might not be true in the 24 hour case where we're not throttling
+    # iterate if response.last_evaluated_key?
+    deny = response.count > ENV['limit_per_day'].to_i
+    if deny
+      # logging is kind of gross, looks like
+      # [{"ttl"=>0.1648766446e10, "user_id"=>"611", "issued_at"=>0.1648680046e10}, {...
+      @client.put_item(
+        table_name: ENV['blocked_users_table'],
+        item: {
+          user_id: blocked_users_user_id,
+          request_log: response.items.to_s,
+          reason: TokenStatus::USER_OVER_DAILY_LIMIT
+        }
+      )
+    end
+
+    deny
+  end
+
+  # update instead of creat??
+  def teachers_over_hourly_limit?
+    deny = true
+    @verified_teachers.split(',').each do |teacher_id|
+      response = @client.query(
+        table_name: ENV['teacher_associated_requests_table'],
+        key_condition_expression: "section_owner_id = :teacher_id AND issued_at > :one_hour_ago",
+        expression_attribute_values: {
+          ":teacher_id" => "#{@origin}##{teacher_id}",
+          ":one_hour_ago" => Time.now.to_i - ONE_HOUR_SECONDS
+        }
+      )
+      # iterate if response.last_evaluated_key
+
+      # check that response.count is less than limit
+      # if its under limit for at least one class, we allow
+      if response.count > 1
+        @client.put_item(
+          table_name: ENV['blocked_users_table'],
+          item: {
+            user_id: blocked_users_section_owner_id(teacher_id),
+            request_log: response.items.to_s,
+            reason: TokenStatus::TEACHERS_OVER_HOURLY_LIMIT
+          }
+        )
+      else
+        deny = false
+      end
+    end
+
+    deny
+  end
+
+  def log_requests
+    @client.put_item(
+      table_name: ENV['user_requests_table'],
+      item: {
+        user_id: "#{@origin}##{@user_id}",
+        issued_at: Time.now.to_i,
+        ttl: Time.now.to_i + USER_REQUEST_RECORD_TTL_SECONDS
+      }
+    )
+
+    @verified_teachers.split(',').each do |teacher_id|
+      client.put_item(
+        table_name: ENV['teacher_associated_requests_table'],
+        item: {
+          section_owner_id: "#{origin}##{teacher_id}",
+          issued_at: Time.now.to_i,
+          ttl: Time.now.to_i + TEACHER_ASSOCIATED_REQUEST_TTL_SECONDS
+        }
+      )
+    end
+  end
+
+  def mark_token_as_vetted
+    @client.update_item(
+      table_name: ENV['token_status_table'],
+      key: {token_id: @token_id},
+      update_expression: 'SET vetted = :v',
+      expression_attribute_values: {':v': true}
+    )
+  end
+
+  private
+
+  def blocked_users_section_owner_id(teacher_id)
+    "#{@origin}#sectionOwnerId##{teacher_id}"
+  end
+
+  def blocked_users_user_id
+    "#{@origin}#userId##{@user_id}"
+  end
+end

--- a/javabuilder-authorizer/token_validator.rb
+++ b/javabuilder-authorizer/token_validator.rb
@@ -5,11 +5,12 @@ class TokenValidator
 
   ONE_HOUR_SECONDS = 60 * 60
   ONE_DAY_SECONDS = 24 * 60 * 60
-  TOKEN_RECORD_TTL_SECONDS = 120 # 2 minutes
-  USER_REQUEST_RECORD_TTL_SECONDS = ONE_DAY_SECONDS
-  # TO DO: update this value to two hours once we've evaluated a classroom-level
-  # throttling threshold.
-  TEACHER_ASSOCIATED_REQUEST_TTL_SECONDS = 14 * ONE_DAY_SECONDS
+  TOKEN_RECORD_TTL_SECONDS = 120 # Two minutes
+  USER_REQUEST_RECORD_TTL_SECONDS = 25 * ONE_HOUR_SECONDS
+  TEACHER_ASSOCIATED_REQUEST_TTL_SECONDS = 25 * ONE_HOUR_SECONDS
+  # TO DO: move this into env variable
+  # https://codedotorg.atlassian.net/browse/JAVA-536
+  TEACHER_HOURLY_LIMIT = 1000
 
   def initialize(payload, origin, region)
     @token_id = payload['sid']
@@ -113,9 +114,7 @@ class TokenValidator
         puts "teacher_associated_requests query has paginated responses. user_id #{@user_id} teacher_id #{teacher_id}"
       end
 
-      # TO DO: set actual limit value
-      # Setting arbitrary super high value temporarily.
-      if response.count > 1_000_000
+      if response.count > TEACHER_HOURLY_LIMIT
         begin
           @client.put_item(
             table_name: ENV['blocked_users_table'],

--- a/javabuilder-authorizer/websocket_authorizer_function.rb
+++ b/javabuilder-authorizer/websocket_authorizer_function.rb
@@ -20,7 +20,8 @@ def lambda_handler(event:, context:)
     return JwtHelper.generate_policy('connectivityTest', "Allow", method_arn, {connectivityTest: true})
   end
 
-  decoded_token = JwtHelper.decode_token(jwt_token, origin)
+  standardized_origin = JwtHelper.get_standardized_origin(origin)
+  decoded_token = JwtHelper.decode_token(jwt_token, standardized_origin)
   return JwtHelper.generate_deny(method_arn) unless decoded_token
 
   token_payload = decoded_token[0]


### PR DESCRIPTION
More updates to our throttling work. Does not actually prevent any access to Javabuilder currently, but adds checks for:
- whether user is blocked
- whether user's classrooms are blocked
- user hourly limit
- user daily limit
- classroom hourly limit

If these all pass (they all do for now), we:
- log the user request
- log the a request for each teacher the user is associated with

~~We do not have a classroom-level limit yet for throttling -- the plan here is to set the expiration time (ttl) for `teacher_associated_requests` to two weeks, such that we can query that raw data and see what a reasonable hourly limit might be. Once we have a throttling limit we feel good about, we can set that value and the ttl to two hours for this table.~~
Update: ended up using Cloudwatch logs to get a sense of what our hourly historical data looks like per teacher, and set a limit (can be updated) accordingly.

## Testing story

Heavy manual testing -- went through each condition and looked at the CloudWatch logs generated and DynamoDB records created, as well as confirming normal behavior in local javabuilder. See follow-up for more on testing.
## Follow-ups

- We need unit tests for this code 😬 -- I will look into what it would take to get basic unit tests set up for our authorizer code. Longer term, it might be nice to have some integration tests with dynamodb, but that is a bigger piece of work.
- [Refactor websocket authorizer code](https://github.com/code-dot-org/javabuilder/blob/main/javabuilder-authorizer/websocket_authorizer_function.rb) to use the new `TokenValidator` helper as well.
- We'll be querying DynamoDB figure out what a reasonable classroom limit is, and see whether any students are crossing the hourly and daily thresholds we've set currently. Then, we can actually turn on throttling!