### PR TITLE
Add warning when user is near hourly throttling limit

### DIFF
--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -131,7 +131,6 @@ def on_default(event, context)
   authorization_warning_response = AuthResponseHelper.get_warning_response(authorizer)
   # if there is a warning response, send the warning via the websocket and continue
   if authorization_warning_response
-    puts "sending warning..."
     resp = client.post_to_connection({
       data: authorization_warning_response,
       connection_id: connection_id

--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -128,6 +128,16 @@ def on_default(event, context)
     return authorization_error_response
   end
 
+  authorization_warning_response = AuthResponseHelper.get_warning_response(authorizer)
+  # if there is a warning response, send the warning via the websocket and continue
+  if authorization_warning_response
+    puts "sending warning..."
+    resp = client.post_to_connection({
+      data: authorization_warning_response,
+      connection_id: connection_id
+    })
+  end
+
   message = event["body"]
   # Return early if this is the user connectivity test
   if message == 'connectivityTest'

--- a/api-gateway-routes/api_gateway_put_function.rb
+++ b/api-gateway-routes/api_gateway_put_function.rb
@@ -1,10 +1,10 @@
 require 'aws-sdk-s3'
-require_relative 'auth_error_response_helper'
-include AuthErrorResponseHelper
+require_relative 'auth_response_helper'
+include AuthResponseHelper
 
 def lambda_handler(event:, context:)
   authorizer = event["requestContext"]["authorizer"]["lambda"]
-  authorization_error_response = AuthErrorResponseHelper.get_response(authorizer)
+  authorization_error_response = AuthResponseHelper.get_error_response(authorizer)
   return authorization_error_response unless authorization_error_response == nil
 
   region = context.invoked_function_arn.split(':')[3]

--- a/api-gateway-routes/auth_response_helper.rb
+++ b/api-gateway-routes/auth_response_helper.rb
@@ -21,7 +21,7 @@ module AuthResponseHelper
     return {
       type: AUTHORIZER_KEY,
       value: authorizer_payload[AUTHORIZATION_WARNING_KEY],
-      detail: authorizer_payload[AUTHORIZATION_WARNING_DETAIL_KEY]
+      detail: JSON.parse(authorizer_payload[AUTHORIZATION_WARNING_DETAIL_KEY])
   }.to_json
   end
 end

--- a/api-gateway-routes/auth_response_helper.rb
+++ b/api-gateway-routes/auth_response_helper.rb
@@ -1,9 +1,10 @@
-module AuthErrorResponseHelper
+module AuthResponseHelper
   AUTHORIZER_KEY = 'AUTHORIZER'.freeze
   AUTHORIZATION_ERROR_KEY = "authorization_error".freeze
   AUTHORIZATION_ERROR_CODE_KEY = "authorization_error_code".freeze
+  AUTHORIZATION_WARNING_KEY = "authorization_warning".freeze
 
-  def get_response(authorizer_payload)
+  def get_error_response(authorizer_payload)
     return nil unless authorizer_payload[AUTHORIZATION_ERROR_KEY] && authorizer_payload[AUTHORIZATION_ERROR_CODE_KEY]
 
     body = {
@@ -11,5 +12,8 @@ module AuthErrorResponseHelper
       value: authorizer_payload[AUTHORIZATION_ERROR_KEY]
     }
     { statusCode: authorizer_payload[AUTHORIZATION_ERROR_CODE_KEY], body: body.to_json }
+  end
+
+  def get_warning_response(authorizer_payload)
   end
 end

--- a/api-gateway-routes/auth_response_helper.rb
+++ b/api-gateway-routes/auth_response_helper.rb
@@ -3,6 +3,7 @@ module AuthResponseHelper
   AUTHORIZATION_ERROR_KEY = "authorization_error".freeze
   AUTHORIZATION_ERROR_CODE_KEY = "authorization_error_code".freeze
   AUTHORIZATION_WARNING_KEY = "authorization_warning".freeze
+  AUTHORIZATION_WARNING_DETAIL_KEY = "authorization_warning_detail".freeze
 
   def get_error_response(authorizer_payload)
     return nil unless authorizer_payload[AUTHORIZATION_ERROR_KEY] && authorizer_payload[AUTHORIZATION_ERROR_CODE_KEY]
@@ -15,5 +16,12 @@ module AuthResponseHelper
   end
 
   def get_warning_response(authorizer_payload)
+    return nil unless authorizer_payload[AUTHORIZATION_WARNING_KEY] && authorizer_payload[AUTHORIZATION_WARNING_DETAIL_KEY]
+    
+    return {
+      type: AUTHORIZER_KEY,
+      value: authorizer_payload[AUTHORIZATION_WARNING_KEY],
+      detail: authorizer_payload[AUTHORIZATION_WARNING_DETAIL_KEY]
+  }.to_json
   end
 end

--- a/javabuilder-authorizer/http_authorizer_function.rb
+++ b/javabuilder-authorizer/http_authorizer_function.rb
@@ -28,6 +28,7 @@ def lambda_handler(event:, context:)
   region = get_region(context)
   token_status = get_token_status(token_payload, standardized_origin, region)
   return JwtHelper.generate_allow_with_error(route_arn, token_status) unless token_status == TokenStatus::VALID_HTTP
+
   JwtHelper.generate_allow(route_arn, token_payload)
 end
 

--- a/javabuilder-authorizer/http_authorizer_function.rb
+++ b/javabuilder-authorizer/http_authorizer_function.rb
@@ -26,10 +26,8 @@ def lambda_handler(event:, context:)
 
   token_payload = decoded_token[0]
   region = get_region(context)
-  validation_result = get_validation_result(token_payload, standardized_origin, region)
-  token_status = validation_result[:status]
+  token_status = get_validation_result(token_payload, standardized_origin, region)
   return JwtHelper.generate_allow_with_error(route_arn, token_status) if ERROR_STATES.include?(token_status)
-  return JwtHelper.generate_allow_with_warning(route_arn, token_status, validation_result[:metadata]) if WARNING_STATES.include?(token_status)
   JwtHelper.generate_allow(route_arn, token_payload)
 end
 

--- a/javabuilder-authorizer/http_authorizer_function.rb
+++ b/javabuilder-authorizer/http_authorizer_function.rb
@@ -26,12 +26,12 @@ def lambda_handler(event:, context:)
 
   token_payload = decoded_token[0]
   region = get_region(context)
-  token_status = get_validation_result(token_payload, standardized_origin, region)
-  return JwtHelper.generate_allow_with_error(route_arn, token_status) if ERROR_STATES.include?(token_status)
+  token_status = get_token_status(token_payload, standardized_origin, region)
+  return JwtHelper.generate_allow_with_error(route_arn, token_status) unless token_status == TokenStatus::VALID_HTTP
   JwtHelper.generate_allow(route_arn, token_payload)
 end
 
-def get_validation_result(token_payload, origin, region)
+def get_token_status(token_payload, origin, region)
   validator = TokenValidator.new(token_payload, origin, region)
   validator.validate
 end

--- a/javabuilder-authorizer/jwt_helper.rb
+++ b/javabuilder-authorizer/jwt_helper.rb
@@ -48,6 +48,14 @@ module JwtHelper
     generate_policy(nil, 'Allow', resource, error_payload)
   end
 
+  # Generates a response that indicates that the request is well-formed, but should
+  # send back a warning due to throttling reasons
+  def generate_allow_with_warning(resource, token_status)
+    warn_payload = {}
+    warn_payload['authorization_warning'] = token_status
+    generate_policy(nil, 'Allow', resource, warn_payload)
+  end
+
   def generate_deny(resource)
     generate_policy(nil, 'Deny', resource, nil)
   end

--- a/javabuilder-authorizer/jwt_helper.rb
+++ b/javabuilder-authorizer/jwt_helper.rb
@@ -33,9 +33,7 @@ module JwtHelper
   end
 
   def generate_allow(resource, token_payload)
-    user_id = token_payload['uid']
-    issuer = token_payload['iss']
-    principal_id = "#{issuer}/#{user_id}"
+    principal_id = get_principal_id(token_payload)
     generate_policy(principal_id, 'Allow', resource, token_payload)
   end
 
@@ -51,13 +49,11 @@ module JwtHelper
   # Generates a response that indicates that the request is well-formed, but should
   # send a warning to the user
   def generate_allow_with_warning(resource, token_payload, token_status, detail)
-    puts "generating allow with warning..."
     warn_payload = token_payload
     warn_payload['authorization_warning'] = token_status
+    # detail is a json object, we must convert to a string for the policy
     warn_payload['authorization_warning_detail'] = detail.to_json
-    user_id = token_payload['uid']
-    issuer = token_payload['iss']
-    principal_id = "#{issuer}/#{user_id}"
+    principal_id = get_principal_id(token_payload)
     generate_policy(principal_id, 'Allow', resource, warn_payload)
   end
 
@@ -82,7 +78,6 @@ module JwtHelper
       auth_response['policyDocument'] = policy_document
     end
     auth_response['context'] = token_payload if token_payload
-    puts "auth_response is #{auth_response}"
     auth_response
   end
 
@@ -129,5 +124,11 @@ module JwtHelper
     # the key generation to work.
     public_key = public_key.gsub('\n ', "\n")
     OpenSSL::PKey::RSA.new(public_key)
+  end
+
+  def get_principal_id(token_payload)
+    user_id = token_payload['uid']
+    issuer = token_payload['iss']
+    "#{issuer}/#{user_id}"
   end
 end

--- a/javabuilder-authorizer/jwt_helper.rb
+++ b/javabuilder-authorizer/jwt_helper.rb
@@ -49,11 +49,16 @@ module JwtHelper
   end
 
   # Generates a response that indicates that the request is well-formed, but should
-  # send back a warning due to throttling reasons
-  def generate_allow_with_warning(resource, token_status)
-    warn_payload = {}
+  # send a warning to the user
+  def generate_allow_with_warning(resource, token_payload, token_status, detail)
+    puts "generating allow with warning..."
+    warn_payload = token_payload
     warn_payload['authorization_warning'] = token_status
-    generate_policy(nil, 'Allow', resource, warn_payload)
+    warn_payload['authorization_warning_detail'] = detail.to_json
+    user_id = token_payload['uid']
+    issuer = token_payload['iss']
+    principal_id = "#{issuer}/#{user_id}"
+    generate_policy(principal_id, 'Allow', resource, warn_payload)
   end
 
   def generate_deny(resource)
@@ -77,6 +82,7 @@ module JwtHelper
       auth_response['policyDocument'] = policy_document
     end
     auth_response['context'] = token_payload if token_payload
+    puts "auth_response is #{auth_response}"
     auth_response
   end
 

--- a/javabuilder-authorizer/token_status.rb
+++ b/javabuilder-authorizer/token_status.rb
@@ -14,6 +14,8 @@ module TokenStatus
   # All of a user's teachers (or the teacher themselves, if the user is a teacher)
   # has reached the hourly limit for Javabuilder requests for a classroom.
   TEACHERS_OVER_HOURLY_LIMIT = 'TEACHERS_OVER_HOURLY_LIMIT'.freeze
+  # A user is near their throttling limit. Token is valid but a warning should be sent.
+  NEAR_LIMIT = 'NEAR_LIMIT'.freeze
 
   ### Token statuses used in websocket authorizer (second step in token validation)
   # Token was validated by websocket authorizer
@@ -26,4 +28,8 @@ module TokenStatus
   ### Token status used by both authorizers
   # Token provided to the authorizer has already been used
   TOKEN_USED = 'TOKEN_USED'.freeze
+
+  ERROR_STATES = [USER_BLOCKED, TEACHERS_BLOCKED, USER_OVER_DAILY_LIMIT, USER_OVER_HOURLY_LIMIT, TEACHERS_OVER_HOURLY_LIMIT, UNKNOWN_ID, NOT_VETTED, TOKEN_USED]
+  WARNING_STATES = [NEAR_LIMIT]
+  VALID_STATES = [VALID_HTTP, VALID_WEBSOCKET]
 end

--- a/javabuilder-authorizer/token_validator.rb
+++ b/javabuilder-authorizer/token_validator.rb
@@ -26,7 +26,7 @@ class TokenValidator
     return error(TOKEN_USED) unless log_token
     return error(USER_BLOCKED) if user_blocked?
     return error(TEACHERS_BLOCKED) if teachers_blocked?
-    hourly_usage_response = user_hourly_usage
+    hourly_usage_response = user_usage(ONE_HOUR_SECONDS)
     return error(USER_OVER_HOURLY_LIMIT) if user_over_hourly_limit?(hourly_usage_response)
     return error(USER_OVER_DAILY_LIMIT) if user_over_daily_limit?
     return error(TEACHERS_OVER_HOURLY_LIMIT) if teachers_over_hourly_limit?
@@ -84,10 +84,6 @@ class TokenValidator
     end
 
     blocked
-  end
-
-  def user_hourly_usage
-    user_usage(ONE_HOUR_SECONDS)
   end
 
   def user_over_hourly_limit?(hourly_usage_response)

--- a/javabuilder-authorizer/token_validator.rb
+++ b/javabuilder-authorizer/token_validator.rb
@@ -11,6 +11,7 @@ class TokenValidator
   # TO DO: move this into env variable
   # https://codedotorg.atlassian.net/browse/JAVA-536
   TEACHER_HOURLY_LIMIT = 1000
+  NEAR_LIMIT_BUFFER = 10
 
   def initialize(payload, origin, region)
     @token_id = payload['sid']
@@ -25,12 +26,17 @@ class TokenValidator
     return error(TOKEN_USED) unless log_token
     return error(USER_BLOCKED) if user_blocked?
     return error(TEACHERS_BLOCKED) if teachers_blocked?
-    return error(USER_OVER_HOURLY_LIMIT) if user_over_hourly_limit?
+    hourly_usage_count = user_hourly_usage_count
+    return error(USER_OVER_HOURLY_LIMIT) if user_over_hourly_limit?(hourly_usage_count)
     return error(USER_OVER_DAILY_LIMIT) if user_over_daily_limit?
     return error(TEACHERS_OVER_HOURLY_LIMIT) if teachers_over_hourly_limit?
+
+    near_limit_metadata =  user_near_hourly_limit?(hourly_usage_count)
+    return warn(NEAR_LIMIT, near_limit_metadata) if near_limit_metadata
+
     log_requests
     mark_token_as_vetted
-    VALID_HTTP
+    validation_result(VALID_HTTP)
   end
 
   private
@@ -81,17 +87,26 @@ class TokenValidator
     blocked
   end
 
-  def user_over_hourly_limit?
+  def user_hourly_usage_count
+    user_usage_count(ONE_HOUR_SECONDS)
+  end
+
+  def user_over_hourly_limit?(hourly_usage_count)
     user_over_limit?(
-      ONE_HOUR_SECONDS,
+      hourly_usage_count,
       ENV['limit_per_hour'].to_i,
       USER_OVER_HOURLY_LIMIT
     )
   end
 
+  def user_near_hourly_limit?(hourly_usage_count)
+    user_near_limit?(hourly_usage_count, ENV['limit_per_hour'].to_i)
+  end
+
   def user_over_daily_limit?
+    usage_count = user_usage_count(ONE_DAY_SECONDS)
     user_over_limit?(
-      ONE_DAY_SECONDS,
+      usage_count,
       ENV['limit_per_day'].to_i,
       USER_OVER_DAILY_LIMIT
     )
@@ -177,11 +192,20 @@ class TokenValidator
   def error(status)
     puts "TOKEN VALIDATION ERROR: #{status} user_id: #{@user_id} verified_teachers: #{@verified_teachers} token_id: #{@token_id}"
     return status if status == TOKEN_USED
-    # status
-    VALID_HTTP
+    validation_result(VALID_HTTP, metadata)
   end
 
-  def user_over_limit?(time_range_seconds, limit, logging_message)
+  def warn(status, metadata)
+    puts "TOKEN VALIDATION WARNING: #{status} user_id: #{@user_id} verified_teachers: #{@verified_teachers} token_id: #{@token_id}"
+    validation_result(status, metadata)
+  end
+
+  def validation_result(status, metadata=nil)
+    {status: status, metadata: metadata}
+  end
+
+
+  def user_usage_count(time_range_seconds)
     response = @client.query(
       table_name: ENV['user_requests_table'],
       key_condition_expression: "user_id = :user_id AND issued_at > :past_time",
@@ -202,8 +226,19 @@ class TokenValidator
     if response.last_evaluated_key
       puts "user_requests query has paginated responses. user_id #{@user_id}"
     end
+    response.count
+  end
 
-    over_limit = response.count > limit
+  def user_near_limit?(count, limit)
+    if count <= limit && count >= (limit - NEAR_LIMIT_BUFFER)
+      return {remaining: limit - count}
+    else
+      return false
+    end
+  end
+
+  def user_over_limit?(count, limit, logging_message)
+    over_limit = count > limit
     if over_limit
       # logging could be improved,
       # [{"ttl"=>0.1648766446e10, "user_id"=>"611", "issued_at"=>0.1648680046e10}, {...

--- a/javabuilder-authorizer/token_validator.rb
+++ b/javabuilder-authorizer/token_validator.rb
@@ -30,8 +30,9 @@ class TokenValidator
     return error(USER_OVER_HOURLY_LIMIT) if user_over_hourly_limit?(hourly_usage_response)
     return error(USER_OVER_DAILY_LIMIT) if user_over_daily_limit?
     return error(TEACHERS_OVER_HOURLY_LIMIT) if teachers_over_hourly_limit?
-    near_limit_detail = user_near_hourly_limit?(hourly_usage_response.count)
-
+    near_limit_detail = get_user_near_hourly_limit_detail(hourly_usage_response.count)
+    puts "hourly usage count: #{hourly_usage_response.count}"
+    puts near_limit_detail
     log_requests
     mark_token_as_vetted
     set_token_warning(NEAR_LIMIT, near_limit_detail) if near_limit_detail
@@ -94,8 +95,8 @@ class TokenValidator
     )
   end
 
-  def user_near_hourly_limit?(hourly_usage_count)
-    user_near_limit?(hourly_usage_count, ENV['limit_per_hour'].to_i)
+  def get_user_near_hourly_limit_detail(hourly_usage_count)
+    get_user_near_limit_detail(hourly_usage_count, ENV['limit_per_hour'].to_i)
   end
 
   def user_over_daily_limit?
@@ -224,11 +225,11 @@ class TokenValidator
     response
   end
 
-  def user_near_limit?(count, limit)
+  def get_user_near_limit_detail(count, limit)
     if count <= limit && count >= (limit - NEAR_LIMIT_BUFFER)
       return {remaining: limit - count}
     else
-      return false
+      return nil
     end
   end
 

--- a/javabuilder-authorizer/websocket_authorizer_function.rb
+++ b/javabuilder-authorizer/websocket_authorizer_function.rb
@@ -43,7 +43,7 @@ def get_token_info(context, sid)
 
   unless item
     puts "TOKEN VALIDATION ERROR: #{TokenStatus::UNKNOWN_ID} token_id: #{sid}"
-    # return TokenStatus::UNKNOWN_ID
+    # return {status: TokenStatus::UNKNOWN_ID}
     return {status: TokenStatus::VALID_WEBSOCKET}
   end
 
@@ -54,7 +54,7 @@ def get_token_info(context, sid)
 
   unless item['vetted']
     puts "TOKEN VALIDATION ERROR: #{TokenStatus::NOT_VETTED} token_id: #{sid}"
-    # return TokenStatus::NOT_VETTED
+    # return {status: TokenStatus::NOT_VETTED}
     return {status: TokenStatus::VALID_WEBSOCKET}
   end
 
@@ -66,13 +66,13 @@ def get_token_info(context, sid)
   )
 
   if item['warning']
-    puts "TOKEN VALIDATION WARNING"
     warning = item['warning']
     # remaining is the number of requests remaining before throttling. Dynamodb
     # returns this in scientific format (ex. 0.1e2 for 10). Convert this decimal format.
     if warning['detail']['remaining']
       warning['detail']['remaining'] = warning['detail']['remaining'].to_i
     end
+    puts "TOKEN VALIDATION WARNING: #{warning['key']} detail: #{warning['detail']} token_id: #{sid}"
     return {status: warning['key'], detail: warning['detail']}
   end
 

--- a/javabuilder-authorizer/websocket_authorizer_function.rb
+++ b/javabuilder-authorizer/websocket_authorizer_function.rb
@@ -73,7 +73,9 @@ def get_token_info(context, sid)
       warning['detail']['remaining'] = warning['detail']['remaining'].to_i
     end
     puts "TOKEN VALIDATION WARNING: #{warning['key']} detail: #{warning['detail']} token_id: #{sid}"
-    return {status: warning['key'], detail: warning['detail']}
+    # TODO: return warning when we turn on throttling
+    # return {status: warning['key'], detail: warning['detail']}
+    return {status: TokenStatus::VALID_WEBSOCKET}
   end
 
   return {status: TokenStatus::VALID_WEBSOCKET}

--- a/javabuilder-authorizer/websocket_authorizer_function.rb
+++ b/javabuilder-authorizer/websocket_authorizer_function.rb
@@ -67,8 +67,13 @@ def get_token_info(context, sid)
 
   if item['warning']
     puts "TOKEN VALIDATION WARNING"
-    puts item['warning']
-    return {status: item['warning']['key'], detail: item['warning']['detail']}
+    warning = item['warning']
+    # remaining is the number of requests remaining before throttling. Dynamodb
+    # returns this in scientific format (ex. 0.1e2 for 10). Convert this decimal format.
+    if warning['detail']['remaining']
+      warning['detail']['remaining'] = warning['detail']['remaining'].to_i
+    end
+    return {status: warning['key'], detail: warning['detail']}
   end
 
   return {status: TokenStatus::VALID_WEBSOCKET}


### PR DESCRIPTION
Add logic to warn the user when they are within 10 runs of the hourly throttling limit. Currently the logic is all there but turned off until we fully turn on throttling (will be done as a follow-up). In order to warn the user we do the following
- In the http authorizer after we check for hourly usage above the limit, we also check if the user was within 10 of the limit. If they were, we set a warning on the token in the `token_status_table` DynamoDB table.
- In the websocket authorizer, when we query the `token_status_table` we check for a warning. If there is one, we send it over the newly created websocket so the user can see it. Right now we won't actually send the message. In order to turn it on we need to change a return value in `get_token_info` (there is a todo to do that)

## Follow up work
Next up we will turn on hourly throttling. We will need to do a bit of refactoring so that we don't return early if a user has reached their daily limit but not their hourly limit, as we won't be throttling on daily limits yet.