### PR TITLE
Replace jcenter with mavenCentral

### DIFF
--- a/cicd/3-app/javabuilder/pr-buildspec.yml
+++ b/cicd/3-app/javabuilder/pr-buildspec.yml
@@ -1,0 +1,31 @@
+version: 0.2
+phases:
+  install:
+    runtime-versions:
+      ruby: 2.7
+      java: corretto11
+      python: 3.8
+    commands:
+      - gem install bundler
+      - pip install cfn-lint
+  build:
+    # This should be moved to a shell script if it gets more complicated.
+    commands:
+      - set -e
+      - BRANCH_NAME=${CODEBUILD_WEBHOOK_HEAD_REF#"refs/heads/"}
+      - ARTIFACT_PATH=branch/$BRANCH_NAME/$CODEBUILD_BUILD_NUMBER
+      - cd ./javabuilder-authorizer
+      - ./build.sh
+
+      - cd $CODEBUILD_SRC_DIR
+      - cd org-code-javabuilder
+      - ./gradlew test
+      - ./build.sh
+
+      - cd $CODEBUILD_SRC_DIR
+      - erb -T - template.yml.erb > template.yml
+      - cat template.yml
+      - cfn-lint template.yml
+      - aws cloudformation package --template-file template.yml --output-template-file cloudformation-output.yml --s3-bucket $ARTIFACT_STORE --s3-prefix "$ARTIFACT_PATH/cloudformation-package"
+      - aws s3 cp cloudformation-output.yml "s3://${ARTIFACT_STORE}/${ARTIFACT_PATH}/"
+      - echo "Artifacts uploaded to S3, view them at https://console.aws.amazon.com/s3/buckets/${ARTIFACT_STORE}?region=us-east-1&prefix=${ARTIFACT_PATH}/"

--- a/org-code-javabuilder/lib/build.gradle
+++ b/org-code-javabuilder/lib/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/org-code-javabuilder/media/build.gradle
+++ b/org-code-javabuilder/media/build.gradle
@@ -11,8 +11,8 @@ java {
 }
 
 repositories {
-    // Use JCenter for resolving dependencies.
-    jcenter()
+    // Use Maven Central for resolving dependencies.
+    mavenCentral()
 }
 
 dependencies {

--- a/org-code-javabuilder/neighborhood/build.gradle
+++ b/org-code-javabuilder/neighborhood/build.gradle
@@ -13,8 +13,8 @@ plugins {
 }
 
 repositories {
-    // Use JCenter for resolving dependencies.
-    jcenter()
+    // Use Maven Central for resolving dependencies.
+    mavenCentral()
 }
 
 java {

--- a/org-code-javabuilder/playground/build.gradle
+++ b/org-code-javabuilder/playground/build.gradle
@@ -5,8 +5,8 @@ plugins {
 }
 
 repositories {
-    // Use JCenter for resolving dependencies.
-    jcenter()
+    // Use Maven Central for resolving dependencies.
+    mavenCentral()
 }
 
 java {

--- a/org-code-javabuilder/protocol/build.gradle
+++ b/org-code-javabuilder/protocol/build.gradle
@@ -14,8 +14,8 @@ plugins {
 }
 
 repositories {
-    // Use JCenter for resolving dependencies.
-    jcenter()
+    // Use Maven Central for resolving dependencies.
+    mavenCentral()
 }
 
 java {

--- a/org-code-javabuilder/theater/build.gradle
+++ b/org-code-javabuilder/theater/build.gradle
@@ -13,8 +13,8 @@ plugins {
 }
 
 repositories {
-    // Use JCenter for resolving dependencies.
-    jcenter()
+    // Use Maven Central for resolving dependencies.
+    mavenCentral()
 }
 
 java {

--- a/org-code-javabuilder/validation/build.gradle
+++ b/org-code-javabuilder/validation/build.gradle
@@ -4,8 +4,8 @@ plugins {
 }
 
 repositories {
-    // Use JCenter for resolving dependencies.
-    jcenter()
+    // Use Maven Central for resolving dependencies.
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
jcenter has [shut down](https://blog.gradle.org/jcenter-shutdown), replacing with mavenCentral

Maven Central is [similarly supported](https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:maven_central) by Gradle, so this swap should be sufficient.

It's possible that some packages may not be available on Maven Centeral. So far I have not encountered any errors.