### PR TITLE
Copy image/sound before draw/play

### DIFF
--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Scene.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Scene.java
@@ -175,7 +175,11 @@ public class Scene {
    * @param rotation the amount to rotate the image in degrees
    */
   public final void drawImage(Image image, int x, int y, int size, double rotation) {
-    this.actions.add(new DrawImageAction(image, x, y, size, UNSPECIFIED, UNSPECIFIED, rotation));
+    // Copy the image to subsequent changes to this image object are not reflected
+    // in the image drawn here.
+    Image imageCopy = new Image(image);
+    this.actions.add(
+        new DrawImageAction(imageCopy, x, y, size, UNSPECIFIED, UNSPECIFIED, rotation));
   }
 
   /**
@@ -190,7 +194,10 @@ public class Scene {
    * @param rotation the amount to rotate the image in degrees
    */
   public final void drawImage(Image image, int x, int y, int width, int height, double rotation) {
-    this.actions.add(new DrawImageAction(image, x, y, UNSPECIFIED, width, height, rotation));
+    // Copy the image to subsequent changes to this image object are not reflected
+    // in the image drawn here.
+    Image imageCopy = new Image(image);
+    this.actions.add(new DrawImageAction(imageCopy, x, y, UNSPECIFIED, width, height, rotation));
   }
 
   /**

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Scene.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Scene.java
@@ -75,8 +75,9 @@ public class Scene {
    * @param sound an array of samples to play.
    */
   public final void playSound(double[] sound) {
-    double[] soundCopy = sound.clone();
-    this.actions.add(new PlaySoundAction(soundCopy));
+    // Copy the array here so subsequent changes to it are not reflected
+    // in the sound played here.
+    this.actions.add(new PlaySoundAction(sound.clone()));
   }
 
   /**
@@ -176,7 +177,7 @@ public class Scene {
    * @param rotation the amount to rotate the image in degrees
    */
   public final void drawImage(Image image, int x, int y, int size, double rotation) {
-    // Copy the image to subsequent changes to this image object are not reflected
+    // Copy the image so subsequent changes to this image object are not reflected
     // in the image drawn here.
     Image imageCopy = new Image(image);
     this.actions.add(
@@ -195,7 +196,7 @@ public class Scene {
    * @param rotation the amount to rotate the image in degrees
    */
   public final void drawImage(Image image, int x, int y, int width, int height, double rotation) {
-    // Copy the image to subsequent changes to this image object are not reflected
+    // Copy the image so subsequent changes to this image object are not reflected
     // in the image drawn here.
     Image imageCopy = new Image(image);
     this.actions.add(new DrawImageAction(imageCopy, x, y, UNSPECIFIED, width, height, rotation));

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Scene.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Scene.java
@@ -75,7 +75,8 @@ public class Scene {
    * @param sound an array of samples to play.
    */
   public final void playSound(double[] sound) {
-    this.actions.add(new PlaySoundAction(sound));
+    double[] soundCopy = sound.clone();
+    this.actions.add(new PlaySoundAction(soundCopy));
   }
 
   /**

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/SceneTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/SceneTest.java
@@ -3,7 +3,6 @@ package org.code.theater;
 import static org.code.theater.Scene.*;
 import static org.code.theater.support.DrawImageAction.UNSPECIFIED;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
 
 import org.code.media.Color;
 import org.code.media.Font;
@@ -65,7 +64,7 @@ class SceneTest {
 
   @Test
   public void testDrawImage() {
-    final Image image = mock(Image.class);
+    final Image image = new Image(1, 1);
     final int x = 100;
     final int y = 100;
     final int size = 200;
@@ -74,7 +73,10 @@ class SceneTest {
     final double rotation = 90.0;
 
     unitUnderTest.drawImage(image, x, y, size);
-    assertSame(image, getLastAction(DrawImageAction.class).getImage());
+    // Confirm we copy the image object when drawing it
+    assertNotSame(image, getLastAction(DrawImageAction.class).getImage());
+    assertEquals(1, getLastAction(DrawImageAction.class).getImage().getHeight());
+
     assertEquals(x, getLastAction(DrawImageAction.class).getX());
     assertEquals(y, getLastAction(DrawImageAction.class).getY());
     assertEquals(size, getLastAction(DrawImageAction.class).getSize());

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/SceneTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/SceneTest.java
@@ -31,7 +31,8 @@ class SceneTest {
   public void testPlaySound() {
     final double[] samples = {1.0, 0.0, 1.0, 0.0};
     unitUnderTest.playSound(samples);
-    assertEquals(samples, getLastAction(PlaySoundAction.class).getSamples());
+    assertNotSame(samples, getLastAction(PlaySoundAction.class).getSamples());
+    assertEquals(1.0, getLastAction(PlaySoundAction.class).getSamples()[0]);
   }
 
   @Test


### PR DESCRIPTION
New Theater API has a bug where if an image is drawn, then modified, the drawn image will reflect the modifications made after the draw.

This PR updates to make a copy of the image to put in the list of actions each time drawImage is called.

Ended up being a pretty short change, ~~hoping I'm not missing something else obvious that needs to be done.~~ Missed that we needed to make a similar update when using playSound, which I added to this PR.

## Testing story

I updated a unit test covering this case and tested manually that an image updated via setPixel after being drawn no longer reflects those changes on the initial draw.