### PR TITLE
Improve performance alarms

### DIFF
--- a/template.yml.erb
+++ b/template.yml.erb
@@ -746,10 +746,10 @@ Resources:
       AlarmActions:
         - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-slow-performance"]
       InsufficientDataActions: []
-      EvaluationPeriods: 15
+      EvaluationPeriods: 20
       DatapointsToAlarm: 15
       ComparisonOperator: GreaterThanUpperThreshold
-      TreatMissingData: ignore
+      TreatMissingData: notBreaching
       Metrics:
           - Id: m1
             ReturnData: true
@@ -779,10 +779,10 @@ Resources:
       AlarmActions:
         - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-slow-performance"]
       InsufficientDataActions: []
-      EvaluationPeriods: 15
+      EvaluationPeriods: 20
       DatapointsToAlarm: 15
       ComparisonOperator: GreaterThanUpperThreshold
-      TreatMissingData: ignore
+      TreatMissingData: notBreaching
       Metrics:
           - Id: m1
             ReturnData: true
@@ -812,10 +812,10 @@ Resources:
       AlarmActions:
         - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-slow-performance"]
       InsufficientDataActions: []
-      EvaluationPeriods: 15
+      EvaluationPeriods: 20
       DatapointsToAlarm: 15
       ComparisonOperator: GreaterThanUpperThreshold
-      TreatMissingData: ignore
+      TreatMissingData: notBreaching
       Metrics:
           - Id: m1
             ReturnData: true
@@ -845,10 +845,10 @@ Resources:
         AlarmActions:
           - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-slow-performance"]
         InsufficientDataActions: []
-        EvaluationPeriods: 15
+        EvaluationPeriods: 20
         DatapointsToAlarm: 15
         ComparisonOperator: GreaterThanUpperThreshold
-        TreatMissingData: missing
+        TreatMissingData: notBreaching
         Metrics:
             - Id: m1
               ReturnData: true
@@ -864,7 +864,7 @@ Resources:
             - Id: ad1
               Label: TransitionTime (expected)
               ReturnData: true
-              Expression: ANOMALY_DETECTION_BAND(m1, 3)
+              Expression: ANOMALY_DETECTION_BAND(m1, 5)
         ThresholdMetricId: ad1
 
 <%end -%>


### PR DESCRIPTION
We got some false alarms last night due to a small number of data points breaching the threshold for transition time. To improve I made the following changes:
- update the missing metric behavior to be `notBreaching` instead of `ignore`
- Change the evaluation period to 20 minutes but keep the datapoints to alarm at 15. Since missing data points are now good, this means that we need to see at least 15 out of 20 minutes with data that is breaching.
- Increase the width of the band for the transition time alarm. That was the one that breached last night, and the band was too narrow for the spikiness of the data.