### PR TITLE
Enable running individual integration tests

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -13,6 +13,12 @@ You can run tests locally against a custom deploy of Javabuilder.
 3. `./run-integration-tests.sh`
 4. `unset AWS_PROFILE`
 
+### Running Individual Tests
+
+Use the `-g` option to target a single test or group of tests; for example: `./run-integration-tests.sh -g Theater`
+
+The `-g` option runs any tests matching the provided string/pattern (see [Mocha docs](https://mochajs.org/#usage) for more information).
+
 ## Adding New Tests
 
 Write new tests in the [./test/](./test/) directory. You can also use and update support code as needed.

--- a/integration-tests/run-integration-tests.sh
+++ b/integration-tests/run-integration-tests.sh
@@ -21,4 +21,4 @@ JAVABUILDER_HTTP_URL=https://"$sub_domain"-http."$base_domain"/seedsources/sourc
 JAVABUILDER_WEBSOCKET_URL=wss://"$sub_domain"."$base_domain" \
 JAVABUILDER_BASE_DOMAIN=$base_domain \
 JAVABUILDER_SUB_DOMAIN=$sub_domain \
-npm test
+npm test -- "${@}"


### PR DESCRIPTION
Quick change - adds the ability to locally run individual integration tests or a subset of tests using Mocha's `-g` (grep) option.