### PR TITLE
Switch from DynamoDB Provisioned Throughput to On-Demand

### DIFF
--- a/template.yml.erb
+++ b/template.yml.erb
@@ -707,8 +707,6 @@ Resources:
   TOKEN_ID_ATTRIBUTE_NAME = 'token_id'
   ISSUED_AT_TIMESTAMP_ATTRIBUTE_NAME = 'issued_at'
   TIME_TO_LIVE_ATTRIBUTE_NAME = 'ttl'
-  READ_CAPACITY_PER_SECOND = 1000
-  WRITE_CAPACITY_PER_SECOND = 1000
 -%>
   BlockedUsersTable:
     Type: AWS::DynamoDB::Table
@@ -717,9 +715,7 @@ Resources:
       KeySchema:
         - AttributeName: <%=DOMAIN_AND_USER_ID_COMPOSITE_ATTRIBUTE_NAME%>
           KeyType: HASH
-      ProvisionedThroughput:
-        ReadCapacityUnits: <%=READ_CAPACITY_PER_SECOND%>
-        WriteCapacityUnits: <%=WRITE_CAPACITY_PER_SECOND%>
+      BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: <%=DOMAIN_AND_USER_ID_COMPOSITE_ATTRIBUTE_NAME%>
           AttributeType: S
@@ -733,9 +729,7 @@ Resources:
       KeySchema:
         - AttributeName: <%=TOKEN_ID_ATTRIBUTE_NAME%>
           KeyType: HASH
-      ProvisionedThroughput:
-        ReadCapacityUnits: <%=READ_CAPACITY_PER_SECOND%>
-        WriteCapacityUnits: <%=WRITE_CAPACITY_PER_SECOND%>
+      BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: <%=TOKEN_ID_ATTRIBUTE_NAME%>
           AttributeType: S
@@ -752,9 +746,7 @@ Resources:
           KeyType: HASH
         - AttributeName: <%=ISSUED_AT_TIMESTAMP_ATTRIBUTE_NAME%>
           KeyType: RANGE
-      ProvisionedThroughput:
-        ReadCapacityUnits: <%=READ_CAPACITY_PER_SECOND%>
-        WriteCapacityUnits: <%=WRITE_CAPACITY_PER_SECOND%>
+      BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: <%=DOMAIN_AND_USER_ID_COMPOSITE_ATTRIBUTE_NAME%>
           AttributeType: S
@@ -773,9 +765,7 @@ Resources:
           KeyType: HASH
         - AttributeName: <%=ISSUED_AT_TIMESTAMP_ATTRIBUTE_NAME%>
           KeyType: RANGE
-      ProvisionedThroughput:
-        ReadCapacityUnits: <%=READ_CAPACITY_PER_SECOND%>
-        WriteCapacityUnits: <%=WRITE_CAPACITY_PER_SECOND%>
+      BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: <%=DOMAIN_AND_SECTION_OWNER_ID_COMPOSITE_ATTRIBUTE_NAME%>
           AttributeType: S


### PR DESCRIPTION
Each instance of Javabuilder, including development Stacks, is consuming about $2200/month in DynamoDB costs because we specify Provisioned read/write Throughput of 1000 units per table and there are 4 tables. Switch to [On-Demand mode](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand).

Once we get a better sense of usage patterns, we could switch back to Provisioned Mode, and use DynamoDB Autoscaling so we don't pay for unused provisioned capacity during low usage time periods, and purchased Reserved Capacity for our production instance for lower costs in a system that has high sustained usage.