### PR TITLE
Neighborhood: add show/hide buckets

### DIFF
--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
@@ -241,6 +241,14 @@ public class Painter {
     return this.direction.getDirectionString();
   }
 
+  public void showBuckets() {
+    this.grid.showBuckets();
+  }
+
+  public void hideBuckets() {
+    this.grid.hideBuckets();
+  }
+
   /**
    * Sets the amount of paint in the painters bucket. Does nothing if paint is negative.
    *


### PR DESCRIPTION
Add methods to the painter to show and hide buckets for the entire neighborhood. Since students only interact with the painter object we need these methods on the painter.