### PR TITLE
Add authorizer alarms/alerts to cloudformation template

### DIFF
--- a/template.yml.erb
+++ b/template.yml.erb
@@ -947,6 +947,151 @@ Resources:
       TimeToLiveSpecification:
         AttributeName: <%=TIME_TO_LIVE_ATTRIBUTE_NAME%>
         Enabled: true
+
+  HighUsersBlockedAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+        AlarmName: !Sub "${SubDomainName}_high_users_blocked"
+        AlarmDescription: Unusually high number of users being blocked by our throttling
+            thresholds.
+        ActionsEnabled: true
+        OKActions: []
+        AlarmActions:
+          - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-high-throttling"]
+        InsufficientDataActions: []
+        MetricName: UserBlocked
+        Namespace: Javabuilder
+        Statistic: Sum
+        Dimensions:
+            - Name: functionName
+              Value: !Ref HttpAuthorizerLambda
+        Period: 60
+        EvaluationPeriods: 1
+        DatapointsToAlarm: 1
+        Threshold: 100
+        ComparisonOperator: GreaterThanThreshold
+        TreatMissingData: notBreaching
+
+  HighClassroomsBlockedAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+        AlarmName: !Sub "${SubDomainName}_high_classrooms_blocked"
+        AlarmDescription: Unusually high number of classrooms being blocked by our throttling
+            thresholds.
+        ActionsEnabled: true
+        OKActions: []
+        AlarmActions:
+          - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-high-throttling"]
+        InsufficientDataActions: []
+        MetricName: ClassroomBlocked
+        Namespace: Javabuilder
+        Statistic: Sum
+        Dimensions:
+            - Name: functionName
+              Value: !Ref HttpAuthorizerLambda
+        Period: 60
+        EvaluationPeriods: 1
+        DatapointsToAlarm: 1
+        Threshold: 10
+        ComparisonOperator: GreaterThanThreshold
+        TreatMissingData: notBreaching
+
+  HighUnknownTokensAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+        AlarmName: !Sub "${SubDomainName}_high_unknown_tokens"
+        AlarmDescription: Websocket authorizer is receiving connection requests using
+            tokens that did not pass through the HTTP authorizer first.
+        ActionsEnabled: true
+        OKActions: []
+        AlarmActions:
+          - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-high-token-errors"]
+        InsufficientDataActions: []
+        MetricName: TokenUnknownId
+        Namespace: Javabuilder
+        Statistic: Sum
+        Dimensions:
+            - Name: functionName
+              Value: !Ref WebsocketAuthorizerLambda
+        Period: 60
+        EvaluationPeriods: 1
+        DatapointsToAlarm: 1
+        Threshold: 100
+        ComparisonOperator: GreaterThanThreshold
+        TreatMissingData: notBreaching
+
+  HighUnvettedTokensAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+        AlarmName: !Sub "${SubDomainName}_high_unvetted_tokens"
+        AlarmDescription: Websocket authorizer is receiving connection requests using
+            tokens that were observed but not vetted as valid by the HTTP authorizer.
+        ActionsEnabled: true
+        OKActions: []
+        AlarmActions:
+          - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-high-token-errors"]
+        InsufficientDataActions: []
+        MetricName: TokenNotVetted
+        Namespace: Javabuilder
+        Statistic: Sum
+        Dimensions:
+            - Name: functionName
+              Value: !Ref WebsocketAuthorizerLambda
+        Period: 60
+        EvaluationPeriods: 1
+        DatapointsToAlarm: 1
+        Threshold: 100
+        ComparisonOperator: GreaterThanThreshold
+        TreatMissingData: notBreaching
+
+  WebsocketHighUsedTokensAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+        AlarmName: !Sub "${SubDomainName}_websocket_high_used_tokens"
+        AlarmDescription: Websocket authorizer is receiving connection requests using
+            tokens have already been used.
+        ActionsEnabled: true
+        OKActions: []
+        AlarmActions:
+          - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-high-token-errors"]
+        InsufficientDataActions: []
+        MetricName: TokenUsed
+        Namespace: Javabuilder
+        Statistic: Sum
+        Dimensions:
+            - Name: functionName
+              Value: !Ref WebsocketAuthorizerLambda
+        Period: 60
+        EvaluationPeriods: 1
+        DatapointsToAlarm: 1
+        Threshold: 100
+        ComparisonOperator: GreaterThanThreshold
+        TreatMissingData: notBreaching
+
+  HttpHighUsedTokensAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+        AlarmName: !Sub "${SubDomainName}_http_high_used_tokens"
+        AlarmDescription: HTTP authorizer is receiving connection requests using
+            tokens have already been used.
+        ActionsEnabled: true
+        OKActions: []
+        AlarmActions:
+          - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-high-token-errors"]
+        InsufficientDataActions: []
+        MetricName: TokenUsed
+        Namespace: Javabuilder
+        Statistic: Sum
+        Dimensions:
+            - Name: functionName
+              Value: !Ref HttpAuthorizerLambda
+        Period: 60
+        EvaluationPeriods: 1
+        DatapointsToAlarm: 1
+        Threshold: 100
+        ComparisonOperator: GreaterThanThreshold
+        TreatMissingData: notBreaching
+
 Outputs:
   JavabuilderURL:
     Value:


### PR DESCRIPTION
Adds new alarms in our authorizers for:

**HTTP authorizer**
- Classrooms blocked
- Individual users blocked
- Used token

**WebSocket authorizer**
- Unknown token
- Unvetted token
- Used token (produces the same metric name as a used token identified in HTTP authorizer, but having a different dimension (the function ID) makes it a different metric

Manually set up these metrics to report to ap-csa-dev when observed, either under the topic of `javabuilder-high-throttling` or `javabuilder-high-token-errors`. More detail on the manual setup [in this Slack thread](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1653605520749359).

The values are totally arbitrary, since we have no data for any of these metrics. I thought having a user-level throttling threshold that is an order of magnitude higher than our classroom-level threshold made sense, but I'm not sure what the right values are (or if we should look at wider than a one minute window).

## Testing story

The cloudformation config here is a bit of a frankenstein -- I configured the alarms via the AWS UI, then added in the alarm action by copying what we have for performance alarms (with a different topic name). I deployed this template to my dev deploy (which doesn't have any of the alerting) and saw this, which looks good:

![image](https://user-images.githubusercontent.com/25372625/170601916-e8268887-8a9f-4736-bfe2-58808d190dda.png)

Some of these metrics have no data even in my dev deploy, so I think this proves that we can deploy alarms against metrics that have no data.