### PR TITLE
Fix local theater

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalTempDirectoryManager.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/LocalTempDirectoryManager.java
@@ -1,6 +1,5 @@
 package dev.javabuilder;
 
-import dev.javabuilder.util.LocalStorageUtils;
 import java.io.File;
 import java.io.IOException;
 import org.code.javabuilder.util.FileUtils;
@@ -17,7 +16,5 @@ public class LocalTempDirectoryManager implements TempDirectoryManager {
     // clearing the entire directory would clear the personal /tmp/ directory
     // in the user's local filesystem.
     FileUtils.recursivelyClearDirectory(tempFolder.toPath());
-    // Also, clear the local storage directory where project sources and output is stored
-    FileUtils.recursivelyClearDirectory(LocalStorageUtils.getLocalStoragePath());
   }
 }


### PR DESCRIPTION
We had an issue where the local version of theater no longer worked because we cleared the folder containing theater output before the client had a change to fetch it. No longer clear that folder. We don't need to worry too much about this folder getting too big, because we almost always put files with the same 3 names in there, so those files will just get overwritten. If you test with a bunch of prompter images the folder could get bigger, but that is a pretty rare scenario and can be solved by the developer manually clearing the folder.