### PR TITLE
Allow CloudWatch record creation from authorizers

### DIFF
--- a/iam.yml
+++ b/iam.yml
@@ -133,6 +133,12 @@ Resources:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_teacher_associated_requests"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_tokens"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_user_requests"
+              # Allow monitoring of throttling in CloudWatch.
+              - Effect: Allow
+                Action:
+                  - 'cloudwatch:PutMetricData'
+                Resource:
+                  - '*'
 
   # Permissions for the lambda that uploads student code to S3
   PutSourcesLambdaRole:


### PR DESCRIPTION
Same as build and run lambda, allow authorizer lambdas to write to CloudWatch.

## Testing story

Deployed this change to our dev account, and was able to write to CloudWatch (was not able to write to CloudWatch before this change).