### PR TITLE
Add InternalFacingRuntimeException

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/InternalFacingException.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/InternalFacingException.java
@@ -1,13 +1,14 @@
 package org.code.javabuilder;
 
 import org.code.protocol.JavabuilderThrowableMessageUtils;
+import org.code.protocol.LoggableProtocol;
 
 /**
  * Exception intended to eventually bubble up to a logger (i.e. CloudWatch) but have no functional
  * effect on the user. These should generally be used in code that executes after the user's code
  * has finished running.
  */
-public class InternalFacingException extends Exception {
+public class InternalFacingException extends Exception implements LoggableProtocol {
   public InternalFacingException(String errorMessage, Throwable cause) {
     super(errorMessage, cause);
   }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/InternalFacingRuntimeException.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/InternalFacingRuntimeException.java
@@ -1,0 +1,15 @@
+package org.code.javabuilder;
+
+import org.code.protocol.JavabuilderThrowableMessageUtils;
+import org.code.protocol.LoggableProtocol;
+
+public class InternalFacingRuntimeException extends RuntimeException implements LoggableProtocol {
+  public InternalFacingRuntimeException(String errorMessage, Throwable cause) {
+    super(errorMessage, cause);
+  }
+
+  /** @return A pretty version of the exception and stack trace. */
+  public String getLoggingString() {
+    return JavabuilderThrowableMessageUtils.getLoggingString(this);
+  }
+}

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderThrowableProtocol.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderThrowableProtocol.java
@@ -1,7 +1,6 @@
 package org.code.protocol;
 
-public interface JavabuilderThrowableProtocol {
+/** A throwable that can be logged and produce a client-facing error message */
+public interface JavabuilderThrowableProtocol extends LoggableProtocol {
   JavabuilderThrowableMessage getExceptionMessage();
-
-  String getLoggingString();
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggableProtocol.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggableProtocol.java
@@ -1,0 +1,6 @@
+package org.code.protocol;
+
+/** An object (typically a throwable) that can be logged */
+public interface LoggableProtocol {
+  String getLoggingString();
+}


### PR DESCRIPTION
Some more pre-work for error handing refactoring. This adds `InternalFacingRuntimeException` as the runtime analog of `InternalFacingException`. This also has some minor refactoring to move the `getLoggingString()` method out of `JavabuilderThrowableProtocol` into its own interface (`LoggableProtocol`) that both the InternalFacing classes can implement. This way there's a distinction between exceptions that are internal-facing and only need to be logged (those that implement `LoggableProtocol`) and exceptions that are external facing and therefore need to be logged and produce a client-facing message (those that implement `JavabuilderThrowableProtocol`).

Like with FatalError, this is currently unused, but will be helpful in error handling code.