### PR TITLE
Add performance alarms

### DIFF
--- a/template.yml.erb
+++ b/template.yml.erb
@@ -683,7 +683,6 @@ Resources:
       AlarmActions:
         - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-slow-performance"]
       InsufficientDataActions: []
-      Dimensions: []
       EvaluationPeriods: 15
       DatapointsToAlarm: 15
       ComparisonOperator: GreaterThanUpperThreshold
@@ -717,7 +716,6 @@ Resources:
       AlarmActions:
         - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-slow-performance"]
       InsufficientDataActions: []
-      Dimensions: []
       EvaluationPeriods: 15
       DatapointsToAlarm: 15
       ComparisonOperator: GreaterThanUpperThreshold
@@ -751,7 +749,6 @@ Resources:
       AlarmActions:
         - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-slow-performance"]
       InsufficientDataActions: []
-      Dimensions: []
       EvaluationPeriods: 15
       DatapointsToAlarm: 15
       ComparisonOperator: GreaterThanUpperThreshold
@@ -785,7 +782,6 @@ Resources:
         AlarmActions:
           - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-slow-performance"]
         InsufficientDataActions: []
-        Dimensions: []
         EvaluationPeriods: 15
         DatapointsToAlarm: 15
         ComparisonOperator: GreaterThanUpperThreshold

--- a/template.yml.erb
+++ b/template.yml.erb
@@ -676,16 +676,18 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${SubDomainName}_<%=name.downcase%>_slow_cleanup_time"
+      AlarmDescription: p(95) cleanup time in Javabuilder's <%=name%> build and run lambda exceeded
+        the normal cleanup time for 15 minutes. Investigate if there has been a performance regression.
       ActionsEnabled: true
       OKActions: []
       AlarmActions:
         - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-slow-performance"]
       InsufficientDataActions: []
       Dimensions: []
-      EvaluationPeriods: 20
+      EvaluationPeriods: 15
       DatapointsToAlarm: 15
       ComparisonOperator: GreaterThanUpperThreshold
-      TreatMissingData: notBreaching
+      TreatMissingData: ignore
       Metrics:
           - Id: m1
             ReturnData: true
@@ -697,12 +699,114 @@ Resources:
                         - Name: functionName
                           Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
                 Period: 60
-                Stat: Average
+                Stat: p95
           - Id: ad1
             Label: CleanupTime (expected)
             ReturnData: true
             Expression: ANOMALY_DETECTION_BAND(m1, 5)
       ThresholdMetricId: ad1
+  
+  <%=name%>SlowColdBootTimeAlarm:    
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${SubDomainName}_<%=name.downcase%>_slow_cold_boot_time"
+      AlarmDescription: p(95) cold boot time in Javabuilder's <%=name%> build and run lambda exceeded
+        the normal cleanup time for 15 minutes. Investigate if there has been a performance regression.
+      ActionsEnabled: true
+      OKActions: []
+      AlarmActions:
+        - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-slow-performance"]
+      InsufficientDataActions: []
+      Dimensions: []
+      EvaluationPeriods: 15
+      DatapointsToAlarm: 15
+      ComparisonOperator: GreaterThanUpperThreshold
+      TreatMissingData: ignore
+      Metrics:
+          - Id: m1
+            ReturnData: true
+            MetricStat:
+                Metric:
+                    Namespace: Javabuilder
+                    MetricName: ColdBootTime
+                    Dimensions:
+                        - Name: functionName
+                          Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
+                Period: 60
+                Stat: p95
+          - Id: ad1
+            Label: ColdBootTime (expected)
+            ReturnData: true
+            Expression: ANOMALY_DETECTION_BAND(m1, 2)
+      ThresholdMetricId: ad1
+
+  <%=name%>SlowInitializationTimeAlarm:    
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${SubDomainName}_<%=name.downcase%>_slow_initialization_time"
+      AlarmDescription: p(95) initialization time in Javabuilder's <%=name%> build and run lambda exceeded
+        the normal cleanup time for 15 minutes. Investigate if there has been a performance regression.
+      ActionsEnabled: true
+      OKActions: []
+      AlarmActions:
+        - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-slow-performance"]
+      InsufficientDataActions: []
+      Dimensions: []
+      EvaluationPeriods: 15
+      DatapointsToAlarm: 15
+      ComparisonOperator: GreaterThanUpperThreshold
+      TreatMissingData: ignore
+      Metrics:
+          - Id: m1
+            ReturnData: true
+            MetricStat:
+                Metric:
+                    Namespace: Javabuilder
+                    MetricName: InitializationTime
+                    Dimensions:
+                        - Name: functionName
+                          Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
+                Period: 60
+                Stat: p95
+          - Id: ad1
+            Label: InitializationTime (expected)
+            ReturnData: true
+            Expression: ANOMALY_DETECTION_BAND(m1, 5)
+      ThresholdMetricId: ad1
+  
+  <%=name%>SlowTransitionTimeAlarm:    
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+        AlarmName: !Sub "${SubDomainName}_<%=name.downcase%>_slow_transition_time"
+        AlarmDescription: p(95) transition time in Javabuilder's <%=name%> build and run lambda exceeded
+          the normal cleanup time for 15 minutes. Investigate if there has been a performance regression.
+        ActionsEnabled: true
+        OKActions: []
+        AlarmActions:
+          - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-slow-performance"]
+        InsufficientDataActions: []
+        Dimensions: []
+        EvaluationPeriods: 15
+        DatapointsToAlarm: 15
+        ComparisonOperator: GreaterThanUpperThreshold
+        TreatMissingData: missing
+        Metrics:
+            - Id: m1
+              ReturnData: true
+              MetricStat:
+                  Metric:
+                      Namespace: Javabuilder
+                      MetricName: TransitionTime
+                      Dimensions:
+                          - Name: functionName
+                            Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
+                  Period: 60
+                  Stat: p95
+            - Id: ad1
+              Label: TransitionTime (expected)
+              ReturnData: true
+              Expression: ANOMALY_DETECTION_BAND(m1, 3)
+        ThresholdMetricId: ad1
 
 <%end -%>
 

--- a/template.yml.erb
+++ b/template.yml.erb
@@ -671,6 +671,39 @@ Resources:
                           Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
                 Period: 300
                 Stat: Sum
+
+  <%=name%>SlowCleanupTimeAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${SubDomainName}_<%=name.downcase%>_slow_cleanup_time"
+      ActionsEnabled: true
+      OKActions: []
+      AlarmActions:
+        - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-slow-performance"]
+      InsufficientDataActions: []
+      Dimensions: []
+      EvaluationPeriods: 20
+      DatapointsToAlarm: 15
+      ComparisonOperator: GreaterThanUpperThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+          - Id: m1
+            ReturnData: true
+            MetricStat:
+                Metric:
+                    Namespace: Javabuilder
+                    MetricName: CleanupTime
+                    Dimensions:
+                        - Name: functionName
+                          Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
+                Period: 60
+                Stat: Average
+          - Id: ad1
+            Label: CleanupTime (expected)
+            ReturnData: true
+            Expression: ANOMALY_DETECTION_BAND(m1, 5)
+      ThresholdMetricId: ad1
+
 <%end -%>
 
 # We use shortened versions of names for partition keys (eg, user_id),


### PR DESCRIPTION
Add alarms when we see slow performance on the build and run lambda for
- cold boot time
- initialization time
- transition time
- cleanup time

These alarms are all set up as anomaly detection for two reasons. Mainly because different lambda configurations create different performance benchmarks (namely theater, which has a higher memory size). In addition, anomaly detection gives a more accurate representation of what our expected performance is than I could get by manually looking at the data.

The alarms are very similar but I split them up individually instead of creating them via an array because we may want to tune the alarms individually. The general configuration is:
- the metric value is set to p(95) for each minute
- the threshold is greater than the anomaly band. Each anomaly band has a width--this is the `5` in `ANOMALY_DETECTION_BAND(m1, 5)`. I gave a wider band to spikier metrics and vice versa, but these may need to be tuned.
- we alarm if we hit 15 out of 15 minutes of poor performance. If we don't see a minute of data we ignore that minute, so if we saw 13 minutes of poor performance and 2 of no data we would still alert.
- The alarms will go to #ap-csa-dev. 