### PR TITLE
Add option to silence alerts

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -25,6 +25,9 @@ STACK=${SUB_DOMAIN}
 PROVISIONED_CONCURRENT_EXECUTIONS=${PROVISIONED_CONCURRENT_EXECUTIONS-'1'}
 RESERVED_CONCURRENT_EXECUTIONS=${RESERVED_CONCURRENT_EXECUTIONS-'3'}
 
+# If alerts should be silenced on this instance. Dev instances will always be silenced.
+SILENCE_ALERTS=${SILENCE_ALERTS-'false'}
+
 # Default per-user limits to prevent javabuilder abuse.
 LIMIT_PER_HOUR=${LIMIT_PER_HOUR-'10'}
 LIMIT_PER_DAY=${LIMIT_PER_DAY-'40'}
@@ -53,6 +56,6 @@ aws cloudformation deploy \
   --template-file ${OUTPUT_TEMPLATE} \
   --parameter-overrides SubDomainName=$SUB_DOMAIN BaseDomainName=$BASE_DOMAIN BaseDomainNameHostedZonedID=$BASE_DOMAIN_HOSTED_ZONE_ID \
     ProvisionedConcurrentExecutions=$PROVISIONED_CONCURRENT_EXECUTIONS ReservedConcurrentExecutions=$RESERVED_CONCURRENT_EXECUTIONS \
-    LimitPerHour=$LIMIT_PER_HOUR LimitPerDay=$LIMIT_PER_DAY \
+    LimitPerHour=$LIMIT_PER_HOUR LimitPerDay=$LIMIT_PER_DAY SilenceAlerts=$SILENCE_ALERTS \
   --stack-name ${STACK} \
   "$@"

--- a/template.yml.erb
+++ b/template.yml.erb
@@ -38,6 +38,11 @@ Parameters:
     Type: String
     Description: The default stage name in the API Gateway APIs
     Default: Prod
+  SilenceAlerts:
+    Type: String
+    AllowedValues: [true, false]
+    Description: If alerts should be silenced on this instance
+    Default: false
 <%
 JAVALAB_APP_TYPES = %w(
   Theater
@@ -54,6 +59,7 @@ Globals:
     Tracing: Active
 Conditions:
   IsDevCondition: !Equals [!Ref BaseDomainName, "dev-code.org"]
+  SilenceAlertsCondition: !Or [Condition: IsDevCondition, !Equals [!Ref SilenceAlerts, "true"]]
 Resources:
 # Note: We can't update the name of a DomainName resource once it has been created because the
 # domain name itself has already been provisioned. When we change from javabuilderbeta to
@@ -586,7 +592,7 @@ Resources:
           Then post in #ap-csa-dev.
       ActionsEnabled: true
       AlarmActions:
-          - !If [IsDevCondition, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-dev-test", !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-Urgent"]
+          - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-Urgent"]
       EvaluationPeriods: 10
       DatapointsToAlarm: 10
       Threshold: 50
@@ -621,7 +627,7 @@ Resources:
           is an indication of an outage.
       ActionsEnabled: true
       AlarmActions:
-          - !If [IsDevCondition, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-dev-test", !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:Javabuilder-high-error-rate"]
+          - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:Javabuilder-high-error-rate"]
       EvaluationPeriods: 4
       DatapointsToAlarm: 4
       Threshold: 10
@@ -661,7 +667,7 @@ Resources:
           consecutive 5 minute periods.
       ActionsEnabled: true
       AlarmActions:
-          - !If [IsDevCondition, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-dev-test", !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-build-and-run-lambda-error-rate"]
+        - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-build-and-run-lambda-error-rate"]
       EvaluationPeriods: 4
       DatapointsToAlarm: 4
       Threshold: 25


### PR DESCRIPTION
Add an option to javabuilder deploys to silence alerts. This option will only apply to non-dev account instances (dev account instances will always have alerts silenced. To enable this option, add `SILENCE_ALERTS=true` to the deploy script command.
This option will allow us to silence alerts on the load test instance of Javabuilder.