### PR TITLE
Updates to load tests

### DIFF
--- a/cicd/3-app/load-test.template.yml
+++ b/cicd/3-app/load-test.template.yml
@@ -37,6 +37,10 @@ Resources:
               awslogs-group:  !Ref CloudwatchLogsGroup
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix:  !Sub "${AWS::StackName}-task"
+          Ulimits:
+            - HardLimit: 4096
+              Name: nofile
+              SoftLimit: 4096
       Cpu: 2048
       ExecutionRoleArn: !Ref ExecutionRole
       Memory: 4096

--- a/load-test/scripts/configuration.js
+++ b/load-test/scripts/configuration.js
@@ -33,7 +33,7 @@ export const MiniAppType = {
 };
 
 export function getTestOptions(maxUserGoal, highLoadTimeMinutes) {
-  const maxConcurrentUsers =  Math.floor(maxUserGoal / 30);
+  const maxConcurrentUsers =  Math.ceil(maxUserGoal / 30);
   return  {
     scenarios: {
       halfConcurrency: {


### PR DESCRIPTION
A couple minor updates to load tests:
- increase the nofile ulimit on the ECS task container. This allows us to make all the network requests we need for load testing.
- Use ceiling instead of floor to determine virtual users so that we do not end up with 0 users
- Catch websocket connection errors so we properly report the connection percentage at the end of the run.
- Add a flag that determines whether we sleep between requests or not. If this flag is set to false we will send many more requests but be guaranteed a concurrency very close to the number of virtual users for the entire run of the load test.