### PR TITLE
Add alert for high Lambda invocations

### DIFF
--- a/template.yml.erb
+++ b/template.yml.erb
@@ -873,11 +873,7 @@ Resources:
         AlarmName: !Sub "${SubDomainName}_<%=name.downcase%>_high_invocations"
         AlarmDescription: Significantly higher <%=name%> build and run invocations than
             normal detected. Investigate if there is a DDOS.
-        ActionsEnabled: true
-        OKActions: []
-        AlarmActions: []
-        InsufficientDataActions: []
-        Dimensions: []
+        ActionsEnabled: false
         EvaluationPeriods: 20
         DatapointsToAlarm: 20
         ComparisonOperator: GreaterThanUpperThreshold

--- a/template.yml.erb
+++ b/template.yml.erb
@@ -867,6 +867,39 @@ Resources:
               Expression: ANOMALY_DETECTION_BAND(m1, 5)
         ThresholdMetricId: ad1
 
+  <%=name%>HighInvocationsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+        AlarmName: !Sub "${SubDomainName}_<%=name.downcase%>_high_invocations"
+        AlarmDescription: Significantly higher <%=name%> build and run invocations than
+            normal detected. Investigate if there is a DDOS.
+        ActionsEnabled: true
+        OKActions: []
+        AlarmActions: []
+        InsufficientDataActions: []
+        Dimensions: []
+        EvaluationPeriods: 20
+        DatapointsToAlarm: 20
+        ComparisonOperator: GreaterThanUpperThreshold
+        TreatMissingData: notBreaching
+        Metrics:
+            - Id: m1
+              ReturnData: true
+              MetricStat:
+                  Metric:
+                      Namespace: AWS/Lambda
+                      MetricName: Invocations
+                      Dimensions:
+                          - Name: FunctionName
+                            Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
+                  Period: 60
+                  Stat: Sum
+            - Id: ad1
+              Label: Invocations (expected)
+              ReturnData: true
+              Expression: ANOMALY_DETECTION_BAND(m1, 8)
+        ThresholdMetricId: ad1
+
 <%end -%>
 
 # We use shortened versions of names for partition keys (eg, user_id),


### PR DESCRIPTION
Adds alerts for abnormally high lambda invocations. This is uses the same anomaly detection parameters as the existing high http/websocket connections alarm.

Tested on dev lambda by verifying that each alarm is correctly generated.