### PR TITLE
Remove FileNotFoundExceptions from Image and SoundLoader

### DIFF
--- a/org-code-javabuilder/media/src/main/java/org/code/media/Image.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/Image.java
@@ -24,10 +24,13 @@ public class Image {
    * manager.
    *
    * @param filename the name of the image loaded into the asset manager for the project
-   * @throws FileNotFoundException if the file doesn't exist in the asset manager.
    */
-  public Image(String filename) throws FileNotFoundException {
-    this.bufferedImage = Image.getImageAssetFromFile(filename);
+  public Image(String filename) {
+    try {
+      this.bufferedImage = Image.getImageAssetFromFile(filename);
+    } catch (FileNotFoundException e) {
+      throw new MediaRuntimeException(MediaRuntimeExceptionKeys.FILE_NOT_FOUND, e);
+    }
     this.width = bufferedImage.getWidth();
     this.height = bufferedImage.getHeight();
     // don't create pixel array until we need it

--- a/org-code-javabuilder/media/src/main/java/org/code/media/SoundLoader.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/SoundLoader.java
@@ -1,6 +1,7 @@
 package org.code.media;
 
 import java.io.FileNotFoundException;
+import org.code.media.support.SoundExceptionKeys;
 import org.code.media.util.AudioUtils;
 
 public class SoundLoader {
@@ -10,10 +11,13 @@ public class SoundLoader {
    * @param filename the name of the audio file
    * @return the array of samples, at 44.1 kilohertz. This means that 441000 samples are played per
    *     second.
-   * @throws SoundException if there is an error reading the file, or FileNotFoundException when the
-   *     file cannot be found
+   * @throws SoundException if there is an error reading the file
    */
-  public static double[] read(String filename) throws SoundException, FileNotFoundException {
-    return AudioUtils.readSamplesFromAssetFile(filename);
+  public static double[] read(String filename) throws SoundException {
+    try {
+      return AudioUtils.readSamplesFromAssetFile(filename);
+    } catch (FileNotFoundException e) {
+      throw new SoundException(SoundExceptionKeys.FILE_NOT_FOUND, e);
+    }
   }
 }

--- a/org-code-javabuilder/media/src/main/java/org/code/media/support/MediaRuntimeExceptionKeys.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/support/MediaRuntimeExceptionKeys.java
@@ -1,5 +1,6 @@
 package org.code.media.support;
 
 public enum MediaRuntimeExceptionKeys {
-  IMAGE_LOAD_ERROR
+  IMAGE_LOAD_ERROR,
+  FILE_NOT_FOUND
 }

--- a/org-code-javabuilder/media/src/main/java/org/code/media/support/SoundExceptionKeys.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/support/SoundExceptionKeys.java
@@ -2,5 +2,6 @@ package org.code.media.support;
 
 public enum SoundExceptionKeys {
   INVALID_AUDIO_FILE_FORMAT,
-  MISSING_AUDIO_DATA
+  MISSING_AUDIO_DATA,
+  FILE_NOT_FOUND
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
@@ -4,10 +4,10 @@ import static org.code.protocol.AllowedFileNames.PROMPTER_FILE_NAME_PREFIX;
 import static org.code.protocol.InputMessages.UPLOAD_ERROR;
 import static org.code.protocol.InputMessages.UPLOAD_SUCCESS;
 
-import java.io.FileNotFoundException;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.code.media.Image;
+import org.code.media.support.MediaRuntimeException;
 import org.code.protocol.*;
 import org.code.theater.support.TheaterMessage;
 import org.code.theater.support.TheaterSignalKey;
@@ -17,7 +17,7 @@ public class Prompter {
 
   // Convenience class just for unit testing
   static class ImageCreator {
-    public Image createImage(String filename) throws FileNotFoundException {
+    public Image createImage(String filename) {
       return new Image(filename);
     }
   }
@@ -68,8 +68,8 @@ public class Prompter {
     if (statusMessage.equals(UPLOAD_SUCCESS)) {
       try {
         return this.imageCreator.createImage(prompterFileName);
-      } catch (FileNotFoundException e) {
-        // If the image was uploaded successfully, a FileNotFoundException means an error on our end
+      } catch (MediaRuntimeException e) {
+        // If the image was uploaded successfully, a MediaRuntimeException means an error on our end
         throw new InternalServerRuntimeException(
             InternalExceptionKey.INTERNAL_RUNTIME_EXCEPTION, e);
       }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Scene.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Scene.java
@@ -213,11 +213,7 @@ public class Scene {
    *     does not appear distorted.
    */
   public final void drawImage(String filename, int x, int y, int size) {
-    try {
-      this.drawImage(new Image(filename), x, y, size);
-    } catch (FileNotFoundException e) {
-      throw new TheaterRuntimeException(ExceptionKeys.FILE_NOT_FOUND, e);
-    }
+    this.drawImage(new Image(filename), x, y, size);
   }
 
   /**
@@ -231,11 +227,7 @@ public class Scene {
    * @param rotation the amount to rotate the image in degrees
    */
   public final void drawImage(String filename, int x, int y, int size, double rotation) {
-    try {
-      this.drawImage(new Image(filename), x, y, size, rotation);
-    } catch (FileNotFoundException e) {
-      throw new TheaterRuntimeException(ExceptionKeys.FILE_NOT_FOUND, e);
-    }
+    this.drawImage(new Image(filename), x, y, size, rotation);
   }
 
   /**
@@ -251,11 +243,7 @@ public class Scene {
    */
   public final void drawImage(
       String filename, int x, int y, int width, int height, double rotation) {
-    try {
-      this.drawImage(new Image(filename), x, y, width, height, rotation);
-    } catch (FileNotFoundException e) {
-      throw new TheaterRuntimeException(ExceptionKeys.FILE_NOT_FOUND, e);
-    }
+    this.drawImage(new Image(filename), x, y, width, height, rotation);
   }
 
   /**


### PR DESCRIPTION
Removes FileNotFoundExceptions from Image and SoundLoader so students don't have to always explicitly write try-catch statements to handle them. Instead, these are thrown as MediaRuntime/SoundExceptions with the key FILE_NOT_FOUND.

JIRA: https://codedotorg.atlassian.net/browse/JAVA-566

Tested locally.