### PR TITLE
Add theater and scanner load test sources

### DIFF
--- a/load-test/scripts/sources.js
+++ b/load-test/scripts/sources.js
@@ -23,3 +23,11 @@ export const neighborhood = JSON.stringify({
   },
   "assetUrls":{}
 });
+
+export const scanner = JSON.stringify({
+  sources: {
+    "main.json":
+      '{"source":{"MyScanner.java":{"text":"import java.util.Scanner;\\n\\npublic class MyScanner {\\n  public static void main(String[] args) {\\n    Scanner myScanner = new Scanner(System.in);\\n    System.out.println(\\"What\'s your name?\\");\\n    String response = myScanner.nextLine();\\n    System.out.println(\\"Hello \\" + response + \\"!\\");\\n  }\\n}\\n","isVisible":true}},"animations":{}}'
+  }
+});
+

--- a/load-test/scripts/sources.js
+++ b/load-test/scripts/sources.js
@@ -31,3 +31,10 @@ export const scanner = JSON.stringify({
   }
 });
 
+export const theater = JSON.stringify({
+  sources: {
+    "main.json":
+      '{"source":{"MyTheater.java":{"text":"import org.code.theater.Theater;\\nimport org.code.theater.Scene;\\nimport org.code.media.Image;\\nimport java.io.FileNotFoundException;\\n\\npublic class MyTheater {\\n  public static void main(String[] args) throws Exception {\\n    Theater.playScenes(createScene());\\n  }\\n\\n  public static Scene createScene() throws FileNotFoundException {\\n    Scene scene = new Scene();\\n    Image image = new Image(\\"dog.jpeg\\");\\n    scene.drawImage(image, 0, 0, 400);\\n    scene.drawText(\\"Hello World\\", 100, 100);\\n    double[] sound = {1.0, 0.0, 1.0, 0.0};\\n    scene.playSound(sound);\\n\\n    return scene;\\n  }\\n}","isVisible":true}},"animations":{}}'
+  },
+  assetUrls: {"dog.jpeg": 'https://studio.code.org/v3/assets/123456/dog.jpeg'}
+});


### PR DESCRIPTION
Add sources used for scanner and theater load tests.

The scanner load test had some custom metrics that were a bit more involved to set up -- [that additional logic is here ](https://github.com/code-dot-org/javabuilder/pull/275) if anyone wants to see it, but I think I'll probably just close that PR without merging it.
