### PR TITLE
Add cloudwatch metrics

### DIFF
--- a/org-code-javabuilder/lib/build.gradle
+++ b/org-code-javabuilder/lib/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-sqs', version: '1.11.978'
     // https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-s3
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.20'
+    // https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-cloudwatch
+    implementation group: 'com.amazonaws', name: 'aws-java-sdk-cloudwatch', version: '1.12.218'
     // https://mvnrepository.com/artifact/org.json/json
     implementation group: 'org.json', name: 'json', version: '20210307'
     // jaxb-api is needed to get rid of warning on run

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMetricClient.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMetricClient.java
@@ -2,6 +2,9 @@ package dev.javabuilder;
 
 import org.code.protocol.MetricClient;
 
+// Local implementation of MetricClient. Since all we can do locally
+// is log and we already have regular logging for every metric,
+// these methods do nothing.
 public class LocalMetricClient implements MetricClient {
   @Override
   public void publishSevereError() {}

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMetricClient.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalMetricClient.java
@@ -1,0 +1,20 @@
+package dev.javabuilder;
+
+import org.code.protocol.MetricClient;
+
+public class LocalMetricClient implements MetricClient {
+  @Override
+  public void publishSevereError() {}
+
+  @Override
+  public void publishColdBootTime(long coldBootTime) {}
+
+  @Override
+  public void publishInitializationTime(long initializationTime) {}
+
+  @Override
+  public void publishTransitionTime(long transitionTime) {}
+
+  @Override
+  public void publishCleanupTime(long cleanupTime) {}
+}

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -76,6 +76,9 @@ public class WebSocketServer {
     // turn off the default console logger
     this.logger.setUseParentHandlers(false);
 
+    MetricClient metricClient = new LocalMetricClient();
+    MetricClientManager.create(metricClient);
+
     Properties.setConnectionId(connectionId);
 
     websocketOutputAdapter = new WebSocketOutputAdapter(session);

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSMetricClient.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSMetricClient.java
@@ -5,6 +5,8 @@ import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
 import com.amazonaws.services.cloudwatch.model.*;
 import org.code.protocol.MetricClient;
 
+// Metric Client which published metrics to AWS CloudWatch.
+// Requires cloudwatch:PutMetricData Permission on the Lambda.
 public class AWSMetricClient implements MetricClient {
   private final AmazonCloudWatch cloudWatchClient;
   private final Dimension functionNameDimension;

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSMetricClient.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSMetricClient.java
@@ -1,15 +1,63 @@
 package org.code.javabuilder;
 
-import java.time.Instant;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
+import com.amazonaws.services.cloudwatch.model.*;
 import org.code.protocol.MetricClient;
 
 public class AWSMetricClient implements MetricClient {
-  @Override
-  public void publishSevereError() {}
+  private final AmazonCloudWatch cloudWatchClient;
+  private final Dimension functionNameDimension;
+
+  private static final String NAMESPACE = "Javabuilder";
+
+  public AWSMetricClient(String functionName) {
+    this.cloudWatchClient = AmazonCloudWatchClientBuilder.defaultClient();
+    this.functionNameDimension = new Dimension().withName("functionName").withValue(functionName);
+  }
 
   @Override
-  public void publishColdBootTime(Instant coldBootTime) {}
+  public void publishSevereError() {
+    MetricDatum metricDatum =
+        new MetricDatum()
+            .withMetricName("SevereError")
+            .withUnit(StandardUnit.Count)
+            .withValue(1.0)
+            .withDimensions(this.functionNameDimension);
+    PutMetricDataRequest request =
+        new PutMetricDataRequest().withNamespace(NAMESPACE).withMetricData(metricDatum);
+    this.cloudWatchClient.putMetricData(request);
+  }
 
   @Override
-  public void publishInitializationTime(Instant initializationTime) {}
+  public void publishColdBootTime(long coldBootTime) {
+    this.publishMillisecondMetric("ColdBootTime", (double) coldBootTime);
+  }
+
+  @Override
+  public void publishInitializationTime(long initializationTime) {
+    this.publishMillisecondMetric("InitializationTime", (double) initializationTime);
+  }
+
+  @Override
+  public void publishTransitionTime(long transitionTime) {
+    this.publishMillisecondMetric("TransitionTime", (double) transitionTime);
+  }
+
+  @Override
+  public void publishCleanupTime(long cleanupTime) {
+    this.publishMillisecondMetric("CleanupTime", (double) cleanupTime);
+  }
+
+  private void publishMillisecondMetric(String metricName, double milliseconds) {
+    MetricDatum metricDatum =
+        new MetricDatum()
+            .withMetricName(metricName)
+            .withUnit(StandardUnit.Milliseconds)
+            .withValue(milliseconds)
+            .withDimensions(this.functionNameDimension);
+    PutMetricDataRequest request =
+        new PutMetricDataRequest().withNamespace(NAMESPACE).withMetricData(metricDatum);
+    this.cloudWatchClient.putMetricData(request);
+  }
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSMetricClient.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSMetricClient.java
@@ -1,0 +1,15 @@
+package org.code.javabuilder;
+
+import java.time.Instant;
+import org.code.protocol.MetricClient;
+
+public class AWSMetricClient implements MetricClient {
+  @Override
+  public void publishSevereError() {}
+
+  @Override
+  public void publishColdBootTime(Instant coldBootTime) {}
+
+  @Override
+  public void publishInitializationTime(Instant initializationTime) {}
+}

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSMetricClient.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSMetricClient.java
@@ -6,7 +6,7 @@ import com.amazonaws.services.cloudwatch.model.*;
 import org.code.protocol.MetricClient;
 
 // Metric Client which published metrics to AWS CloudWatch.
-// Requires cloudwatch:PutMetricData Permission on the Lambda.
+// Requires cloudwatch:PutMetricData permission on the Lambda.
 public class AWSMetricClient implements MetricClient {
   private final AmazonCloudWatch cloudWatchClient;
   private final Dimension functionNameDimension;
@@ -15,20 +15,13 @@ public class AWSMetricClient implements MetricClient {
 
   public AWSMetricClient(String functionName) {
     this.cloudWatchClient = AmazonCloudWatchClientBuilder.defaultClient();
+    // this will split out metrics by function name in CloudWatch
     this.functionNameDimension = new Dimension().withName("functionName").withValue(functionName);
   }
 
   @Override
   public void publishSevereError() {
-    MetricDatum metricDatum =
-        new MetricDatum()
-            .withMetricName("SevereError")
-            .withUnit(StandardUnit.Count)
-            .withValue(1.0)
-            .withDimensions(this.functionNameDimension);
-    PutMetricDataRequest request =
-        new PutMetricDataRequest().withNamespace(NAMESPACE).withMetricData(metricDatum);
-    this.cloudWatchClient.putMetricData(request);
+    this.publishCountMetric("SevereError", 1.0);
   }
 
   @Override
@@ -57,6 +50,18 @@ public class AWSMetricClient implements MetricClient {
             .withMetricName(metricName)
             .withUnit(StandardUnit.Milliseconds)
             .withValue(milliseconds)
+            .withDimensions(this.functionNameDimension);
+    PutMetricDataRequest request =
+        new PutMetricDataRequest().withNamespace(NAMESPACE).withMetricData(metricDatum);
+    this.cloudWatchClient.putMetricData(request);
+  }
+
+  private void publishCountMetric(String metricName, double count) {
+    MetricDatum metricDatum =
+        new MetricDatum()
+            .withMetricName(metricName)
+            .withUnit(StandardUnit.Count)
+            .withValue(count)
             .withDimensions(this.functionNameDimension);
     PutMetricDataRequest request =
         new PutMetricDataRequest().withNamespace(NAMESPACE).withMetricData(metricDatum);

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -108,6 +108,9 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     logger.setUseParentHandlers(false);
     Properties.setConnectionId(connectionId);
 
+    MetricClient metricClient = new AWSMetricClient(context.getFunctionName());
+    MetricClientManager.create(metricClient);
+
     PerformanceTracker.resetTracker();
     if (coldBoot) {
       PerformanceTracker.getInstance().trackColdBoot(COLD_BOOT_START, COLD_BOOT_END, instanceStart);
@@ -256,6 +259,8 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
    * added here can be run more than once without negative effect.
    */
   private void cleanUpResources(String connectionId, AmazonApiGatewayManagementApi api) {
+    // delete the metric client manager if it exists
+    MetricClientManager.destroy();
     final DeleteConnectionRequest deleteConnectionRequest =
         new DeleteConnectionRequest().withConnectionId(connectionId);
     // Deleting the API Gateway connection should always be the last thing executed because the

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/PerformanceTracker.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/PerformanceTracker.java
@@ -6,6 +6,8 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.logging.Logger;
 import org.code.protocol.LoggerConstants;
+import org.code.protocol.MetricClient;
+import org.code.protocol.MetricClientManager;
 import org.json.JSONObject;
 
 /**
@@ -91,20 +93,29 @@ public class PerformanceTracker {
 
   public void logPerformance() {
     logs.put(LoggerConstants.TYPE, TYPE);
+    MetricClient metricClient = MetricClientManager.getInstance().getMetricClient();
     if (!logs.isNull(COLD_BOOT_START) && !logs.isNull(COLD_BOOT_END)) {
-      logs.put(COLD_BOOT_TIME, logs.getLong(COLD_BOOT_END) - logs.getLong(COLD_BOOT_START));
+      long coldBootTime = logs.getLong(COLD_BOOT_END) - logs.getLong(COLD_BOOT_START);
+      logs.put(COLD_BOOT_TIME, coldBootTime);
+      metricClient.publishColdBootTime(coldBootTime);
     }
 
     if (!logs.isNull(COMPILE_START) && !logs.isNull(INSTANCE_START)) {
-      logs.put(INITIALIZATION_TIME, logs.getLong(COMPILE_START) - logs.getLong(INSTANCE_START));
+      long initializationTime = logs.getLong(COMPILE_START) - logs.getLong(INSTANCE_START);
+      logs.put(INITIALIZATION_TIME, initializationTime);
+      metricClient.publishInitializationTime(initializationTime);
     }
 
     if (!logs.isNull(COMPILE_END) && !logs.isNull(USER_CODE_START)) {
-      logs.put(TRANSITION_TIME, logs.getLong(USER_CODE_START) - logs.getLong(COMPILE_END));
+      long transitionTime = logs.getLong(USER_CODE_START) - logs.getLong(COMPILE_END);
+      logs.put(TRANSITION_TIME, transitionTime);
+      metricClient.publishTransitionTime(transitionTime);
     }
 
     if (!logs.isNull(USER_CODE_END) && !logs.isNull(INSTANCE_END)) {
-      logs.put(CLEANUP_TIME, logs.getLong(INSTANCE_END) - logs.getLong(USER_CODE_END));
+      long cleanupTime = logs.getLong(INSTANCE_END) - logs.getLong(USER_CODE_END);
+      logs.put(CLEANUP_TIME, cleanupTime);
+      metricClient.publishCleanupTime(cleanupTime);
     }
 
     Logger.getLogger(MAIN_LOGGER).info(logs.toString());

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerUtils.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerUtils.java
@@ -76,6 +76,7 @@ public class LoggerUtils {
     if (cause != null) {
       eventData.put(LoggerConstants.CAUSE, cause);
     }
+    MetricClientManager.getInstance().getMetricClient().publishSevereError();
     Logger.getLogger(MAIN_LOGGER).severe(eventData.toString());
   }
 
@@ -86,6 +87,7 @@ public class LoggerUtils {
     if (e.getCause() != null) {
       eventData.put(LoggerConstants.CAUSE, e.getCause());
     }
+    MetricClientManager.getInstance().getMetricClient().publishSevereError();
     Logger.getLogger(MAIN_LOGGER).severe(eventData.toString());
   }
 

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/MetricClient.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/MetricClient.java
@@ -1,5 +1,6 @@
 package org.code.protocol;
 
+// Interface for logging metrics for use in monitoring and alerting.
 public interface MetricClient {
   void publishSevereError();
 

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/MetricClient.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/MetricClient.java
@@ -1,11 +1,13 @@
 package org.code.protocol;
 
-import java.time.Instant;
-
 public interface MetricClient {
   void publishSevereError();
 
-  void publishColdBootTime(Instant coldBootTime);
+  void publishColdBootTime(long coldBootTime);
 
-  void publishInitializationTime(Instant initializationTime);
+  void publishInitializationTime(long initializationTime);
+
+  void publishTransitionTime(long transitionTime);
+
+  void publishCleanupTime(long cleanupTime);
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/MetricClient.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/MetricClient.java
@@ -1,0 +1,11 @@
+package org.code.protocol;
+
+import java.time.Instant;
+
+public interface MetricClient {
+  void publishSevereError();
+
+  void publishColdBootTime(Instant coldBootTime);
+
+  void publishInitializationTime(Instant initializationTime);
+}

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/MetricClientManager.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/MetricClientManager.java
@@ -1,0 +1,31 @@
+package org.code.protocol;
+
+public class MetricClientManager {
+  private static MetricClientManager clientManagerInstance;
+
+  private MetricClient metricClient;
+
+  private MetricClientManager(MetricClient metricClient) {
+    this.metricClient = metricClient;
+  }
+
+  public static void create(MetricClient metricClient) {
+    MetricClientManager.clientManagerInstance = new MetricClientManager(metricClient);
+  }
+
+  public static MetricClientManager getInstance() {
+    if (MetricClientManager.clientManagerInstance == null) {
+      throw new InternalServerRuntimeException(InternalExceptionKey.INTERNAL_EXCEPTION);
+    }
+
+    return MetricClientManager.clientManagerInstance;
+  }
+
+  public static void destroy() {
+    MetricClientManager.clientManagerInstance = null;
+  }
+
+  public MetricClient getMetricClient() {
+    return this.metricClient;
+  }
+}


### PR DESCRIPTION
Add custom cloudwatch metrics for the metrics we have been deriving via logs. These metrics are:
- Severe Errors (count)
- Cold Boot Time (ms)
- Initialization Time (ms)
- Transition Time (ms)
- Cleanup Time (ms)

The only dimension I put on the metrics is `functionName` so we can split data out by lambda.

Note: [This PR](https://github.com/code-dot-org/javabuilder/pull/305) must be merged and the iam change deployed before this can be merged.