### PR TITLE
Don't destroy metrics client

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -257,8 +257,6 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
    * added here can be run more than once without negative effect.
    */
   private void cleanUpResources(String connectionId, AmazonApiGatewayManagementApi api) {
-    // delete the metric client manager if it exists
-    MetricClientManager.destroy();
     final DeleteConnectionRequest deleteConnectionRequest =
         new DeleteConnectionRequest().withConnectionId(connectionId);
     // Deleting the API Gateway connection should always be the last thing executed because the

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/MetricClientManager.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/MetricClientManager.java
@@ -22,10 +22,6 @@ public class MetricClientManager {
     return MetricClientManager.clientManagerInstance;
   }
 
-  public static void destroy() {
-    MetricClientManager.clientManagerInstance = null;
-  }
-
   public MetricClient getMetricClient() {
     return this.metricClient;
   }


### PR DESCRIPTION
We hit an issue where we were trying to use a metrics client that had already been destroyed. This happened when we trigger an early exit, because we do the cleanup without waiting for the exit to complete (which send performance metrics) I considered moving the metrics client destroy to `onPostExecute` but that could still cause an issue because we can catch and log a severe error thrown from `onPostExecute`, which will in turn try to log a metric.

To solve this, we no longer destroy the Metrics Client. It's ok for this to persist between runs, as we replace it on each run of the lambda and I believe we could potentially reuse it without issue, as we are always writing to the same cloudwatch account.

To follow up we should investigate if the metrics client should be reused between iterations instead of always creating a new one, but this will solve our immediate problem of noisy logs and missing some data.