### PR TITLE
Add cloudwatch put metric data permission to Lambdas

### DIFF
--- a/iam.yml
+++ b/iam.yml
@@ -57,6 +57,12 @@ Resources:
                   - "execute-api:ManageConnections"
                 Resource:
                   - !Sub "arn:aws:execute-api:*:${AWS::AccountId}:${JavabuilderApiId}/*"
+              # Build and Run Lambdas need to be able to write metrics to CloudWatch
+              - Effect: Allow
+                Action:
+                  - 'cloudwatch:PutMetricData'
+                Resource:
+                  - '*'
   
   # Permissions for the synchronous Lambda that invokes the long-running Lambda
   # and then relays web messages to it


### PR DESCRIPTION
We need this permission to publish custom metrics to cloudwatch from the build and run lambdas. More details in [this slack thread](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1652460222474799)