### PR TITLE
Use canAccessDashboardAssets flag

### DIFF
--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -67,7 +67,8 @@ def on_connect(event, context)
     :miniAppType => authorizer["mini_app_type"],
     :javabuilderSessionId => authorizer['sid'],
     :queueName => queue_name,
-    :executionType => authorizer['execution_type']
+    :executionType => authorizer['execution_type'],
+    :canAccessDashboardAssets => authorizer['can_access_dashboard_assets']
   }
 
   response = nil

--- a/integration-tests/test/lib/JavabuilderConnectionHelper.js
+++ b/integration-tests/test/lib/JavabuilderConnectionHelper.js
@@ -77,6 +77,7 @@ class JavabuilderConnectionHelper {
       verified_teachers: this.getRandomId(),
       options: "{}",
       sid: sessionId,
+      can_access_dashboard_assets: false
     };
 
     const key = crypto.createPrivateKey({

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSContentManager.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSContentManager.java
@@ -91,10 +91,8 @@ public class AWSContentManager implements ContentManager {
     }
 
     // If this asset file refers to a Dashboard URL, and Javabuilder cannot access Dashboard for
-    // assets or running an integration test, Javabuilder won't be able access this file. Use a
-    // stubbed file URL instead.
-    if (this.isUrlFromDashboard(url)
-        && (!Properties.canAccessDashboardAssets() || Properties.isIntegrationTest())) {
+    // assets, Javabuilder won't be able access this file. Use a stubbed file URL instead.
+    if (this.isUrlFromDashboard(url) && !Properties.canAccessDashboardAssets()) {
       return this.assetFileStubber.getStubAssetUrl(filename);
     }
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AssetFileStubber.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AssetFileStubber.java
@@ -7,7 +7,7 @@ import java.util.logging.Logger;
 /**
  * Generates URLs for local, static asset files that can be used to stub asset file requests when
  * URLs cannot be accessed, notably in the cases where asset URLs point to Dashboard running on
- * localhost, or during an integration test.
+ * localhost or during an automated test.
  */
 public class AssetFileStubber {
   private static final String[] IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif"};

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -1,6 +1,5 @@
 package org.code.javabuilder;
 
-import static org.code.javabuilder.DashboardConstants.DASHBOARD_LOCALHOST_DOMAIN;
 import static org.code.javabuilder.LambdaErrorCodes.TEMP_DIRECTORY_CLEANUP_ERROR_CODE;
 import static org.code.protocol.InternalExceptionKey.INTERNAL_EXCEPTION;
 import static org.code.protocol.LoggerNames.MAIN_LOGGER;
@@ -90,11 +89,11 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     final String channelId =
         lambdaInput.get("channelId") == null ? "noneProvided" : lambdaInput.get("channelId");
     final ExecutionType executionType = ExecutionType.valueOf(lambdaInput.get("executionType"));
-    final String dashboardHostname = lambdaInput.get("iss");
     final JSONObject options = new JSONObject(lambdaInput.get("options"));
     final String javabuilderSessionId = lambdaInput.get("javabuilderSessionId");
     final List<String> compileList = JSONUtils.listFromJSONObjectMember(options, "compileList");
-
+    final boolean canUseDashboardAssets =
+        Boolean.parseBoolean(lambdaInput.get("canAccessDashboardAssets"));
     Logger logger = Logger.getLogger(MAIN_LOGGER);
     logger.addHandler(
         new LambdaLogHandler(
@@ -116,8 +115,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
       PerformanceTracker.getInstance().trackInstanceStart(instanceStart);
     }
 
-    // Dashboard assets are only accessible if the dashboard domain is not localhost
-    Properties.setCanAccessDashboardAssets(!dashboardHostname.equals(DASHBOARD_LOCALHOST_DOMAIN));
+    Properties.setCanAccessDashboardAssets(canUseDashboardAssets);
 
     // Create user-program output handlers
     final AWSOutputAdapter awsOutputAdapter = new AWSOutputAdapter(connectionId, API_CLIENT);

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -92,7 +92,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     final JSONObject options = new JSONObject(lambdaInput.get("options"));
     final String javabuilderSessionId = lambdaInput.get("javabuilderSessionId");
     final List<String> compileList = JSONUtils.listFromJSONObjectMember(options, "compileList");
-    final boolean canUseDashboardAssets =
+    final boolean canAccessDashboardAssets =
         Boolean.parseBoolean(lambdaInput.get("canAccessDashboardAssets"));
     Logger logger = Logger.getLogger(MAIN_LOGGER);
     logger.addHandler(
@@ -115,7 +115,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
       PerformanceTracker.getInstance().trackInstanceStart(instanceStart);
     }
 
-    Properties.setCanAccessDashboardAssets(canUseDashboardAssets);
+    Properties.setCanAccessDashboardAssets(canAccessDashboardAssets);
 
     // Create user-program output handlers
     final AWSOutputAdapter awsOutputAdapter = new AWSOutputAdapter(connectionId, API_CLIENT);

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/Properties.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/Properties.java
@@ -5,8 +5,6 @@ public class Properties {
   private static String connectionId = "localhost";
   /** If Javabuilder can access assets from the Dashboard service that invoked it */
   private static boolean CAN_ACCESS_DASHBOARD_ASSETS = true;
-  /** Whether Javabuilder is running an integration test */
-  private static boolean IS_INTEGRATION_TEST = false;
 
   public static void setConnectionId(String connectionId) {
     Properties.connectionId = connectionId;
@@ -22,13 +20,5 @@ public class Properties {
 
   public static boolean canAccessDashboardAssets() {
     return Properties.CAN_ACCESS_DASHBOARD_ASSETS;
-  }
-
-  public static void setIsIntegrationTest(boolean isIntegrationTest) {
-    Properties.IS_INTEGRATION_TEST = isIntegrationTest;
-  }
-
-  public static boolean isIntegrationTest() {
-    return Properties.IS_INTEGRATION_TEST;
   }
 }


### PR DESCRIPTION
[This PR](https://github.com/code-dot-org/code-dot-org/pull/46315) adds a new `canAccessDashboardAssets` flag on the code-dot-org side. Use this flag on the Javabuilder side to set the `canAccessDashboardAssets` property instead of inferring it based on the dashboard hostname. This PR also removed the `isIntegrationTest` property as it was only used to check if dashboard assets were accessible. It also adds the `canAccessDashboardAssets` property to the integration test configuration, which will enable theater integration tests. 

Note: this should not be merged until the PR linked above is deployed.