### PR TITLE
Use integration tests private key and password

### DIFF
--- a/integration-tests/run-integration-tests.sh
+++ b/integration-tests/run-integration-tests.sh
@@ -12,8 +12,8 @@ set -e
 npm install
 
 # TODO: Use integration tests specific private key and password once those have been added.
-private_key=$(aws secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:us-east-1:475661607190:secret:development/cdo/javabuilder_private_key-gZE3SO)
-password=$(aws secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:us-east-1:475661607190:secret:development/cdo/javabuilder_key_password-J1RILi)
+private_key=$(aws secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:us-east-1:475661607190:secret:development/cdo/javabuilder_integration_tests_key-b4BQG2)
+password=$(aws secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:us-east-1:475661607190:secret:development/cdo/javabuilder_integration_tests_key_password-sWpRnW)
 
 JAVABUILDER_PRIVATE_KEY=$private_key \
 JAVABUILDER_PASSWORD=$password \

--- a/integration-tests/test/lib/JavabuilderConnectionHelper.js
+++ b/integration-tests/test/lib/JavabuilderConnectionHelper.js
@@ -10,8 +10,7 @@ import {
   PRIVATE_KEY,
 } from "./environment.js";
 
-// TODO: use integration test specific origin once the key pair has been setup.
-const INTEGRATION_TESTS_ORIGIN = "localhost-studio.code.org";
+const INTEGRATION_TESTS_ORIGIN = "integration-tests";
 const INTEGRATION_TESTS_SESSION_ID_PREFIX = "integrationTests-";
 
 /**


### PR DESCRIPTION
In integration tests, use the integration test specific private key and password, now that the associated public key has been added to Javabuilder.

Testing: confirmed that integration tests run successfully using the new key pair