### PR TITLE
Hide deprecation warnings

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserCodeCompiler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserCodeCompiler.java
@@ -21,6 +21,12 @@ public class UserCodeCompiler {
   private final File tempFolder;
   private final OutputAdapter outputAdapter;
 
+  private static final String SYSTEM_PACKAGE_OVERRIDE_NAME = "org.code.lang.System";
+  private static final String DIAGNOSTIC_CODE_SINGLE_IMPORT_ERROR =
+      "compiler.err.already.defined.single.import";
+  private static final String DIAGNOSTIC_CODE_DEPRECATED_WARNING_PREFIX =
+      "compiler.note.deprecated";
+
   public UserCodeCompiler(
       List<JavaProjectFile> javaFiles, File tempFolder, OutputAdapter outputAdapter) {
     this.javaFiles = javaFiles;
@@ -44,6 +50,10 @@ public class UserCodeCompiler {
 
     // diagnostics will include any compiler errors
     for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
+      if (diagnostic.getCode().startsWith(DIAGNOSTIC_CODE_DEPRECATED_WARNING_PREFIX)) {
+        continue;
+      }
+
       String customMessage = this.getCustomCompilerError(diagnostic);
       if (customMessage != null) {
         // If we got a custom message, just send it and stop sending any more diagnostics to avoid
@@ -108,8 +118,8 @@ public class UserCodeCompiler {
   private String getCustomCompilerError(Diagnostic<? extends JavaFileObject> diagnostic) {
     // Check if the compiler error is due to the student importing java.lang.System
     // directly and give a more helpful message.
-    if (diagnostic.getCode().equals("compiler.err.already.defined.single.import")
-        && diagnostic.getMessage(Locale.US).contains("org.code.lang.System")) {
+    if (diagnostic.getCode().equals(DIAGNOSTIC_CODE_SINGLE_IMPORT_ERROR)
+        && diagnostic.getMessage(Locale.US).contains(SYSTEM_PACKAGE_OVERRIDE_NAME)) {
       return "Import of java.lang.System is not supported.";
     }
     return null;

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserCodeCompiler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserCodeCompiler.java
@@ -50,6 +50,8 @@ public class UserCodeCompiler {
 
     // diagnostics will include any compiler errors
     for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
+      // Students are sometimes taught deprecated methods (eg, integer constructor)
+      // for the AP exam. Do not show deprecation warnings to avoid confusion.
       if (diagnostic.getCode().startsWith(DIAGNOSTIC_CODE_DEPRECATED_WARNING_PREFIX)) {
         continue;
       }


### PR DESCRIPTION
Hides deprecation warnings from students. Relevant for situations where they are taught methods that are deprecated (eg, integer constructor).

[JAVA-473](https://codedotorg.atlassian.net/browse/JAVA-473)

**Before (top set of messages) and after (bottom set) this change**

<img width="1276" alt="image" src="https://user-images.githubusercontent.com/25372625/164814609-6d4f7848-acd4-4e3b-85dc-2319154534b6.png">

I looked into [using suppressing deprecation warnings via tag instead](https://docs.oracle.com/en/java/javase/11/core/enhanced-deprecation1.html#GUID-F0CD4B54-CD8A-4153-87F9-7E7481F9AAFC) (which works if you add it directly to the top of the class with the main method in the student code being compiled), but doesn't work in our reflective world.