### PR TITLE
Turn on hourly throttling

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -31,6 +31,8 @@ SILENCE_ALERTS=${SILENCE_ALERTS-'false'}
 # Default per-user limits to prevent javabuilder abuse.
 LIMIT_PER_HOUR=${LIMIT_PER_HOUR-'50'}
 LIMIT_PER_DAY=${LIMIT_PER_DAY-'150'}
+# Default per-classroom hourly limit
+TEACHER_LIMIT_PER_HOUR=${TEACHER_LIMIT_PER_HOUR-'1000'}
 
 erb -T - template.yml.erb > template.yml
 TEMPLATE=template.yml
@@ -56,6 +58,6 @@ aws cloudformation deploy \
   --template-file ${OUTPUT_TEMPLATE} \
   --parameter-overrides SubDomainName=$SUB_DOMAIN BaseDomainName=$BASE_DOMAIN BaseDomainNameHostedZonedID=$BASE_DOMAIN_HOSTED_ZONE_ID \
     ProvisionedConcurrentExecutions=$PROVISIONED_CONCURRENT_EXECUTIONS ReservedConcurrentExecutions=$RESERVED_CONCURRENT_EXECUTIONS \
-    LimitPerHour=$LIMIT_PER_HOUR LimitPerDay=$LIMIT_PER_DAY SilenceAlerts=$SILENCE_ALERTS \
+    LimitPerHour=$LIMIT_PER_HOUR LimitPerDay=$LIMIT_PER_DAY TeacherLimitPerHour=$TEACHER_LIMIT_PER_HOUR SilenceAlerts=$SILENCE_ALERTS \
   --stack-name ${STACK} \
   "$@"

--- a/deploy.sh
+++ b/deploy.sh
@@ -29,8 +29,8 @@ RESERVED_CONCURRENT_EXECUTIONS=${RESERVED_CONCURRENT_EXECUTIONS-'3'}
 SILENCE_ALERTS=${SILENCE_ALERTS-'false'}
 
 # Default per-user limits to prevent javabuilder abuse.
-LIMIT_PER_HOUR=${LIMIT_PER_HOUR-'10'}
-LIMIT_PER_DAY=${LIMIT_PER_DAY-'40'}
+LIMIT_PER_HOUR=${LIMIT_PER_HOUR-'50'}
+LIMIT_PER_DAY=${LIMIT_PER_DAY-'150'}
 
 erb -T - template.yml.erb > template.yml
 TEMPLATE=template.yml

--- a/javabuilder-authorizer/token_status.rb
+++ b/javabuilder-authorizer/token_status.rb
@@ -6,7 +6,7 @@ module TokenStatus
   USER_BLOCKED = 'USER_BLOCKED'.freeze
   # All of a user's teachers (or the teacher themselves, if the user is a teacher)
   # has been blocked for violating hourly throttle limits
-  TEACHERS_BLOCKED = 'TEACHERS_BLOCKED'.freeze
+  CLASSROOM_BLOCKED = 'CLASSROOM_BLOCKED'.freeze
   # User has reached the hourly limit for Javabuilder requests.
   USER_OVER_HOURLY_LIMIT = 'USER_OVER_HOURLY_LIMIT'.freeze
   # User has reached the daily limit for Javabuilder requests.
@@ -29,7 +29,7 @@ module TokenStatus
   # Token provided to the authorizer has already been used
   TOKEN_USED = 'TOKEN_USED'.freeze
 
-  ERROR_STATES = [USER_BLOCKED, TEACHERS_BLOCKED, USER_OVER_DAILY_LIMIT, USER_OVER_HOURLY_LIMIT, TEACHERS_OVER_HOURLY_LIMIT, UNKNOWN_ID, NOT_VETTED, TOKEN_USED]
+  ERROR_STATES = [USER_BLOCKED, CLASSROOM_BLOCKED, USER_OVER_DAILY_LIMIT, USER_OVER_HOURLY_LIMIT, TEACHERS_OVER_HOURLY_LIMIT, UNKNOWN_ID, NOT_VETTED, TOKEN_USED]
   WARNING_STATES = [NEAR_LIMIT]
   VALID_STATES = [VALID_HTTP, VALID_WEBSOCKET]
 end

--- a/javabuilder-authorizer/token_validator.rb
+++ b/javabuilder-authorizer/token_validator.rb
@@ -26,22 +26,13 @@ class TokenValidator
     # TODO: uncomment other throttling thresholds once we have fine-tuned those limits
     return error(TOKEN_USED) unless log_token
     return error(USER_BLOCKED) if user_blocked?
-    # return error(CLASSROOM_BLOCKED) if teachers_blocked?
+    return error(CLASSROOM_BLOCKED) if teachers_blocked?
     hourly_usage_response = user_usage(ONE_HOUR_SECONDS)
-<<<<<<< HEAD
     return error(USER_BLOCKED) if user_over_hourly_limit?(hourly_usage_response)
     # return error(USER_BLOCKED) if user_over_daily_limit?
-    # return error(CLASSROOM_BLOCKED) if teachers_over_hourly_limit?
-    near_limit_detail = user_near_hourly_limit?(hourly_usage_response.count)
+    return error(CLASSROOM_BLOCKED) if teachers_over_hourly_limit?
 
-=======
-    return error(USER_OVER_HOURLY_LIMIT) if user_over_hourly_limit?(hourly_usage_response)
-    return error(USER_OVER_DAILY_LIMIT) if user_over_daily_limit?
-    return error(TEACHERS_OVER_HOURLY_LIMIT) if teachers_over_hourly_limit?
-    near_limit_detail = get_user_near_hourly_limit_detail(hourly_usage_response.count)
-    puts "hourly usage count: #{hourly_usage_response.count}"
-    puts near_limit_detail
->>>>>>> origin/main
+    near_limit_detail = user_near_hourly_limit?(hourly_usage_response.count)
     log_requests
     mark_token_as_vetted
     set_token_warning(NEAR_LIMIT, near_limit_detail) if near_limit_detail

--- a/javabuilder-authorizer/token_validator.rb
+++ b/javabuilder-authorizer/token_validator.rb
@@ -23,13 +23,14 @@ class TokenValidator
   end
 
   def validate
+    # TODO: uncomment other throttling thresholds once we have fine-tuned those limits
     return error(TOKEN_USED) unless log_token
     return error(USER_BLOCKED) if user_blocked?
-    return error(TEACHERS_BLOCKED) if teachers_blocked?
+    # return error(CLASSROOM_BLOCKED) if teachers_blocked?
     hourly_usage_response = user_usage(ONE_HOUR_SECONDS)
-    return error(USER_OVER_HOURLY_LIMIT) if user_over_hourly_limit?(hourly_usage_response)
-    return error(USER_OVER_DAILY_LIMIT) if user_over_daily_limit?
-    return error(TEACHERS_OVER_HOURLY_LIMIT) if teachers_over_hourly_limit?
+    return error(USER_BLOCKED) if user_over_hourly_limit?(hourly_usage_response)
+    # return error(USER_BLOCKED) if user_over_daily_limit?
+    # return error(CLASSROOM_BLOCKED) if teachers_over_hourly_limit?
     near_limit_detail = user_near_hourly_limit?(hourly_usage_response.count)
 
     log_requests
@@ -190,14 +191,10 @@ class TokenValidator
     )
   end
 
-  # TO DO: return actual error status instead of valid HTTP
-  # when we actually want to throttle. For now, only return error
-  # status if a token has already been used.
+  # Log the error and return it
   def error(status)
     puts "TOKEN VALIDATION ERROR: #{status} user_id: #{@user_id} verified_teachers: #{@verified_teachers} token_id: #{@token_id}"
-    return status if status == TOKEN_USED
-    # status
-    VALID_HTTP
+    status
   end
 
   def user_usage(time_range_seconds)

--- a/javabuilder-authorizer/token_validator.rb
+++ b/javabuilder-authorizer/token_validator.rb
@@ -8,9 +8,6 @@ class TokenValidator
   TOKEN_RECORD_TTL_SECONDS = 120 # Two minutes
   USER_REQUEST_RECORD_TTL_SECONDS = 25 * ONE_HOUR_SECONDS
   TEACHER_ASSOCIATED_REQUEST_TTL_SECONDS = 25 * ONE_HOUR_SECONDS
-  # TO DO: move this into env variable
-  # https://codedotorg.atlassian.net/browse/JAVA-536
-  TEACHER_HOURLY_LIMIT = 1000
   NEAR_LIMIT_BUFFER = 10
 
   def initialize(payload, origin, region)
@@ -32,7 +29,7 @@ class TokenValidator
     # return error(USER_BLOCKED) if user_over_daily_limit?
     return error(CLASSROOM_BLOCKED) if teachers_over_hourly_limit?
 
-    near_limit_detail = user_near_hourly_limit?(hourly_usage_response.count)
+    near_limit_detail = get_user_near_hourly_limit_detail(hourly_usage_response.count)
     log_requests
     mark_token_as_vetted
     set_token_warning(NEAR_LIMIT, near_limit_detail) if near_limit_detail
@@ -125,7 +122,7 @@ class TokenValidator
         puts "teacher_associated_requests query has paginated responses. user_id #{@user_id} teacher_id #{teacher_id}"
       end
 
-      if response.count > TEACHER_HOURLY_LIMIT
+      if response.count > ENV['teacher_limit_per_hour'].to_i
         begin
           @client.put_item(
             table_name: ENV['blocked_users_table'],

--- a/javabuilder-authorizer/websocket_authorizer_function.rb
+++ b/javabuilder-authorizer/websocket_authorizer_function.rb
@@ -43,8 +43,7 @@ def get_token_info(context, sid)
 
   unless item
     puts "TOKEN VALIDATION ERROR: #{TokenStatus::UNKNOWN_ID} token_id: #{sid}"
-    # return {status: TokenStatus::UNKNOWN_ID}
-    return {status: TokenStatus::VALID_WEBSOCKET}
+    return {status: TokenStatus::UNKNOWN_ID}
   end
 
   if item['used']
@@ -54,8 +53,7 @@ def get_token_info(context, sid)
 
   unless item['vetted']
     puts "TOKEN VALIDATION ERROR: #{TokenStatus::NOT_VETTED} token_id: #{sid}"
-    # return {status: TokenStatus::NOT_VETTED}
-    return {status: TokenStatus::VALID_WEBSOCKET}
+    return {status: TokenStatus::NOT_VETTED}
   end
 
   client.update_item(
@@ -73,9 +71,7 @@ def get_token_info(context, sid)
       warning['detail']['remaining'] = warning['detail']['remaining'].to_i
     end
     puts "TOKEN VALIDATION WARNING: #{warning['key']} detail: #{warning['detail']} token_id: #{sid}"
-    # TODO: return warning when we turn on throttling
-    # return {status: warning['key'], detail: warning['detail']}
-    return {status: TokenStatus::VALID_WEBSOCKET}
+    return {status: warning['key'], detail: warning['detail']}
   end
 
   return {status: TokenStatus::VALID_WEBSOCKET}

--- a/template.yml.erb
+++ b/template.yml.erb
@@ -28,12 +28,12 @@ Parameters:
     Type: Number
     Description: The number of Javabuilder invocations allowed per user per hour.
     MinValue: 1
-    Default: 10
+    Default: 50
   LimitPerDay:
     Type: Number
     Description: The number of Javabuilder invocations allowed per user per day.
     MinValue: 1
-    Default: 40
+    Default: 150
   StageName:
     Type: String
     Description: The default stage name in the API Gateway APIs

--- a/template.yml.erb
+++ b/template.yml.erb
@@ -34,6 +34,11 @@ Parameters:
     Description: The number of Javabuilder invocations allowed per user per day.
     MinValue: 1
     Default: 150
+  TeacherLimitPerHour:
+    Type: Number
+    Description: The number of Javabuilder invocations allowed for all students in a classroom per hour.
+    MinValue: 1
+    Default: 1000
   StageName:
     Type: String
     Description: The default stage name in the API Gateway APIs
@@ -428,6 +433,7 @@ Resources:
             -----END RSA PUBLIC KEY-----'
           limit_per_hour: !Ref LimitPerHour
           limit_per_day: !Ref LimitPerDay
+          teacher_limit_per_hour: !Ref TeacherLimitPerHour
           blocked_users_table: !Ref BlockedUsersTable
           token_status_table: !Ref TokenStatusTable
           user_requests_table: !Ref UserRequestsTable


### PR DESCRIPTION
Turn on hourly throttling for users and classrooms. This change does the following
- actually trigger errors and warnings for hourly usage
- stop querying and logging for daily usage limits. We can't log these anymore because they would end up blocking users, as the daily blocked users go to the same table as the hourly blocked users.
- Fix up the error keys sent back to align with those expected by Java Lab (we had `TEACHERS_BLOCKED` instead of `CLASSROOM_BLOCKED` and sent an invalid key the first time a user was blocked).
- move the teacher hourly limit to an environment variable.
NOTE: Clear the blocked users table before deploying this change