### PR TITLE
Neighborhood integration test

### DIFF
--- a/integration-tests/test/helloWorld.js
+++ b/integration-tests/test/helloWorld.js
@@ -1,6 +1,7 @@
 import { helloWorld } from "./lib/sources.js";
 import { NEIGHBORHOOD } from "./lib/MiniAppType.js";
-import { verifyMessagesRecevied } from "./helpers/testHelpers.js";
+import { verifyMessagesReceived } from "./helpers/testHelpers.js";
+import { expect } from "chai";
 
 describe("Hello World", () => {
   it("Runs Hello World project", (done) => {
@@ -12,7 +13,8 @@ describe("Hello World", () => {
       { type: "SYSTEM_OUT", value: "\n" },
       { type: "STATUS", value: "EXITED" },
     ];
+    const assertOnMessagesReceived = receivedMessages => expect(expectedMessages).to.deep.equal(receivedMessages);
 
-    verifyMessagesRecevied(helloWorld, NEIGHBORHOOD, expectedMessages, done);
+    verifyMessagesReceived(helloWorld, NEIGHBORHOOD, assertOnMessagesReceived, done);
   }).timeout(20000);
 });

--- a/integration-tests/test/helpers/testHelpers.js
+++ b/integration-tests/test/helpers/testHelpers.js
@@ -1,5 +1,5 @@
 import connectionHelper from "../lib/JavabuilderConnectionHelper.js";
-import { expect } from "chai";
+import {expect} from "chai";
 
 /**
  * Helper for verifying the basic case that set of messages was received
@@ -10,10 +10,10 @@ import { expect } from "chai";
  * @param {*} expectedMessages a list of expected messages from Javabuilder
  * @param {*} doneCallback Mocha's 'done' callback
  */
-export const verifyMessagesRecevied = (
+export const verifyMessagesReceived = (
   sourcesJson,
   miniAppType,
-  expectedMessages,
+  assertOnMessagesReceived,
   doneCallback
 ) => {
   const receivedMessages = [];
@@ -26,7 +26,7 @@ export const verifyMessagesRecevied = (
   };
   const onClose = (event) => {
     expect(event.wasClean).to.be.true;
-    expect(expectedMessages).to.deep.equal(receivedMessages);
+    assertOnMessagesReceived(receivedMessages);
     doneCallback();
   };
 

--- a/integration-tests/test/lib/sources.js
+++ b/integration-tests/test/lib/sources.js
@@ -5,3 +5,13 @@ export const helloWorld = JSON.stringify({
   },
   assetUrls: {},
 });
+
+export const neighborhood = JSON.stringify({
+  sources: {
+    "grid.txt":
+        "[[{\"tileType\":2,\"value\":0,\"assetId\":287},{\"tileType\":1,\"assetId\":303,\"value\":5},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0}],[{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":0,\"assetId\":53,\"value\":0},{\"tileType\":0,\"assetId\":54,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":99,\"assetId\":303}],[{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0}],[{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":0,\"assetId\":12,\"value\":0},{\"tileType\":0,\"assetId\":13,\"value\":0}],[{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":0,\"assetId\":14,\"value\":0},{\"tileType\":0,\"assetId\":15,\"value\":0}],[{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":0,\"assetId\":16,\"value\":0},{\"tileType\":0,\"assetId\":17,\"value\":0}],[{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":0,\"assetId\":18,\"value\":0},{\"tileType\":0,\"assetId\":19,\"value\":0}],[{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0},{\"tileType\":1,\"value\":0}]]",
+    "main.json":
+        "{\"source\":{\"PainterTest.java\":{\"text\":\"import org.code.neighborhood.*;\\n\\npublic class PainterTest {\\n  public static void main(String[] args) {\\n    Painter p = new Painter(0, 0, \\\"east\\\", 1);\\n    p.paint(\\\"blue\\\");\\n  }\\n}\",\"isVisible\":true}},\"animations\":{}}"
+  },
+  "assetUrls":{}
+});

--- a/integration-tests/test/neighborhood.js
+++ b/integration-tests/test/neighborhood.js
@@ -1,3 +1,66 @@
+import {neighborhood} from "./lib/sources.js";
+import {NEIGHBORHOOD} from "./lib/MiniAppType.js";
+import {verifyMessagesReceived} from "./helpers/testHelpers.js";
+import {expect} from "chai";
+
 describe("Neighborhood", () => {
-  // TODO
+  it("Paints single square", (done) => {
+    const expectedMessages = [
+      {type: "STATUS", value: "COMPILING"},
+      {type: "STATUS", value: "COMPILATION_SUCCESSFUL"},
+      {type: "STATUS", value: "RUNNING"},
+      {
+        type: "NEIGHBORHOOD",
+        value: "INITIALIZE_PAINTER",
+        detail: {
+          x: "0",
+          y: "0",
+          paint: "1",
+          direction: "east"
+        }
+      },
+      {
+        type: "NEIGHBORHOOD",
+        value: "PAINT",
+        detail: {
+          color: "blue"
+        }
+      },
+      {type: "STATUS", value: "EXITED"}
+    ];
+
+    const assertOnMessagesReceived = receivedMessages => {
+      expect(receivedMessages.length).to.equal(expectedMessages.length);
+
+      let expectedPainterId;
+      receivedMessages.forEach((receivedMessage, index) => {
+        const expectedMessage = expectedMessages[index];
+
+        const messageType = receivedMessage.type;
+        if (messageType === "STATUS") {
+          expect(receivedMessage).to.deep.equal(expectedMessage);
+        } else if (messageType === "NEIGHBORHOOD") {
+          expect(receivedMessage.type).to.equal(expectedMessage.type);
+          expect(receivedMessage.value).to.equal(expectedMessage.value);
+
+          const detail = receivedMessage.detail;
+          Object.keys(detail).forEach((key) => {
+            if (key === 'id') {
+              if (receivedMessage.value === "INITIALIZE_PAINTER") {
+                expectedPainterId = detail.id;
+              } else {
+                expect(detail.id).to.equal(expectedPainterId);
+              }
+            } else {
+              expect(receivedMessage.detail[key]).to.equal(expectedMessage.detail[key]);
+            }
+          })
+        } else {
+          throw new Error(`Unexpected message type received: ${messageType}`);
+        }
+      });
+    };
+
+    verifyMessagesReceived(neighborhood, NEIGHBORHOOD, assertOnMessagesReceived, done);
+  }).timeout(20000);
 });

--- a/integration-tests/test/neighborhood.js
+++ b/integration-tests/test/neighborhood.js
@@ -43,8 +43,12 @@ describe("Neighborhood", () => {
           expect(receivedMessage.type).to.equal(expectedMessage.type);
           expect(receivedMessage.value).to.equal(expectedMessage.value);
 
+          // Verify details object is as expected.
+          // The painter ID varies across executions,
+          // so assert that the intialized painter ID
+          // persists in other painter messages.
           const detail = receivedMessage.detail;
-          Object.keys(detail).forEach((key) => {
+          Object.keys(detail).forEach(key => {
             if (key === 'id') {
               if (receivedMessage.value === "INITIALIZE_PAINTER") {
                 expectedPainterId = detail.id;


### PR DESCRIPTION
Adds an integration test for painting a single square on a Neighborhood level. It'd be nice to add an integration test to move the painter as well, but I thought it'd be good to use the exact same sources as what we have in load tests so we could easily dedupe if we'd like.

## Testing story

Successfully executed test against our test instance.