### PR TITLE
Add integration tests for error states

### DIFF
--- a/integration-tests/test/errors.js
+++ b/integration-tests/test/errors.js
@@ -61,8 +61,7 @@ describe("Errors", () => {
     verifyMessages(blockedClassError, CONSOLE, assertOnMessagesReceived, done);
   }).timeout(20000);
 
-  it("Does not have valid token", async () => {
-    // We don't appear to get any more detail than a 500 response when an invalid token is provided.
+  it("Does not accept malformed token", async () => {
     const httpResponse = await uploadSources(blankProject, 'aBadToken');
     expect(httpResponse.status).to.equal(500);
   }).timeout(2000);

--- a/integration-tests/test/errors.js
+++ b/integration-tests/test/errors.js
@@ -8,7 +8,7 @@ import {
   EXIT_STATUS_MESSAGE,
 } from "./helpers/testHelpers.js";
 import {expect} from "chai";
-import connectionHelper from "./lib/JavabuilderConnectionHelper.js";
+import {uploadSources} from "./lib/JavabuilderConnectionHelper.js";
 
 describe("Errors", () => {
   it("Compilation Error", (done) => {
@@ -61,13 +61,11 @@ describe("Errors", () => {
     verifyMessages(blockedClassError, CONSOLE, assertOnMessagesReceived, done);
   }).timeout(20000);
 
-  it("Does not have valid token", (done) => {
+  it("Does not have valid token", async () => {
     // We don't appear to get any more detail than a 500 response when an invalid token is provided.
-    const confirmErrorResponse = httpResponse => expect(httpResponse.status).to.equal(500);
-    connectionHelper
-      .connect(blankProject, CONSOLE, () => {}, () => {}, () => {}, () => {}, () => 'fakeToken', confirmErrorResponse)
-      .finally(done)
-  }).timeout(20000);
+    const httpResponse = await uploadSources(blankProject, 'aBadToken');
+    expect(httpResponse.status).to.equal(500);
+  }).timeout(2000);
 });
 
 const validateExceptionDetailKey = (key, receivedMessage, expectedMessage) => {

--- a/integration-tests/test/errors.js
+++ b/integration-tests/test/errors.js
@@ -1,0 +1,82 @@
+import {blockedClassError, compilationError, theaterRuntimeFileNotFound, blankProject} from "./lib/sources.js";
+import {CONSOLE, THEATER} from "./lib/MiniAppType.js";
+import {
+  assertMessagesEqual,
+  verifyMessages,
+  COMPILING_STATUS_MESSAGE,
+  INITIAL_STATUS_MESSAGES,
+  EXIT_STATUS_MESSAGE,
+} from "./helpers/testHelpers.js";
+import {expect} from "chai";
+import connectionHelper from "./lib/JavabuilderConnectionHelper.js";
+
+describe("Errors", () => {
+  it("Compilation Error", (done) => {
+    const expectedMessages = [
+      COMPILING_STATUS_MESSAGE,
+      { type: "SYSTEM_OUT", value: "/HelloWorld.java:1: error: reached end of file while parsing\npublic class HelloWorld {\n                         ^\n" },
+      { type: "EXCEPTION", value: "COMPILER_ERROR" },
+      EXIT_STATUS_MESSAGE
+    ];
+
+    const assertOnMessagesReceived = receivedMessages => assertMessagesEqual(receivedMessages, expectedMessages);
+    verifyMessages(compilationError, CONSOLE, assertOnMessagesReceived, done);
+  }).timeout(20000);
+
+  it("Runtime Error", (done) => {
+    const expectedMessages = [
+      ...INITIAL_STATUS_MESSAGES,
+      {
+        type: "EXCEPTION",
+        value: "FILE_NOT_FOUND",
+        detail: {
+          causeMessage: "dog.jpeg",
+          cause: "Exception message: java.io.FileNotFoundException: dog.jpeg",
+          fallbackMessage: "Exception message: java.io.FileNotFoundException: dog.jpeg"
+        }
+      },
+      EXIT_STATUS_MESSAGE
+    ];
+
+    const assertOnMessagesReceived = receivedMessages => assertMessagesEqual(receivedMessages, expectedMessages, validateExceptionDetailKey);
+    verifyMessages(theaterRuntimeFileNotFound, THEATER, assertOnMessagesReceived, done);
+  }).timeout(20000);
+
+  it("Uses blocked classes", (done) => {
+    const expectedMessages = [
+      ...INITIAL_STATUS_MESSAGES,
+      {
+        type: "EXCEPTION",
+        value: "INVALID_CLASS",
+        detail: {
+          causeMessage: "java.lang.Thread",
+          cause: "Exception message: java.lang.ClassNotFoundException: java.lang.Thread",
+          fallbackMessage: "Exception message: java.lang.ClassNotFoundException: java.lang.Thread"
+        }
+      },
+      EXIT_STATUS_MESSAGE
+    ];
+
+    const assertOnMessagesReceived = receivedMessages => assertMessagesEqual(receivedMessages, expectedMessages, validateExceptionDetailKey);
+    verifyMessages(blockedClassError, CONSOLE, assertOnMessagesReceived, done);
+  }).timeout(20000);
+
+  it("Does not have valid token", (done) => {
+    // We don't appear to get any more detail than a 500 response when an invalid token is provided.
+    const confirmErrorResponse = httpResponse => expect(httpResponse.status).to.equal(500);
+    connectionHelper
+      .connect(blankProject, CONSOLE, () => {}, () => {}, () => {}, () => {}, () => 'fakeToken', confirmErrorResponse)
+      .finally(done)
+  }).timeout(20000);
+});
+
+const validateExceptionDetailKey = (key, receivedMessage, expectedMessage) => {
+  if (key === "causeMessage") {
+    expect(receivedMessage.detail.causeMessage).to.equal(expectedMessage.detail.causeMessage);
+  } else if (['cause', 'fallbackMessage'].includes(key)) {
+    const receivedErrorMessageFirstLine = receivedMessage.detail[key].split("\n")[0];
+    expect(receivedErrorMessageFirstLine).to.equal(expectedMessage.detail[key]);
+  } else {
+    throw new Error(`Unexpected detail key ${key}`);
+  }
+}

--- a/integration-tests/test/helpers/testHelpers.js
+++ b/integration-tests/test/helpers/testHelpers.js
@@ -40,9 +40,7 @@ export const verifyMessages = (
 
   connectionHelper
     .connect(sourcesJson, miniAppType, () => {}, onMessage, onError, onClose)
-    .catch((err) => {
-      doneCallback(err);
-    });
+    .catch(doneCallback);
 };
 
 export const assertMessagesEqual = (observedMessages, expectedMessages, verifyDetailKey) => {
@@ -58,8 +56,10 @@ export const assertMessagesEqual = (observedMessages, expectedMessages, verifyDe
   });
 };
 
+export const COMPILING_STATUS_MESSAGE = {type: "STATUS", value: "COMPILING"};
+
 export const INITIAL_STATUS_MESSAGES = [
-  {type: "STATUS", value: "COMPILING"},
+  COMPILING_STATUS_MESSAGE,
   {type: "STATUS", value: "COMPILATION_SUCCESSFUL"},
   {type: "STATUS", value: "RUNNING"}
 ];

--- a/integration-tests/test/lib/sources.js
+++ b/integration-tests/test/lib/sources.js
@@ -1,3 +1,8 @@
+const theaterImageAndTextSources = {
+  "main.json":
+    '{"source":{"MyTheater.java":{"text":"import org.code.theater.Theater;\\nimport org.code.theater.Scene;\\nimport org.code.media.Image;\\nimport java.io.FileNotFoundException;\\n\\npublic class MyTheater {\\n  public static void main(String[] args) throws Exception {\\n    Theater.playScenes(createScene());\\n  }\\n\\n  public static Scene createScene() throws FileNotFoundException {\\n    Scene scene = new Scene();\\n    Image image = new Image(\\"dog.jpeg\\");\\n    scene.drawImage(image, 0, 0, 400);\\n    scene.drawText(\\"Hello World\\", 100, 100);\\n    double[] sound = {1.0, 0.0, 1.0, 0.0};\\n    scene.playSound(sound);\\n\\n    return scene;\\n  }\\n}","isVisible":true}},"animations":{}}'
+};
+
 export const helloWorld = JSON.stringify({
   sources: {
     "main.json":
@@ -24,9 +29,33 @@ export const scanner = JSON.stringify({
 });
 
 export const theaterImageAndText = JSON.stringify({
+  sources: theaterImageAndTextSources,
+  assetUrls: {"dog.jpeg": 'https://studio.code.org/v3/assets/123456/dog.jpeg'}
+});
+
+export const theaterRuntimeFileNotFound = JSON.stringify({
+  sources: theaterImageAndTextSources,
+  assetUrls: {"unknownCatImage.jpeg": 'https://studio.code.org/v3/assets/123456/unknownCatImage.jpeg'}
+});
+
+export const compilationError = JSON.stringify({
   sources: {
     "main.json":
-      '{"source":{"MyTheater.java":{"text":"import org.code.theater.Theater;\\nimport org.code.theater.Scene;\\nimport org.code.media.Image;\\nimport java.io.FileNotFoundException;\\n\\npublic class MyTheater {\\n  public static void main(String[] args) throws Exception {\\n    Theater.playScenes(createScene());\\n  }\\n\\n  public static Scene createScene() throws FileNotFoundException {\\n    Scene scene = new Scene();\\n    Image image = new Image(\\"dog.jpeg\\");\\n    scene.drawImage(image, 0, 0, 400);\\n    scene.drawText(\\"Hello World\\", 100, 100);\\n    double[] sound = {1.0, 0.0, 1.0, 0.0};\\n    scene.playSound(sound);\\n\\n    return scene;\\n  }\\n}","isVisible":true}},"animations":{}}'
+      '{"source":{"HelloWorld.java":{"text":"public class HelloWorld {","isVisible":true}},"animations":{}}'
   },
-  assetUrls: {"dog.jpeg": 'https://studio.code.org/v3/assets/123456/dog.jpeg'}
+  assetUrls: {}
+});
+
+export const blockedClassError = JSON.stringify({
+  sources: {
+    "main.json":
+      '{"source":{"HelloWorld.java":{"text":"import java.lang.Thread;\\npublic class HelloWorld {\\n  public static void main(String[] args) {\\n    Thread thread = new Thread();\\n  }\\n}","isVisible":true}},"animations":{}}'
+  }
+});
+
+export const blankProject = JSON.stringify({
+  sources: {
+    "main.json":
+      '{"source":{"MyClass.java":{"text":"","isVisible":true}},"animations":{}}'
+  }
 });


### PR DESCRIPTION
Adds new integration states to cover:
- compilation error
- use of an unsupported class
- use of an invalid token
- runtime error (trying to use an image that has not been uploaded)

Admittedly a lot of callbacks being passed around as I've been working through this, open to thoughts on whether there's any restructuring that might make this easier to read going forward!