### PR TITLE
Convert auth response to JSON

### DIFF
--- a/api-gateway-routes/auth_error_response_helper.rb
+++ b/api-gateway-routes/auth_error_response_helper.rb
@@ -10,6 +10,6 @@ module AuthErrorResponseHelper
       type: AUTHORIZER_KEY,
       value: authorizer_payload[AUTHORIZATION_ERROR_KEY]
     }
-    { statusCode: authorizer_payload[AUTHORIZATION_ERROR_CODE_KEY], body: body.to_s }
+    { statusCode: authorizer_payload[AUTHORIZATION_ERROR_CODE_KEY], body: body.to_json }
   end
 end


### PR DESCRIPTION
Quick fix to convert the auth error response body to JSON for easy parsing on the client side. Previously it was getting returned in ruby hash syntax.

Tested on dev lambda.