### PR TITLE
Increase gretty version

### DIFF
--- a/org-code-javabuilder/lib/build.gradle
+++ b/org-code-javabuilder/lib/build.gradle
@@ -8,7 +8,7 @@
  */
 
 plugins {
-    id "org.gretty" version "3.0.4"
+    id "org.gretty" version "3.0.5"
     id 'application'
     id 'com.github.sherter.google-java-format' version '0.8'
     id 'java'


### PR DESCRIPTION
Our previous version of gretty did not exist on mavenCentral, the repository we are using now that jCenter is deprecated. Bump up to a version that does exist on mavenCentral. We use gretty for running local javabuilder--without this change running local javabuilder (`appRun`) fails. 