### PR TITLE
Add retries to load test

### DIFF
--- a/load-test/README.md
+++ b/load-test/README.md
@@ -1,5 +1,5 @@
 # Load Testing
-This folder contains scripts and helpers for load testing.
+This folder contains scripts and helpers for load testing Javabuilder. Load tests are instrumented via [k6](https://k6.io/docs/).
 
 ## One time set up
 - [Install Docker](https://docs.docker.com/get-docker/)
@@ -16,3 +16,41 @@ This folder contains scripts and helpers for load testing.
 
 ### Run on AWS
 - See instructions in [this document](https://docs.google.com/document/d/1GIiiMYCLbPE9QAqTRzHyslBzjFNvV1V1q8tdGwpKiNY).
+
+
+## Customizing a Load Test
+### Load Configuration Options
+In [loadTest.js](scripts/loadTest.js#L19) you can modify 2 basic parameters for the load. 
+
+The first is the user goal. This is the number of expected total Javabuilder users 
+you would like to simulate. An important thing to note here is this is not the number 
+of Virtual Users we will simulate during the test. The number of Virtual Users is the 
+user goal divided by 30, as that is the highest load we saw historically based on number of users.
+
+The second is the high load time. This is the time in minutes the test will run at its highest load.
+This time does not include a 2 minute manual ramp-up stage.
+
+There is also a slightly more complex toggle, [`SHOULD_SLEEP`](scripts/loadTest.js#L28). If this is set to
+true, requests will be spaced out at a specific interval, to simulate more realistic traffic. If it is set
+to false, requests will never sleep, which will ensure we have concurrent requests equal to the number of
+Virtual Users. If you want to simulate the highest possible load, use `false` here. If you do use `false`,
+you should not run the load test for very long, as you will get a lot of data (and send a lot of requests)
+from 5 minutes of high load.
+
+### Configure Student Code
+If you would like to add new source code that the load test will upload to Javabuilder, 
+add the JSON string to [sources.js](scripts/sources.js). An easy way to generate this data is
+to run Java Lab normally with your desired source code, then copy over the JSON from the content bucket.
+Then update [loadTest.js](scripts/loadTest.js#L25) to use your new sources object.
+
+### Add a Metric
+We have many [k6 metrics](https://k6.io/docs/using-k6/metrics/) we calculate during a load test. If you would
+like to create a new one, initialize it with the other [metrics](loadTest.js#L30), and track it wherever makes sense.
+The metric will automatically show up in the test summary so long as the value is not zero.
+
+### Change the script file
+If you want to create a fully new load test script, you can substitute the new script name in the [Dockerfile](Dockerfile#L2).
+
+### Further Details
+If you need to do further customization, the [k6 documention](https://k6.io/docs/) and 
+[API Guide](https://k6.io/docs/javascript-api/) detail the capabilities available to you.

--- a/load-test/scripts/configuration.js
+++ b/load-test/scripts/configuration.js
@@ -23,7 +23,7 @@ export const PRIVATE_KEY = null;
 // reached this time. This is so we do not issue too many requests.
 export const REQUEST_TIME_MS = 20000;
 // Time after which to timeout a request
-export const TIMEOUT_MS = 40000;
+export const TIMEOUT_MS = 60000;
 
 // Mini-app types
 export const MiniAppType = {
@@ -60,8 +60,7 @@ export function getTestOptions(maxUserGoal, highLoadTimeMinutes) {
       exceptions: ["count == 0"],
       errors: ["count == 0"],
       timeouts: ["count == 0"],
-      total_session_time: ["p(95) < 5000"],
-      dropped_iterations: ["count == 0"]
+      total_session_time: ["p(95) < 5000"]
     },
     summaryTrendStats: ["avg", "min", "med", "max", "p(90)", "p(95)", "p(98)", "p(99)"],
   };

--- a/load-test/scripts/loadTest.js
+++ b/load-test/scripts/loadTest.js
@@ -18,14 +18,14 @@ import {
 // Change these options to increase the user goal or time to run the test.
 export const options = getTestOptions(
   /* User goal */ 1000,
-  /* High load time minutes */ 15
+  /* High load time minutes */ 4
 );
 
 // Change this to test different code
 const sourceToTest = helloWorld;
 // Set this to true to space out requests every REQUEST_TIME_MS milliseconds. Set to
 // false to send as many requests as possible.
-const SHOULD_SLEEP = true;
+const SHOULD_SLEEP = false;
 
 const exceptionCounter = new Counter("exceptions");
 const errorCounter = new Counter("errors");
@@ -34,6 +34,9 @@ const totalSessionTime = new Trend("total_session_time", true);
 const sessionsOver10Seconds = new Counter("session_over_10_seconds");
 const sessionsOver15Seconds = new Counter("session_over_15_seconds");
 const sessionsOver20Seconds = new Counter("session_over_20_seconds");
+const zeroRetries = new Counter("sessions_with_0_retries");
+const oneRetry = new Counter("sessions_with_1_retry");
+const twoRetries = new Counter("sessions_with_2_retries");
 
 
 function isResultSuccess(result) {
@@ -53,18 +56,51 @@ export default function () {
   check(uploadResult, { "upload status is 200": (r) => isResultSuccess(r)});
 
   if (isResultSuccess(uploadResult)) {
-    let res = null;
-    try {
-      res = ws.connect(WEBSOCKET_URL + authToken, WEBSOCKET_PARAMS, (socket) =>
-        onSocketConnect(socket, requestStartTime, Date.now(), sessionId)
-      );
-    } catch(error) {
-      console.log(`ERROR ${error} for session id ${sessionId}`);
-    }
+    let res = connectToWebsocketWithRetry(authToken, sessionId, requestStartTime);
     check(res, { "websocket status is 101": (r) => r && r.status === 101 });
   } else {
     console.log(`ERROR upload failed for session id ${sessionId}`);
   }
+}
+
+function connectToWebsocketWithRetry(authToken, sessionId, requestStartTime) {
+  let res = null;
+  let tries = 0;
+  let shouldRetry = true;
+  while(tries < 3 && shouldRetry) {
+    if (tries > 0) {
+      // before the first retry sleep for 1 second, before the second retry sleep for 2 seconds.
+      console.log(`RETRY ${tries} for session id ${sessionId}`);
+      sleep(1 * tries);
+    }
+    res = connectToWebsocket(authToken, sessionId, requestStartTime);
+    if (res != null) {
+      shouldRetry = false;
+    } 
+    tries++;
+  }
+  if (tries === 1) {
+    zeroRetries.add(1);
+  } else if (tries === 2) {
+    oneRetry.add(1);
+  } else if (tries === 3) {
+    twoRetries.add(1);
+  } else {
+    console.log(`Unexpected number of retries: ${tries}`);
+  }
+  return res;
+}
+
+function connectToWebsocket(authToken, sessionId, requestStartTime) {
+  let res = null;
+  try {
+    res = ws.connect(WEBSOCKET_URL + authToken, WEBSOCKET_PARAMS, (socket) =>
+      onSocketConnect(socket, requestStartTime, Date.now(), sessionId)
+    );
+  } catch(error) {
+    console.log(`ERROR ${error} for session id ${sessionId}`);
+  }
+  return res;
 }
 
 function onSocketConnect(socket, requestStartTime, websocketStartTime, sessionId) {

--- a/load-test/scripts/loadTest.js
+++ b/load-test/scripts/loadTest.js
@@ -22,7 +22,7 @@ export const options = getTestOptions(
 );
 
 // Change this to test different code
-const sourceToTest = helloWorld;
+const SOURCE_TO_TEST = helloWorld;
 // Set this to true to space out requests every REQUEST_TIME_MS milliseconds. Set to
 // false to send as many requests as possible.
 const SHOULD_SLEEP = false;
@@ -34,9 +34,10 @@ const totalSessionTime = new Trend("total_session_time", true);
 const sessionsOver10Seconds = new Counter("session_over_10_seconds");
 const sessionsOver15Seconds = new Counter("session_over_15_seconds");
 const sessionsOver20Seconds = new Counter("session_over_20_seconds");
-const zeroRetries = new Counter("sessions_with_0_retries");
-const oneRetry = new Counter("sessions_with_1_retry");
-const twoRetries = new Counter("sessions_with_2_retries");
+const retryCounters = [new Counter("sessions_with_0_retries"), new Counter("sessions_with_1_retry"), new Counter("sessions_with_2_retries")];
+// const zeroRetries = new Counter("sessions_with_0_retries");
+// const oneRetry = new Counter("sessions_with_1_retry");
+// const twoRetries = new Counter("sessions_with_2_retries");
 
 
 function isResultSuccess(result) {
@@ -49,7 +50,7 @@ export default function () {
   const authToken = generateToken(MiniAppType.CONSOLE, sessionId);
   const uploadResult = http.put(
     UPLOAD_URL + authToken,
-    sourceToTest,
+    SOURCE_TO_TEST,
     UPLOAD_PARAMS
   );
 
@@ -79,15 +80,7 @@ function connectToWebsocketWithRetry(authToken, sessionId, requestStartTime) {
     } 
     tries++;
   }
-  if (tries === 1) {
-    zeroRetries.add(1);
-  } else if (tries === 2) {
-    oneRetry.add(1);
-  } else if (tries === 3) {
-    twoRetries.add(1);
-  } else {
-    console.log(`Unexpected number of retries: ${tries}`);
-  }
+  retryCounters[tries - 1].add(1);
   return res;
 }
 

--- a/load-test/scripts/loadTest.js
+++ b/load-test/scripts/loadTest.js
@@ -35,9 +35,6 @@ const sessionsOver10Seconds = new Counter("session_over_10_seconds");
 const sessionsOver15Seconds = new Counter("session_over_15_seconds");
 const sessionsOver20Seconds = new Counter("session_over_20_seconds");
 const retryCounters = [new Counter("sessions_with_0_retries"), new Counter("sessions_with_1_retry"), new Counter("sessions_with_2_retries")];
-// const zeroRetries = new Counter("sessions_with_0_retries");
-// const oneRetry = new Counter("sessions_with_1_retry");
-// const twoRetries = new Counter("sessions_with_2_retries");
 
 
 function isResultSuccess(result) {


### PR DESCRIPTION
Add up to two retries to connect to the websocket in load tests. With [this change](https://github.com/code-dot-org/javabuilder/pull/272) we should see very few failures, but it is still worth including this logic so we can track requests that would have succeeded on retry. Since we now do these retries, this PR also increases the timeout for a request to 1 minute, as there were occasional successful requests that took up to 40 seconds, and the timeout is intended to stop requests that have failed.

I also set the default sleep to `false` as we get better data with that option, and decreased the default high load time since sleep is now false. In addition I updated the `README` with details about how to customize a load test.