### PR TITLE
Console integration test

### DIFF
--- a/integration-tests/test/console.js
+++ b/integration-tests/test/console.js
@@ -18,12 +18,11 @@ describe("Console", () => {
       {type: "SYSTEM_OUT", value: "\n"},
       EXIT_STATUS_MESSAGE
     ];
-    const assertOnMessagesReceived = receivedMessages => {console.log(receivedMessages); assertMessagesEqual(receivedMessages, expectedMessages);}
+    const assertOnMessagesReceived = receivedMessages => assertMessagesEqual(receivedMessages, expectedMessages);
 
     let hasReceivedMessage, hasReceivedNewLineAfterMessage;
     const onMessageCallback = (parsedData, socket, allMessages) => {
-      // Confirm receipt of "What's your name" and new line messages back to back
-      // This logic is tightly coupled to the scanner sources.
+      // Confirm receipt of "What's your name" and new line messages back to back.
       if (parsedData.type === "SYSTEM_OUT" && parsedData.value === "What's your name?") {
         hasReceivedMessage = true;
       } else if (hasReceivedMessage && (parsedData.type === "SYSTEM_OUT" && parsedData.value === "\n")) {

--- a/integration-tests/test/console.js
+++ b/integration-tests/test/console.js
@@ -1,3 +1,48 @@
+import { scanner } from "./lib/sources.js";
+import { CONSOLE } from "./lib/MiniAppType.js";
+import {
+  INITIAL_STATUS_MESSAGES,
+  EXIT_STATUS_MESSAGE,
+  assertMessagesEqual,
+  verifyMessages
+} from "./helpers/testHelpers.js";
+
 describe("Console", () => {
-  // TODO
+  it("Runs simple interactive console project", (done) => {
+    const expectedMessages = [
+      ...INITIAL_STATUS_MESSAGES,
+      {type: "SYSTEM_OUT", value: "What's your name?"},
+      {type: "SYSTEM_OUT", value: "\n"},
+      {messageType: "SYSTEM_IN", message: "Ben"},
+      {type: "SYSTEM_OUT", value: "Hello Ben!"},
+      {type: "SYSTEM_OUT", value: "\n"},
+      EXIT_STATUS_MESSAGE
+    ];
+    const assertOnMessagesReceived = receivedMessages => {console.log(receivedMessages); assertMessagesEqual(receivedMessages, expectedMessages);}
+
+    let hasReceivedMessage, hasReceivedNewLineAfterMessage;
+    const onMessageCallback = (parsedData, socket, allMessages) => {
+      // Confirm receipt of "What's your name" and new line messages back to back
+      // This logic is tightly coupled to the scanner sources.
+      if (parsedData.type === "SYSTEM_OUT" && parsedData.value === "What's your name?") {
+        hasReceivedMessage = true;
+      } else if (hasReceivedMessage && (parsedData.type === "SYSTEM_OUT" && parsedData.value === "\n")) {
+        hasReceivedNewLineAfterMessage = true;
+      } else {
+        hasReceivedNewLineAfterMessage = false;
+        hasReceivedMessage = false;
+      }
+
+      if (hasReceivedMessage && hasReceivedNewLineAfterMessage) {
+        const message = {
+          messageType: "SYSTEM_IN",
+          message: "Ben"
+        };
+        socket.send(JSON.stringify(message));
+        allMessages.push(message);
+      }
+    };
+
+    verifyMessages(scanner, CONSOLE, assertOnMessagesReceived, done, onMessageCallback);
+  }).timeout(20000);
 });

--- a/integration-tests/test/console.js
+++ b/integration-tests/test/console.js
@@ -18,7 +18,7 @@ describe("Console", () => {
       {type: "SYSTEM_OUT", value: "\n"},
       EXIT_STATUS_MESSAGE
     ];
-    const assertOnMessagesReceived = receivedMessages => assertMessagesEqual(receivedMessages, expectedMessages);
+    const assertOnMessagesObserved = observedMessages => assertMessagesEqual(observedMessages, expectedMessages);
 
     let hasReceivedMessage, hasReceivedNewLineAfterMessage;
     const onMessageCallback = (parsedData, socket, allMessages) => {
@@ -42,6 +42,6 @@ describe("Console", () => {
       }
     };
 
-    verifyMessages(scanner, CONSOLE, assertOnMessagesReceived, done, onMessageCallback);
+    verifyMessages(scanner, CONSOLE, assertOnMessagesObserved, done, onMessageCallback);
   }).timeout(20000);
 });

--- a/integration-tests/test/helloWorld.js
+++ b/integration-tests/test/helloWorld.js
@@ -2,7 +2,7 @@ import { helloWorld } from "./lib/sources.js";
 import { NEIGHBORHOOD } from "./lib/MiniAppType.js";
 import {
   assertMessagesEqual,
-  verifyMessagesReceived,
+  verifyMessages,
   INITIAL_STATUS_MESSAGES,
   EXIT_STATUS_MESSAGE,
 } from "./helpers/testHelpers.js";
@@ -17,6 +17,6 @@ describe("Hello World", () => {
     ];
     const assertOnMessagesReceived = receivedMessages => assertMessagesEqual(receivedMessages, expectedMessages);
 
-    verifyMessagesReceived(helloWorld, NEIGHBORHOOD, assertOnMessagesReceived, done);
+    verifyMessages(helloWorld, NEIGHBORHOOD, assertOnMessagesReceived, done);
   }).timeout(20000);
 });

--- a/integration-tests/test/helpers/testHelpers.js
+++ b/integration-tests/test/helpers/testHelpers.js
@@ -2,7 +2,7 @@ import connectionHelper from "../lib/JavabuilderConnectionHelper.js";
 import {expect} from "chai";
 
 /**
- * Helper for verifying the basic case that set of messages was received
+ * Helper for verifying that a set of messages was received (and possibly sent)
  * from Javabuilder. Fails if there are any errors connecting.
  *
  * @param {*} sourcesJson sources (see sources.js)

--- a/integration-tests/test/helpers/testHelpers.js
+++ b/integration-tests/test/helpers/testHelpers.js
@@ -9,24 +9,32 @@ import {expect} from "chai";
  * @param {*} miniAppType mini-app type (see MiniAppType.js)
  * @param {*} assertOnMessagesReceived a verification callback to be called once all messages have been received
  * @param {*} doneCallback Mocha's 'done' callback
+ * @param {*} onMessageCallback a callback executed after each received message that can be used to respond to messages
  */
-export const verifyMessagesReceived = (
+export const verifyMessages = (
   sourcesJson,
   miniAppType,
   assertOnMessagesReceived,
-  doneCallback
+  doneCallback,
+  onMessageCallback
 ) => {
-  const receivedMessages = [];
+  const allMessages = [];
 
-  const onMessage = (event) => {
-    receivedMessages.push(JSON.parse(event.data));
-  };
+  const onMessage = (event, socket) => {
+    const parsedData = JSON.parse(event.data);
+    allMessages.push(parsedData);
+
+    if (onMessageCallback) {
+      onMessageCallback(parsedData, socket, allMessages);
+    }
+  }
+
   const onError = (error) => {
     doneCallback(new Error(error.message));
   };
   const onClose = (event) => {
     expect(event.wasClean).to.be.true;
-    assertOnMessagesReceived(receivedMessages);
+    assertOnMessagesReceived(allMessages);
     doneCallback();
   };
 

--- a/integration-tests/test/helpers/testHelpers.js
+++ b/integration-tests/test/helpers/testHelpers.js
@@ -7,14 +7,14 @@ import {expect} from "chai";
  *
  * @param {*} sourcesJson sources (see sources.js)
  * @param {*} miniAppType mini-app type (see MiniAppType.js)
- * @param {*} assertOnMessagesReceived a verification callback to be called once all messages have been received
+ * @param {*} assertOnMessagesObserved a verification callback to be called once all messages have been sent/received
  * @param {*} doneCallback Mocha's 'done' callback
  * @param {*} onMessageCallback a callback executed after each received message that can be used to respond to messages
  */
 export const verifyMessages = (
   sourcesJson,
   miniAppType,
-  assertOnMessagesReceived,
+  assertOnMessagesObserved,
   doneCallback,
   onMessageCallback
 ) => {
@@ -34,7 +34,7 @@ export const verifyMessages = (
   };
   const onClose = (event) => {
     expect(event.wasClean).to.be.true;
-    assertOnMessagesReceived(allMessages);
+    assertOnMessagesObserved(allMessages);
     doneCallback();
   };
 
@@ -45,15 +45,15 @@ export const verifyMessages = (
     });
 };
 
-export const assertMessagesEqual = (receivedMessages, expectedMessages, verifyDetailKey) => {
-  expect(receivedMessages.length).to.equal(expectedMessages.length);
+export const assertMessagesEqual = (observedMessages, expectedMessages, verifyDetailKey) => {
+  expect(observedMessages.length).to.equal(expectedMessages.length);
   expectedMessages.forEach((expectedMessage, index) => {
-    const receivedMessage = receivedMessages[index];
-    expect(receivedMessage.type).to.equal(expectedMessage.type);
-    expect(receivedMessage.value).to.equal(expectedMessage.value);
+    const observedMessage = observedMessages[index];
+    expect(observedMessage.type).to.equal(expectedMessage.type);
+    expect(observedMessage.value).to.equal(expectedMessage.value);
 
     if (verifyDetailKey && expectedMessage.detail) {
-      Object.keys(expectedMessage.detail).forEach(key => verifyDetailKey(key, receivedMessage, expectedMessage));
+      Object.keys(expectedMessage.detail).forEach(key => verifyDetailKey(key, observedMessage, expectedMessage));
     }
   });
 };

--- a/integration-tests/test/lib/JavabuilderConnectionHelper.js
+++ b/integration-tests/test/lib/JavabuilderConnectionHelper.js
@@ -57,8 +57,10 @@ class JavabuilderConnectionHelper {
       onOpen();
     };
 
+    const onMessageWrapper = event => onMessage(event, socket);
+
     socket.onopen = logOnOpen;
-    socket.onmessage = onMessage;
+    socket.onmessage = onMessageWrapper;
     socket.onclose = onClose;
     socket.onerror = onError;
   }

--- a/integration-tests/test/lib/sources.js
+++ b/integration-tests/test/lib/sources.js
@@ -16,6 +16,13 @@ export const neighborhood = JSON.stringify({
   "assetUrls":{}
 });
 
+export const scanner = JSON.stringify({
+  sources: {
+    "main.json":
+      '{"source":{"MyScanner.java":{"text":"import java.util.Scanner;\\n\\npublic class MyScanner {\\n  public static void main(String[] args) {\\n    Scanner myScanner = new Scanner(System.in);\\n    System.out.println(\\"What\'s your name?\\");\\n    String response = myScanner.nextLine();\\n    System.out.println(\\"Hello \\" + response + \\"!\\");\\n  }\\n}\\n","isVisible":true}},"animations":{}}'
+  }
+});
+
 export const theaterImageAndText = JSON.stringify({
   sources: {
     "main.json":

--- a/integration-tests/test/neighborhood.js
+++ b/integration-tests/test/neighborhood.js
@@ -4,7 +4,7 @@ import {
   INITIAL_STATUS_MESSAGES,
   EXIT_STATUS_MESSAGE,
   assertMessagesEqual,
-  verifyMessagesReceived
+  verifyMessages
 } from "./helpers/testHelpers.js";
 import {expect} from "chai";
 
@@ -51,6 +51,6 @@ describe("Neighborhood", () => {
       assertMessagesEqual(receivedMessages, expectedMessages, verifyDetailKey);
     };
 
-    verifyMessagesReceived(neighborhood, NEIGHBORHOOD, assertOnMessagesReceived, done);
+    verifyMessages(neighborhood, NEIGHBORHOOD, assertOnMessagesReceived, done);
   }).timeout(20000);
 });

--- a/integration-tests/test/theater.js
+++ b/integration-tests/test/theater.js
@@ -4,7 +4,7 @@ import {
   INITIAL_STATUS_MESSAGES,
   EXIT_STATUS_MESSAGE,
   assertMessagesEqual,
-  verifyMessagesReceived
+  verifyMessages
 } from "./helpers/testHelpers.js";
 import {JAVABUILDER_BASE_DOMAIN, JAVABUILDER_SUB_DOMAIN} from "./lib/environment.js";
 import { expect } from "chai";
@@ -37,7 +37,7 @@ describe("Theater", () => {
       assertMessagesEqual(receivedMessages, expectedMessages, verifyDetailKey);
     }
 
-    verifyMessagesReceived(theaterImageAndText, THEATER, assertOnMessagesReceived, done);
+    verifyMessages(theaterImageAndText, THEATER, assertOnMessagesReceived, done);
   }).timeout(20000);
 });
 


### PR DESCRIPTION
Add an integration test for console projects, where the program asks a user's name. Adds new logic to allow for sending of messages (or doing anything) in response to messages received from Javabuilder in integration tests.