### PR TITLE
Handle output adapter exceptions in lambda handler

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -284,8 +284,11 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
   private void sendOutputMessage(OutputAdapter outputAdapter, ClientMessage message) {
     try {
       outputAdapter.sendMessage(message);
-    } catch (Exception e) {
+    } catch (InternalServerRuntimeException e) {
       // This likely means the connection has been lost. Log a warning.
+      Logger.getLogger(MAIN_LOGGER).warning(e.getLoggingString());
+    } catch (Exception e) {
+      // Catch any other exceptions here to prevent them from propogating.
       Logger.getLogger(MAIN_LOGGER).warning(e.getMessage());
     }
   }


### PR DESCRIPTION
Adds some logic to the lambda handler to prevent uncaught exceptions from being thrown when we try to send messages to a dead connection. This should ideally fix some of the connection terminated errors we've been seeing.

Tested using dev lambda