### PR TITLE
Add isFacing<Direction> methods to painter

### DIFF
--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
@@ -175,23 +175,55 @@ public class Painter {
   }
 
   /** @return True if facing North */
-  public boolean facingNorth() {
+  public boolean isFacingNorth() {
     return this.direction.isNorth();
   }
 
   /** @return True if facing East */
-  public boolean facingEast() {
+  public boolean isFacingEast() {
     return this.direction.isEast();
   }
 
   /** @return True if facing South */
-  public boolean facingSouth() {
+  public boolean isFacingSouth() {
     return this.direction.isSouth();
   }
 
   /** @return True if facing West */
-  public boolean facingWest() {
+  public boolean isFacingWest() {
     return this.direction.isWest();
+  }
+
+  /**
+   * @deprecated use {@link Painter#isFacingNorth()}
+   * @return True if facing North
+   */
+  public boolean facingNorth() {
+    return this.isFacingNorth();
+  }
+
+  /**
+   * @deprecated use {@link Painter#isFacingEast()}
+   * @return True if facing East
+   */
+  public boolean facingEast() {
+    return this.isFacingEast();
+  }
+
+  /**
+   * @deprecated use {@link Painter#isFacingSouth()}
+   * @return True if facing South
+   */
+  public boolean facingSouth() {
+    return this.isFacingSouth();
+  }
+
+  /**
+   * @deprecated use {@link Painter#isFacingWest()}
+   * @return True if facing West
+   */
+  public boolean facingWest() {
+    return this.isFacingWest();
   }
 
   /** @return the x coordinate of the painter's current position */

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
@@ -38,7 +38,7 @@ public class PainterTest {
   void defaultConstructorMakesPainterWithNoPaintFacingEast() {
     Painter p = new Painter();
     assertEquals(p.getMyPaint(), 0);
-    assertTrue(p.facingEast());
+    assertTrue(p.isFacingEast());
   }
 
   @Test


### PR DESCRIPTION
Ask from curriculum - adds `isFacing<Direction>` methods to Painter to conform to conventions around using be-naming for boolean accessors. This keeps the original methods around but with `@deprecated` tags to avoid breaking existing student projects.

https://codedotorg.atlassian.net/browse/JAVA-612

Tested locally.