### PR TITLE
Prevent duplicate authorizer warnings

### DIFF
--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -129,15 +129,6 @@ def on_default(event, context)
     return authorization_error_response
   end
 
-  authorization_warning_response = AuthResponseHelper.get_warning_response(authorizer)
-  # if there is a warning response, send the warning via the websocket and continue
-  if authorization_warning_response
-    resp = client.post_to_connection({
-      data: authorization_warning_response,
-      connection_id: connection_id
-    })
-  end
-
   message = event["body"]
   # Return early if this is the user connectivity test
   if message == 'connectivityTest'
@@ -148,8 +139,16 @@ def on_default(event, context)
     return { statusCode: 200, body: "success"}
   end
 
-  # Return early if this is the initial "CONNECTED" message
+  # Return early if this is the initial "CONNECTED" message. Send authorization warning if needed.
   if message == CONNECTED_MESSAGE
+    authorization_warning_response = AuthResponseHelper.get_warning_response(authorizer)
+    # if there is a warning response, send the warning via the websocket before returning.
+    if authorization_warning_response
+      resp = client.post_to_connection({
+        data: authorization_warning_response,
+        connection_id: connection_id
+      })
+    end
     return { statusCode: 200, body: "success" }
   end
 


### PR DESCRIPTION
Quick fix to prevent duplicate authorizer warnings from being sent. The issue was that if there was an authorizer warning, we'd send it every time the user sent a message over the websocket (ex. in a console project) so this change only sends the warning in response to the initial "CONNECTED" message.

Tested on dev lambda with a console project. Confirmed that the warning is only sent at the beginning and not after any subsequent input.