### PR TITLE
Add high websocket connection alarm

### DIFF
--- a/template.yml.erb
+++ b/template.yml.erb
@@ -587,6 +587,37 @@ Resources:
               Period: 60
               Stat: Maximum
 <%end -%>
+
+  HighWebsocketConnectionsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${SubDomainName}_high_websocket_connections"
+      AlarmDescription: Significantly higher websocket connections than normal detected. Investigate if there is a DDOS.
+      ActionsEnabled: false
+      EvaluationPeriods: 20
+      DatapointsToAlarm: 20
+      ComparisonOperator: GreaterThanUpperThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+          - Id: m1
+            ReturnData: true
+            MetricStat:
+                Metric:
+                    Namespace: AWS/ApiGateway
+                    MetricName: ConnectCount
+                    Dimensions:
+                        - Name: Stage
+                          Value: !Sub "${StageName}"
+                        - Name: ApiId
+                          Value: !Ref WebSocketAPI
+                Period: 60
+                Stat: Sum
+          - Id: ad1
+            Label: ConnectCount (expected)
+            ReturnData: true
+            Expression: ANOMALY_DETECTION_BAND(m1, 8)
+      ThresholdMetricId: ad1
+
 <%JAVALAB_APP_TYPES.each do | name | -%>
 
   <%=name%>HighSevereErrorRateAlarm:


### PR DESCRIPTION
Add an alarm when we see significantly higher websocket connections than normal, using AWS anomaly detection. I made the band pretty wide since we expect a lot of spikiness in this metric.

This alarm is silent, as it will be used as part of a composite alarm soon. See [this slack message](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1653501758703379) for details.