### PR TITLE
Set up unit tests for javabuilder-authorizer

### DIFF
--- a/cicd/3-app/javabuilder/pr-buildspec.yml
+++ b/cicd/3-app/javabuilder/pr-buildspec.yml
@@ -24,6 +24,9 @@ phases:
       - cd $CODEBUILD_SRC_DIR
       - cd api-gateway-routes
       - rake test
+      - cd $CODEBUILD_SRC_DIR
+      - cd javabuilder-authorizer
+      - rake test
 
       - cd $CODEBUILD_SRC_DIR
       - erb -T - template.yml.erb > template.yml

--- a/javabuilder-authorizer/Gemfile
+++ b/javabuilder-authorizer/Gemfile
@@ -8,3 +8,5 @@ gem 'jwt'
 gem "aws-sdk-dynamodb", "~> 1.60"
 
 gem "aws-sdk-cloudwatch", "~> 1.52"
+
+gem "minitest", "~> 5.5"

--- a/javabuilder-authorizer/Gemfile.lock
+++ b/javabuilder-authorizer/Gemfile.lock
@@ -21,6 +21,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     jmespath (1.4.0)
     jwt (2.2.2)
+    minitest (5.15.0)
 
 PLATFORMS
   ruby
@@ -30,6 +31,7 @@ DEPENDENCIES
   aws-sdk-dynamodb (~> 1.60)
   aws-sdk-lambda (= 1.39.0)
   jwt
+  minitest (~> 5.5)
 
 RUBY VERSION
    ruby 2.7.4p191

--- a/javabuilder-authorizer/README.md
+++ b/javabuilder-authorizer/README.md
@@ -8,3 +8,6 @@ It expects a JWT token to be sent in an Authorization header in the standard for
 You must be running ruby version 2.7.2 for the upload to work properly. The lambda 
 expects the gems to be in `vendor\bundle\ruby\2.7.0\*`. You may be able to manually
 rename the `2.7.0` folder to workaround installing a different ruby version.
+
+## Testing
+To run unit tests, run `rake test` from this folder. For end to end testing, refer to the main [README](../README.MD).

--- a/javabuilder-authorizer/Rakefile
+++ b/javabuilder-authorizer/Rakefile
@@ -1,0 +1,7 @@
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.test_files = FileList['test/*.rb']
+  t.verbose = true
+end

--- a/javabuilder-authorizer/test/jwt_helper_test.rb
+++ b/javabuilder-authorizer/test/jwt_helper_test.rb
@@ -13,12 +13,10 @@ class JwtHelperTest < Minitest::Test
 
     auth_response = JwtHelper.generate_allow(resource, token_payload)
 
-    assert auth_response != nil
     assert_equal "#{issuer}/#{user_id}", auth_response['principalId']
     assert_equal token_payload, auth_response['context']
 
-    policy_document = auth_response['policyDocument']
-    statement = policy_document['Statement'][0]
+    statement = auth_response['policyDocument']['Statement'][0]
     assert_equal 'Allow', statement['Effect']
     assert_equal resource, statement['Resource']
    end

--- a/javabuilder-authorizer/test/jwt_helper_test.rb
+++ b/javabuilder-authorizer/test/jwt_helper_test.rb
@@ -1,0 +1,25 @@
+require 'minitest/autorun'
+require_relative '../jwt_helper'
+include JwtHelper
+
+class JwtHelperTest < Minitest::Test
+   def test_generates_allow_policy
+    user_id = "user_id123"
+    issuer = "issuer123"
+    token_payload = {}
+    token_payload['uid'] = user_id
+    token_payload['iss'] = issuer
+    resource = "resource123"
+
+    auth_response = JwtHelper.generate_allow(resource, token_payload)
+
+    assert auth_response != nil
+    assert_equal "#{issuer}/#{user_id}", auth_response['principalId']
+    assert_equal token_payload, auth_response['context']
+
+    policy_document = auth_response['policyDocument']
+    statement = policy_document['Statement'][0]
+    assert_equal 'Allow', statement['Effect']
+    assert_equal resource, statement['Resource']
+   end
+end


### PR DESCRIPTION
Sets up unit testing and adds a single test to `javabuilder-authorizer`. This is pretty much the same as https://github.com/code-dot-org/javabuilder/pull/313, plus a single test (jwt_helper_test).

JIRA: https://codedotorg.atlassian.net/browse/JAVA-609