### PR TITLE
Add alarm for high HTTP requests

### DIFF
--- a/template.yml.erb
+++ b/template.yml.erb
@@ -628,7 +628,6 @@ Resources:
         OKActions: []
         AlarmActions: []
         InsufficientDataActions: []
-        Dimensions: []
         EvaluationPeriods: 20
         DatapointsToAlarm: 20
         ComparisonOperator: GreaterThanUpperThreshold

--- a/template.yml.erb
+++ b/template.yml.erb
@@ -618,6 +618,39 @@ Resources:
             Expression: ANOMALY_DETECTION_BAND(m1, 8)
       ThresholdMetricId: ad1
 
+  HighHttpRequestsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+        AlarmName: !Sub "${SubDomainName}_high_http_requests"
+        AlarmDescription: Significantly higher HTTP requests than normal detected.
+            Investigate if there is a DDOS.
+        ActionsEnabled: true
+        OKActions: []
+        AlarmActions: []
+        InsufficientDataActions: []
+        Dimensions: []
+        EvaluationPeriods: 20
+        DatapointsToAlarm: 20
+        ComparisonOperator: GreaterThanUpperThreshold
+        TreatMissingData: notBreaching
+        Metrics:
+            - Id: m1
+              ReturnData: true
+              MetricStat:
+                  Metric:
+                      Namespace: AWS/ApiGateway
+                      MetricName: Count
+                      Dimensions:
+                          - Name: ApiId
+                            Value: !Ref HttpAPI
+                  Period: 60
+                  Stat: Sum
+            - Id: ad1
+              Label: Count (expected)
+              ReturnData: true
+              Expression: ANOMALY_DETECTION_BAND(m1, 8)
+        ThresholdMetricId: ad1
+
 <%JAVALAB_APP_TYPES.each do | name | -%>
 
   <%=name%>HighSevereErrorRateAlarm:


### PR DESCRIPTION
Adds an alarm for the default HTTP request count CloudWatch metric. Uses same configuration as the websocket alarm -- not configured to notify even if threshold is breached.

## Testing story

I build the metric manually in the AWS web console (in our production account), copied the config and made some slight updates to reference the correct API ID, etc. I was able to deploy it to my dev deploy. I just deleted the prod alarm to avoid conflicts with an existing resource.