### PR TITLE
Move error handling logic to the handler level

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSInputAdapter.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSInputAdapter.java
@@ -1,5 +1,7 @@
 package org.code.javabuilder;
 
+import static org.code.javabuilder.InternalFacingExceptionTypes.CONNECTION_TERMINATED;
+
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.Message;
 import com.amazonaws.services.sqs.model.QueueDoesNotExistException;
@@ -8,8 +10,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import org.code.protocol.InputAdapter;
-import org.code.protocol.InternalExceptionKey;
-import org.code.protocol.InternalServerRuntimeException;
 
 /** Accesses Amazon SQS to get user input for the currently running program. */
 public class AWSInputAdapter implements InputAdapter {
@@ -48,7 +48,7 @@ public class AWSInputAdapter implements InputAdapter {
         }
       } catch (QueueDoesNotExistException e) {
         // if we tried to send a message and got queue does not exist, we have lost our connection
-        throw new InternalServerRuntimeException(InternalExceptionKey.CONNECTION_TERMINATED, e);
+        throw new InternalFacingRuntimeException(CONNECTION_TERMINATED, e);
       }
     }
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSOutputAdapter.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSOutputAdapter.java
@@ -1,5 +1,7 @@
 package org.code.javabuilder;
 
+import static org.code.javabuilder.InternalFacingExceptionTypes.CONNECTION_TERMINATED;
+
 import com.amazonaws.services.apigatewaymanagementapi.AmazonApiGatewayManagementApi;
 import com.amazonaws.services.apigatewaymanagementapi.model.GoneException;
 import com.amazonaws.services.apigatewaymanagementapi.model.PostToConnectionRequest;
@@ -41,7 +43,7 @@ public class AWSOutputAdapter implements OutputAdapter {
     try {
       this.api.postToConnection(post);
     } catch (GoneException e) {
-      throw new InternalServerRuntimeException(InternalExceptionKey.CONNECTION_TERMINATED, e);
+      throw new InternalFacingRuntimeException(CONNECTION_TERMINATED, e);
     }
   }
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeExecutionManager.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeExecutionManager.java
@@ -1,8 +1,6 @@
 package org.code.javabuilder;
 
-import static org.code.javabuilder.InternalFacingExceptionTypes.CONNECTION_TERMINATED;
 import static org.code.javabuilder.LambdaErrorCodes.TEMP_DIRECTORY_CLEANUP_ERROR_CODE;
-import static org.code.protocol.LoggerNames.MAIN_LOGGER;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,7 +8,7 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.util.List;
-import java.util.logging.Logger;
+import org.code.javabuilder.util.LambdaUtils;
 import org.code.protocol.*;
 
 /**
@@ -155,19 +153,8 @@ public class CodeExecutionManager {
    */
   private void onPostExecute() {
     // Notify user and listeners
-    try {
-      this.outputAdapter.sendMessage(new StatusMessage(StatusMessageKey.EXITED));
-    } catch (InternalFacingRuntimeException e) {
-      // Only log if this is not a connection terminated exception. If it is, we should have already
-      // logged a warning.
-      if (!e.getMessage().equals(CONNECTION_TERMINATED)) {
-        Logger.getLogger(MAIN_LOGGER).warning(e.getLoggingString());
-      }
-    } catch (Exception e) {
-      // Catch any other exceptions here to prevent them from propagating.
-      Logger.getLogger(MAIN_LOGGER).warning(e.getMessage());
-    }
-
+    LambdaUtils.safelySendMessage(
+        this.outputAdapter, new StatusMessage(StatusMessageKey.EXITED), false);
     this.lifecycleNotifier.onExecutionEnded();
     GlobalProtocol.getInstance().cleanUpResources();
     try {

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeRunner.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeRunner.java
@@ -12,5 +12,5 @@ public interface CodeRunner {
    * @throws JavabuilderException if there is an error running code
    * @return true if there was code to run, false if there was not.
    */
-  boolean run(URLClassLoader urlClassLoader) throws JavabuilderException;
+  boolean run(URLClassLoader urlClassLoader) throws JavabuilderException, InternalFacingException;
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/InternalFacingExceptionTypes.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/InternalFacingExceptionTypes.java
@@ -1,0 +1,14 @@
+package org.code.javabuilder;
+
+/**
+ * Constants for internal facing exception types. Note that unlike other exception types, these do
+ * not map to client-side strings because they are not sent to the user.
+ */
+public final class InternalFacingExceptionTypes {
+  private InternalFacingExceptionTypes() {
+    throw new UnsupportedOperationException("Instantiation of constants class not allowed");
+  }
+
+  public static final String CONNECTION_TERMINATED = "CONNECTION_TERMINATED";
+  public static final String INVALID_INPUT = "INVALID_INPUT";
+}

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -1,7 +1,7 @@
 package org.code.javabuilder;
 
-import static org.code.javabuilder.LambdaErrorCodes.TEMP_DIRECTORY_CLEANUP_ERROR_CODE;
-import static org.code.protocol.InternalExceptionKey.INTERNAL_EXCEPTION;
+import static org.code.javabuilder.InternalFacingExceptionTypes.INVALID_INPUT;
+import static org.code.protocol.InternalExceptionKey.*;
 import static org.code.protocol.LoggerNames.MAIN_LOGGER;
 
 import com.amazonaws.client.builder.AwsClientBuilder;
@@ -59,6 +59,10 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
   private static final AmazonSQS SQS_CLIENT = AmazonSQSClientBuilder.defaultClient();
   private static final AmazonS3 S3_CLIENT = AmazonS3ClientBuilder.standard().build();
 
+  // Controls whether the current invocation session has been initialized. This should be reset on
+  // every invocation.
+  private boolean isSessionInitialized = false;
+
   public LambdaRequestHandler() {
     // create CachedResources once for the entire container.
     // This will only be called once in the initial creation of the lambda instance.
@@ -69,7 +73,20 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
 
   /**
    * This is the implementation of the long-running-lambda where user code will be compiled and
-   * executed.
+   * executed. The handler performs the following actions for each invocation:
+   *
+   * <p>1. Initialize the current session (set global properties, setup static objects, etc)
+   *
+   * <p>2.Create the OutputAdapter to communicate with the user
+   *
+   * <p>3. Clear the temp directory on the current container
+   *
+   * <p>4. Setup the code execution environment, and execute code
+   *
+   * <p>5. Handle any exceptions/errors if they are thrown
+   *
+   * <p>6. Shut down the current session (shut down the execution environment, clean up AWS
+   * resources, etc).
    *
    * @param lambdaInput A map of the json input to this lambda function. Input is formatted like
    *     this: { "queueUrl": <session-specific-url>, "queueName": <session-specific-string>
@@ -79,21 +96,19 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
    */
   @Override
   public String handleRequest(Map<String, String> lambdaInput, Context context) {
-    final Instant instanceStart = Clock.systemUTC().instant();
-    // The lambda handler should have minimal application logic:
-    // https://docs.aws.amazon.com/lambda/latest/dg/best-practices.html
+    this.isSessionInitialized = false;
+    this.trackStartupPerformance();
+
+    // TODO: Because we reference the logger object throughout the codebase via
+    // Logger.getLogger(MAIN_LOGGER), we need to set it up in the same scope as code execution to
+    // prevent the instance from being garbage collected. Instead, we should store a global
+    // reference to this logger object and access that directly rather than via
+    // Logger.getLogger(MAIN_LOGGER)
     final String connectionId = lambdaInput.get("connectionId");
-    final String queueUrl = lambdaInput.get("queueUrl");
-    final String queueName = lambdaInput.get("queueName");
     final String levelId = lambdaInput.get("levelId");
     final String channelId =
         lambdaInput.get("channelId") == null ? "noneProvided" : lambdaInput.get("channelId");
-    final ExecutionType executionType = ExecutionType.valueOf(lambdaInput.get("executionType"));
-    final JSONObject options = new JSONObject(lambdaInput.get("options"));
     final String javabuilderSessionId = lambdaInput.get("javabuilderSessionId");
-    final List<String> compileList = JSONUtils.listFromJSONObjectMember(options, "compileList");
-    final boolean canAccessDashboardAssets =
-        Boolean.parseBoolean(lambdaInput.get("canAccessDashboardAssets"));
     Logger logger = Logger.getLogger(MAIN_LOGGER);
     logger.addHandler(
         new LambdaLogHandler(
@@ -105,11 +120,80 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
             channelId));
     // turn off the default console logger
     logger.setUseParentHandlers(false);
+
+    this.initialize(lambdaInput, connectionId, context);
+
+    // Try to construct the output adapter as early as possible, so we can notify the user if
+    // something goes wrong. If for some reason we cannot construct the output adapter, our only
+    // option is to log and exit.
+    final OutputAdapter outputAdapter;
+    try {
+      outputAdapter = this.createOutputAdapter(lambdaInput);
+    } catch (InternalFacingException e) {
+      LoggerUtils.logSevereException(e);
+      return "error";
+    }
+
+    final ExceptionHandler exceptionHandler =
+        new ExceptionHandler(outputAdapter, new AWSSystemExitHelper(connectionId, API_CLIENT));
+    final TempDirectoryManager tempDirectoryManager = new AWSTempDirectoryManager();
+
+    CodeExecutionManager codeExecutionManager = null;
+    Thread timeoutNotifierThread = null;
+
+    try {
+      this.clearTempDirectory(tempDirectoryManager);
+
+      codeExecutionManager =
+          this.createExecutionManager(
+              lambdaInput, context, connectionId, outputAdapter, tempDirectoryManager);
+
+      // Create and start thread that that will notify us if we're nearing the timeout limit
+      timeoutNotifierThread =
+          this.createTimeoutThread(
+              context, outputAdapter, codeExecutionManager, connectionId, API_CLIENT);
+      timeoutNotifierThread.start();
+
+      // Initialize and start code execution
+      codeExecutionManager.execute();
+    } catch (Throwable e) {
+      // Catch and handle all exceptions
+      exceptionHandler.handle(e);
+    } finally {
+      if (timeoutNotifierThread != null) {
+        timeoutNotifierThread.interrupt();
+      }
+      this.shutDown(codeExecutionManager, connectionId, API_CLIENT);
+    }
+
+    return "done";
+  }
+
+  /**
+   * Sets up the lambda environment for the current invocation by setting global properties and
+   * creating global objects
+   */
+  private void initialize(Map<String, String> lambdaInput, String connectionId, Context context) {
+    final boolean canAccessDashboardAssets =
+        Boolean.parseBoolean(lambdaInput.get("canAccessDashboardAssets"));
+
     Properties.setConnectionId(connectionId);
 
     MetricClient metricClient = new AWSMetricClient(context.getFunctionName());
     MetricClientManager.create(metricClient);
 
+    // Dashboard assets are only accessible if the dashboard domain is not localhost
+    Properties.setCanAccessDashboardAssets(canAccessDashboardAssets);
+    // manually set font configuration file since there is no font configuration on a lambda.
+    java.util.Properties props = System.getProperties();
+    // /opt is the folder all layer files go into.
+    props.put("sun.awt.fontconfig", "/opt/fontconfig.properties");
+
+    this.isSessionInitialized = true;
+  }
+
+  private void trackStartupPerformance() {
+    final Instant instanceStart = Clock.systemUTC().instant();
     PerformanceTracker.resetTracker();
     if (coldBoot) {
       PerformanceTracker.getInstance().trackColdBoot(COLD_BOOT_START, COLD_BOOT_END, instanceStart);
@@ -117,105 +201,119 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     } else {
       PerformanceTracker.getInstance().trackInstanceStart(instanceStart);
     }
+  }
 
-    Properties.setCanAccessDashboardAssets(canAccessDashboardAssets);
-
-    // Create user-program output handlers
+  /**
+   * Create an {@link OutputAdapter} for the session.
+   *
+   * @throws InternalFacingException if the OutputAdapter cannot be created from the given input.
+   */
+  private OutputAdapter createOutputAdapter(Map<String, String> lambdaInput)
+      throws InternalFacingException {
+    final String connectionId = lambdaInput.get("connectionId");
+    if (connectionId == null) {
+      throw new InternalFacingException(INVALID_INPUT, new Exception("Missing connection ID"));
+    }
     final AWSOutputAdapter awsOutputAdapter = new AWSOutputAdapter(connectionId, API_CLIENT);
 
-    // Create user input handlers
-    final AWSInputAdapter inputAdapter = new AWSInputAdapter(SQS_CLIENT, queueUrl, queueName);
-    final AWSTempDirectoryManager tempDirectoryManager = new AWSTempDirectoryManager();
-    final LifecycleNotifier lifecycleNotifier = new LifecycleNotifier();
-    OutputAdapter outputAdapter = awsOutputAdapter;
-    if (executionType == ExecutionType.TEST) {
-      outputAdapter = new UserTestOutputAdapter(awsOutputAdapter);
-    }
-
-    final AWSContentManager contentManager;
     try {
-      contentManager =
-          new AWSContentManager(
-              S3_CLIENT, CONTENT_BUCKET_NAME, javabuilderSessionId, CONTENT_BUCKET_URL, context);
-    } catch (InternalServerException e) {
-      return onInitializationError("error loading data", e, outputAdapter, connectionId);
+      final ExecutionType executionType = ExecutionType.valueOf(lambdaInput.get("executionType"));
+      if (executionType == ExecutionType.TEST) {
+        return new UserTestOutputAdapter(awsOutputAdapter);
+      }
+      return awsOutputAdapter;
+    } catch (IllegalArgumentException e) {
+      throw new InternalFacingException(INVALID_INPUT, e);
     }
+  }
 
-    // manually set font configuration file since there is no font configuration on a lambda.
-    java.util.Properties props = System.getProperties();
-    // /opt is the folder all layer files go into.
-    props.put("sun.awt.fontconfig", "/opt/fontconfig.properties");
-
+  /**
+   * Clear the container's temp directory in preparation for code execution. Throws a {@link
+   * FatalError} if any IOException occurs to force the container to shutdown and release resources.
+   */
+  private void clearTempDirectory(TempDirectoryManager tempDirectoryManager) {
     try {
       // Log disk space before clearing the directory
       LoggerUtils.sendDiskSpaceReport();
-
       tempDirectoryManager.cleanUpTempDirectory(null);
     } catch (IOException e) {
       // Wrap this in our error type so we can log it and tell the user.
-      InternalServerException error = new InternalServerException(INTERNAL_EXCEPTION, e);
-      onInitializationError("error clearing tmpdir", error, outputAdapter, connectionId);
-      // If there was an issue clearing the temp directory, this may be because too many files are
-      // open. Force the JVM to quit in order to release the resources for the next use of the
-      // container.
-      System.exit(TEMP_DIRECTORY_CLEANUP_ERROR_CODE);
+      throw new FatalError(FatalErrorKey.TEMP_DIRECTORY_CLEANUP_ERROR, e);
+    }
+  }
+
+  /** Creates the {@link CodeExecutionManager} for building and executing code. */
+  private CodeExecutionManager createExecutionManager(
+      Map<String, String> lambdaInput,
+      Context context,
+      String connectionId,
+      OutputAdapter outputAdapter,
+      TempDirectoryManager tempDirectoryManager)
+      throws InternalServerException {
+    final String queueUrl = lambdaInput.get("queueUrl");
+    final String queueName = lambdaInput.get("queueName");
+    final ExecutionType executionType = ExecutionType.valueOf(lambdaInput.get("executionType"));
+    final JSONObject options = new JSONObject(lambdaInput.get("options"));
+    final String javabuilderSessionId = lambdaInput.get("javabuilderSessionId");
+    final List<String> compileList = JSONUtils.listFromJSONObjectMember(options, "compileList");
+
+    final AWSInputAdapter inputAdapter = new AWSInputAdapter(SQS_CLIENT, queueUrl, queueName);
+    final LifecycleNotifier lifecycleNotifier = new LifecycleNotifier();
+    final AWSContentManager contentManager =
+        new AWSContentManager(
+            S3_CLIENT, CONTENT_BUCKET_NAME, javabuilderSessionId, CONTENT_BUCKET_URL, context);
+
+    return new CodeExecutionManager(
+        contentManager.getProjectFileLoader(),
+        inputAdapter,
+        outputAdapter,
+        executionType,
+        compileList,
+        tempDirectoryManager,
+        contentManager,
+        lifecycleNotifier,
+        new AWSSystemExitHelper(connectionId, API_CLIENT));
+  }
+
+  /**
+   * Cleans up resources used by the current invocation, and prepares the container for the next
+   * invocation.
+   */
+  private void shutDown(
+      CodeExecutionManager executionManager,
+      String connectionId,
+      AmazonApiGatewayManagementApi api) {
+    // No need to shut down if the session is not initialized. This means that we've already shut
+    // down (ex. due to timeout) or this method was somehow called out of turn.
+    if (!this.isSessionInitialized) {
+      return;
     }
 
-    final CodeExecutionManager codeExecutionManager =
-        new CodeExecutionManager(
-            contentManager.getProjectFileLoader(),
-            inputAdapter,
-            outputAdapter,
-            executionType,
-            compileList,
-            tempDirectoryManager,
-            contentManager,
-            lifecycleNotifier,
-            new AWSSystemExitHelper(connectionId, API_CLIENT));
-
-    final Thread timeoutNotifierThread =
-        createTimeoutThread(context, outputAdapter, codeExecutionManager, connectionId, API_CLIENT);
-    timeoutNotifierThread.start();
-
-    try {
-      // start code build and block until completed
-      codeExecutionManager.execute();
-    } catch (Throwable e) {
-      // All errors should be caught, but if for any reason we encounter an error here, make sure we
-      // catch it, log, and always clean up resources
-      LoggerUtils.logSevereException(e);
-    } finally {
-      // Stop timeout listener and clean up
-      timeoutNotifierThread.interrupt();
-      PerformanceTracker.getInstance().trackInstanceEnd();
-      PerformanceTracker.getInstance().logPerformance();
-      cleanUpResources(connectionId, API_CLIENT);
-      File f = Paths.get(System.getProperty("java.io.tmpdir")).toFile();
-      if ((double) f.getUsableSpace() / f.getTotalSpace() < 0.5) {
-        // The current project holds a lock on too many resources. Force the JVM to quit in
-        // order to release the resources for the next use of the container.
-        System.exit(LOW_DISK_SPACE_ERROR_CODE);
+    if (executionManager != null) {
+      try {
+        executionManager.shutDown();
+      } catch (Throwable e) {
+        // Catch any exceptions thrown during shutdown; the program has already terminated,
+        // so these don't need to be reported to the user.
+        final InternalFacingRuntimeException internal =
+            new InternalFacingRuntimeException("Exception during shutdown", e);
+        Logger.getLogger(MAIN_LOGGER).warning(internal.getLoggingString());
       }
     }
 
-    return "done";
-  }
-
-  /** Handles logging and cleanup in the case of an initialization error. */
-  private String onInitializationError(
-      String errorMessage,
-      InternalServerException error,
-      OutputAdapter outputAdapter,
-      String connectionId) {
-    // Log the error
-    LoggerUtils.logSevereError(error);
-
-    // This affected the user. Let's tell them about it.
-    this.sendOutputMessage(outputAdapter, error.getExceptionMessage());
     PerformanceTracker.getInstance().trackInstanceEnd();
     PerformanceTracker.getInstance().logPerformance();
-    cleanUpResources(connectionId, API_CLIENT);
-    return errorMessage;
+
+    this.cleanUpAWSResources(connectionId, api);
+
+    File f = Paths.get(System.getProperty("java.io.tmpdir")).toFile();
+    if ((double) f.getUsableSpace() / f.getTotalSpace() < 0.5) {
+      // The current project holds a lock on too many resources. Force the JVM to quit in
+      // order to release the resources for the next use of the container.
+      System.exit(LOW_DISK_SPACE_ERROR_CODE);
+    }
+
+    this.isSessionInitialized = false;
   }
 
   private Thread createTimeoutThread(
@@ -240,10 +338,8 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
 
               if (context.getRemainingTimeInMillis() < TIMEOUT_CLEANUP_BUFFER_MS) {
                 this.sendOutputMessage(outputAdapter, new StatusMessage(StatusMessageKey.TIMEOUT));
-                // Tell the execution manager to clean up early
-                codeExecutionManager.requestEarlyExit();
-                // Clean up AWS resources
-                cleanUpResources(connectionId, api);
+                // Shut down the environment
+                this.shutDown(codeExecutionManager, connectionId, api);
                 break;
               }
             } catch (InterruptedException e) {
@@ -257,7 +353,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
    * Note: This can sometimes be called twice when a user's project times out. Make sure anything
    * added here can be run more than once without negative effect.
    */
-  private void cleanUpResources(String connectionId, AmazonApiGatewayManagementApi api) {
+  private void cleanUpAWSResources(String connectionId, AmazonApiGatewayManagementApi api) {
     final DeleteConnectionRequest deleteConnectionRequest =
         new DeleteConnectionRequest().withConnectionId(connectionId);
     // Deleting the API Gateway connection should always be the last thing executed because the
@@ -282,11 +378,11 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
   private void sendOutputMessage(OutputAdapter outputAdapter, ClientMessage message) {
     try {
       outputAdapter.sendMessage(message);
-    } catch (InternalServerRuntimeException e) {
+    } catch (InternalFacingRuntimeException e) {
       // This likely means the connection has been lost. Log a warning.
       Logger.getLogger(MAIN_LOGGER).warning(e.getLoggingString());
     } catch (Exception e) {
-      // Catch any other exceptions here to prevent them from propogating.
+      // Catch any other exceptions here to prevent them from propagating.
       Logger.getLogger(MAIN_LOGGER).warning(e.getMessage());
     }
   }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/MainRunner.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/MainRunner.java
@@ -25,7 +25,8 @@ public class MainRunner implements CodeRunner {
    * @throws JavabuilderException when the user's code hits an error
    * @return true if there was code to run, false if there was not.
    */
-  public boolean run(URLClassLoader urlClassLoader) throws JavabuilderException {
+  public boolean run(URLClassLoader urlClassLoader)
+      throws JavabuilderException, InternalFacingException {
     try {
       // Preload error handling classes in case a user project uses up all resources
       Class.forName(UserInitiatedExceptionKey.class.getName());
@@ -48,13 +49,22 @@ public class MainRunner implements CodeRunner {
       // TODO: this error message may not be not very friendly
       throw new UserInitiatedException(UserInitiatedExceptionKey.ILLEGAL_METHOD_ACCESS, e);
     } catch (InvocationTargetException e) {
-      // If the invocation exception is wrapping another JavabuilderException or
-      // JavabuilderRuntimeException, we don't need to wrap it in a UserInitiatedException
+      // If the invocation exception is wrapping a known exception type, we don't need to wrap it in
+      // a UserInitiatedException
       if (e.getCause() instanceof JavabuilderException) {
         throw (JavabuilderException) e.getCause();
       }
       if (e.getCause() instanceof JavabuilderRuntimeException) {
         throw (JavabuilderRuntimeException) e.getCause();
+      }
+      if (e.getCause() instanceof InternalFacingException) {
+        throw (InternalFacingException) e.getCause();
+      }
+      if (e.getCause() instanceof InternalFacingRuntimeException) {
+        throw (InternalFacingRuntimeException) e.getCause();
+      }
+      if (e.getCause() instanceof JavabuilderError) {
+        throw (JavabuilderError) e.getCause();
       }
       // FileNotFoundExceptions may be thrown from student code, so we treat them as a
       // specific case of a UserInitiatedException

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/util/LambdaUtils.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/util/LambdaUtils.java
@@ -1,0 +1,39 @@
+package org.code.javabuilder.util;
+
+import static org.code.javabuilder.InternalFacingExceptionTypes.CONNECTION_TERMINATED;
+import static org.code.protocol.LoggerNames.MAIN_LOGGER;
+
+import java.util.logging.Logger;
+import org.code.javabuilder.InternalFacingRuntimeException;
+import org.code.protocol.ClientMessage;
+import org.code.protocol.OutputAdapter;
+
+public final class LambdaUtils {
+  private LambdaUtils() {
+    throw new UnsupportedOperationException("Instantiation of utility class is not allowed.");
+  }
+
+  /**
+   * Sends a message via the OutputAdapter and handles any exceptions if they are thrown. This
+   * allows us to safely try and send messages from the handler without unintentionally raising
+   * uncaught exceptions.
+   *
+   * @param logOnLostConnection whether we should log if the OutputAdapter throws a
+   *     CONNECTION_TERMINATED exception. This can be false in situations where we know we've
+   *     already logged elsewhere.
+   */
+  public static void safelySendMessage(
+      OutputAdapter outputAdapter, ClientMessage message, boolean logOnLostConnection) {
+    try {
+      outputAdapter.sendMessage(message);
+    } catch (InternalFacingRuntimeException e) {
+      // Unless logOnLostConnection is true, only log for messages that aren't CONNECTION_TERMINATED
+      if (logOnLostConnection || !e.getMessage().equals(CONNECTION_TERMINATED)) {
+        Logger.getLogger(MAIN_LOGGER).warning(e.getLoggingString());
+      }
+    } catch (Exception e) {
+      // Catch any other exceptions here to prevent them from propagating.
+      Logger.getLogger(MAIN_LOGGER).warning(e.getMessage());
+    }
+  }
+}

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/AWSInputAdapterTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/AWSInputAdapterTest.java
@@ -1,5 +1,6 @@
 package org.code.javabuilder;
 
+import static org.code.javabuilder.InternalFacingExceptionTypes.CONNECTION_TERMINATED;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -11,8 +12,6 @@ import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.amazonaws.services.sqs.model.ReceiveMessageResult;
 import java.util.ArrayList;
 import java.util.List;
-import org.code.protocol.InternalExceptionKey;
-import org.code.protocol.InternalServerRuntimeException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -93,7 +92,7 @@ public class AWSInputAdapterTest {
   void throwsOnLostConnection() {
     this.mockLostConnection();
     Exception actual =
-        assertThrows(InternalServerRuntimeException.class, () -> inputAdapter.getNextMessage());
-    assertEquals(InternalExceptionKey.CONNECTION_TERMINATED.toString(), actual.getMessage());
+        assertThrows(InternalFacingRuntimeException.class, () -> inputAdapter.getNextMessage());
+    assertEquals(CONNECTION_TERMINATED, actual.getMessage());
   }
 }

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/ExceptionHandlerTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/ExceptionHandlerTest.java
@@ -1,0 +1,102 @@
+package org.code.javabuilder;
+
+import static org.code.protocol.LoggerNames.MAIN_LOGGER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.code.protocol.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ExceptionHandlerTest {
+
+  private OutputAdapter outputAdapter;
+  private SystemExitHelper systemExitHelper;
+  private Handler testHandler;
+  private ArgumentCaptor<ClientMessage> messageCaptor;
+  private ExceptionHandler unitUnderTest;
+
+  @BeforeEach
+  public void setUp() {
+    outputAdapter = mock(OutputAdapter.class);
+    systemExitHelper = mock(SystemExitHelper.class);
+    testHandler = mock(Handler.class);
+    messageCaptor = ArgumentCaptor.forClass(ClientMessage.class);
+    unitUnderTest = new ExceptionHandler(outputAdapter, systemExitHelper);
+
+    Logger.getLogger(MAIN_LOGGER).addHandler(testHandler);
+    Logger.getLogger(MAIN_LOGGER).setUseParentHandlers(false);
+    MetricClientManager.create(mock(MetricClient.class));
+  }
+
+  @AfterEach
+  public void tearDown() {
+    Logger.getLogger(MAIN_LOGGER).removeHandler(testHandler);
+    Logger.getLogger(MAIN_LOGGER).setUseParentHandlers(true);
+  }
+
+  @Test
+  public void testFatalError() {
+    final FatalError error = new FatalError(FatalErrorKey.LOW_DISK_SPACE);
+    unitUnderTest.handle(error);
+
+    // Should log, notify user, and exit
+    verify(testHandler).publish(any(LogRecord.class));
+    verify(outputAdapter).sendMessage(any(ClientMessage.class));
+    verify(systemExitHelper).exit(error.getErrorCode());
+  }
+
+  @Test
+  public void testInternalServerException() {
+    final InternalServerException internal =
+        new InternalServerException(InternalExceptionKey.INTERNAL_EXCEPTION);
+    unitUnderTest.handle(internal);
+
+    // Should log and notify user
+    verify(testHandler).publish(any(LogRecord.class));
+    verify(outputAdapter).sendMessage(any(ClientMessage.class));
+  }
+
+  @Test
+  public void testInternalFacingException() {
+    final InternalFacingException internal =
+        new InternalFacingException("internal", new Exception());
+    unitUnderTest.handle(internal);
+
+    // Should log only
+    verify(testHandler).publish(any(LogRecord.class));
+    verify(outputAdapter, never()).sendMessage(any(ClientMessage.class));
+  }
+
+  @Test
+  public void testUserInitiatedException() {
+    final UserInitiatedException userInitiated =
+        new UserInitiatedException(UserInitiatedExceptionKey.COMPILER_ERROR);
+    unitUnderTest.handle(userInitiated);
+
+    // Should notify user only
+    verify(testHandler, never()).publish(any(LogRecord.class));
+    verify(outputAdapter).sendMessage(any(ClientMessage.class));
+  }
+
+  @Test
+  public void testUnknownException() {
+    doNothing().when(outputAdapter).sendMessage(messageCaptor.capture());
+    final IOException unknown = new IOException();
+    unitUnderTest.handle(unknown);
+
+    // Should log and notify user
+    verify(testHandler).publish(any(LogRecord.class));
+    verify(outputAdapter).sendMessage(any(ClientMessage.class));
+
+    final ClientMessage message = messageCaptor.getValue();
+    assertEquals(InternalExceptionKey.UNKNOWN_ERROR.toString(), message.getValue());
+  }
+}


### PR DESCRIPTION
This refactors our handler and code execution logic to move error handling up to the handler level. The primary goals of this change are to 1) have a central place where all exception/errors are caught and dealt with and 2) try to ensure as much as possible that no exceptions/errors go uncaught from the handler. This shouldn't result in any behavioral changes; it's mostly moving existing logic around. 

Quick summary of the main changes to hopefully make things easier to read:
- `ExceptionHandler` is a new class that houses all the exception/error handling logic. It's mostly the same as the pre-existing error handling in `CodeBuilderRunnable` with some new additions to handle new error/exception types
- In `CodeExecutionManager`, while previously all the initialization, execution, and cleanup would happen within `execute`, now callers need to manually call `shutDown` after they call `execute`. This is because in order for exceptions to bubble up to the top level, we need to allow `execute` to throw any exceptions it encounters, and afterwards call `shutDown` once all exceptions have been dealt with. This also replaces  the `requestEarlyExit` method since the timeout thread can now just call `shutDown` directly.
- In `LambdaRequestHandler` I reorganized the code to hopefully make it easier to parse. Related chunks of logic like initialization, creating the execution manager, etc, are moved into their own methods to slim down the `handle()` method a bit.

There a few cleanup/follow-up tasks I have in mind which I opted to not include since this PR is already pretty large. These include:
- Finding a way to consolidate the duplicated cleanup code between LambdaRequestHandler and AWSSystemExitHelper
- Dealing with the fact that anytime the OutputAdapter is called outside of the code execution block, we need to wrap it in a try-catch to prevent errors from propagating. A couple things we could do are 1) store the connection state on the output adapter (similar to the flag we used to have when we were running code in a thread) and 2) move the shared try-catch block to some util

Testing: tested locally and on dev lambda. Tried to simulate as many possible error types including fatal errors, internal errors, timeouts, user errors, etc.