### PR TITLE
Add FatalError class

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/FatalError.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/FatalError.java
@@ -1,0 +1,25 @@
+package org.code.javabuilder;
+
+import org.code.protocol.JavabuilderError;
+
+/**
+ * A non-recoverable error that affects the user. This error typically results in shutting down the
+ * runtime.
+ */
+public class FatalError extends JavabuilderError {
+  private final int errorCode;
+
+  public FatalError(FatalErrorKey key) {
+    super(key);
+    this.errorCode = key.getErrorCode();
+  }
+
+  public FatalError(FatalErrorKey key, Throwable cause) {
+    super(key, cause);
+    this.errorCode = key.getErrorCode();
+  }
+
+  public int getErrorCode() {
+    return this.errorCode;
+  }
+}

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/FatalErrorKey.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/FatalErrorKey.java
@@ -1,0 +1,19 @@
+package org.code.javabuilder;
+
+import static org.code.javabuilder.LambdaErrorCodes.LOW_DISK_SPACE_ERROR_CODE;
+import static org.code.javabuilder.LambdaErrorCodes.TEMP_DIRECTORY_CLEANUP_ERROR_CODE;
+
+public enum FatalErrorKey {
+  LOW_DISK_SPACE(LOW_DISK_SPACE_ERROR_CODE),
+  TEMP_DIRECTORY_CLEANUP_ERROR(TEMP_DIRECTORY_CLEANUP_ERROR_CODE);
+
+  private final int errorCode;
+
+  FatalErrorKey(int errorCode) {
+    this.errorCode = errorCode;
+  }
+
+  int getErrorCode() {
+    return this.errorCode;
+  }
+}

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaErrorCodes.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaErrorCodes.java
@@ -6,4 +6,5 @@ public final class LambdaErrorCodes {
   }
 
   public static final int TEMP_DIRECTORY_CLEANUP_ERROR_CODE = 10;
+  public static final int LOW_DISK_SPACE_ERROR_CODE = 50;
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderError.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderError.java
@@ -1,0 +1,33 @@
+package org.code.protocol;
+
+/** Parent error for all errors that are displayed to the user. */
+public abstract class JavabuilderError extends Error implements JavabuilderThrowableProtocol {
+  private final Enum key;
+  private String fallbackMessage;
+
+  protected JavabuilderError(Enum key) {
+    super(key.toString());
+    this.key = key;
+  }
+
+  protected JavabuilderError(Enum key, Throwable cause) {
+    super(key.toString(), cause);
+    this.key = key;
+  }
+
+  protected JavabuilderError(Enum key, String fallbackMessage) {
+    super(key.toString());
+    this.key = key;
+    this.fallbackMessage = fallbackMessage;
+  }
+
+  public JavabuilderThrowableMessage getExceptionMessage() {
+    return JavabuilderThrowableMessageUtils.getExceptionMessage(
+        this, this.key, this.fallbackMessage);
+  }
+
+  /** @return A pretty version of the exception and stack trace. */
+  public String getLoggingString() {
+    return JavabuilderThrowableMessageUtils.getLoggingString(this);
+  }
+}


### PR DESCRIPTION
Some pre-work for refactoring our error handling. This adds a new `FatalError` class, which is a sub class of `JavabuilderError` - JavabuilderError is the `Error` analog of JavabuilderException/RuntimeException. These classes are currently unused, but they'll help our error handling code differentiate between truly unrecoverable errors (ex. out of disk space) that require shutting down the runtime, vs severe but recoverable exceptions (InternalServerException/RuntimeExceptions).

Tested locally (to make sure there's no effect on existing behavior)