### PR TITLE
Neighborhood: Refactor show/hide buckets and output adapter

### DIFF
--- a/org-code-javabuilder/.gitignore
+++ b/org-code-javabuilder/.gitignore
@@ -17,3 +17,6 @@ app/.project
 .vscode/*
 
 *.zip
+
+# ignore neighborhood grid.txt file (auto-generated when running locally)
+lib/grid.txt

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
@@ -4,6 +4,7 @@ import static org.code.protocol.ClientMessageDetailKeys.*;
 
 import java.util.HashMap;
 import org.code.neighborhood.support.*;
+import org.code.protocol.GlobalProtocol;
 import org.code.protocol.OutputAdapter;
 
 public class Painter {
@@ -27,7 +28,7 @@ public class Painter {
     World worldInstance = World.getInstance();
     this.grid = worldInstance.getGrid();
     this.hasInfinitePaint = this.grid.getSize() >= LARGE_GRID_SIZE;
-    this.outputAdapter = worldInstance.getOutputAdapter();
+    this.outputAdapter = GlobalProtocol.getInstance().getOutputAdapter();
     this.id = "painter-" + lastId++;
     this.sendInitializationMessage();
   }
@@ -48,7 +49,7 @@ public class Painter {
     this.hasInfinitePaint = false;
     World worldInstance = World.getInstance();
     this.grid = worldInstance.getGrid();
-    this.outputAdapter = worldInstance.getOutputAdapter();
+    this.outputAdapter = GlobalProtocol.getInstance().getOutputAdapter();
     int gridSize = this.grid.getSize();
     if (x < 0 || y < 0 || x >= gridSize || y >= gridSize) {
       throw new NeighborhoodRuntimeException(ExceptionKeys.INVALID_LOCATION);
@@ -242,11 +243,13 @@ public class Painter {
   }
 
   public void showBuckets() {
-    this.grid.showBuckets();
+    this.outputAdapter.sendMessage(
+        new NeighborhoodSignalMessage(NeighborhoodSignalKey.SHOW_BUCKETS, new HashMap<>()));
   }
 
   public void hideBuckets() {
-    this.grid.hideBuckets();
+    this.outputAdapter.sendMessage(
+        new NeighborhoodSignalMessage(NeighborhoodSignalKey.HIDE_BUCKETS, new HashMap<>()));
   }
 
   /**

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/support/Grid.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/support/Grid.java
@@ -1,20 +1,16 @@
 package org.code.neighborhood.support;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import org.code.protocol.OutputAdapter;
 
 public class Grid {
   private final GridSquare[][] grid;
   private final int width;
   private final int height;
-  private final OutputAdapter outputAdapter;
 
-  protected Grid(GridSquare[][] squares, OutputAdapter outputAdapter) {
+  protected Grid(GridSquare[][] squares) {
     this.grid = squares;
     this.height = squares.length;
     this.width = squares[0].length;
-    this.outputAdapter = outputAdapter;
   }
 
   public void printGrid() {
@@ -41,18 +37,6 @@ public class Grid {
     } else {
       throw new NeighborhoodRuntimeException(ExceptionKeys.GET_SQUARE_FAILED);
     }
-  }
-
-  /** Hides all buckets from the screen */
-  public void hideBuckets() {
-    this.outputAdapter.sendMessage(
-        new NeighborhoodSignalMessage(NeighborhoodSignalKey.HIDE_BUCKETS, new HashMap<>()));
-  }
-
-  /** Displays all buckets on the screen */
-  public void showBuckets() {
-    this.outputAdapter.sendMessage(
-        new NeighborhoodSignalMessage(NeighborhoodSignalKey.SHOW_BUCKETS, new HashMap<>()));
   }
 
   public int getSize() {

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/support/GridFactory.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/support/GridFactory.java
@@ -3,7 +3,6 @@ package org.code.neighborhood.support;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import org.code.protocol.OutputAdapter;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -13,11 +12,8 @@ public class GridFactory {
   private static final String GRID_SQUARE_TYPE_FIELD = "tileType";
   private static final String GRID_SQUARE_ASSET_ID_FIELD = "assetId";
   private static final String GRID_SQUARE_VALUE_FIELD = "value";
-  private final OutputAdapter outputAdapter;
 
-  protected GridFactory(OutputAdapter outputAdapter) {
-    this.outputAdapter = outputAdapter;
-  }
+  protected GridFactory() {}
 
   protected Grid createGridFromJSON(String filename) throws IOException {
     File file = new File(GRID_FILE_NAME);
@@ -76,7 +72,7 @@ public class GridFactory {
           }
         }
       }
-      return new Grid(grid, this.outputAdapter);
+      return new Grid(grid);
     } catch (JSONException e) {
       throw new NeighborhoodRuntimeException(ExceptionKeys.INVALID_GRID);
     }
@@ -91,6 +87,6 @@ public class GridFactory {
         grid[i][j] = new GridSquare(1, 0);
       }
     }
-    return new Grid(grid, this.outputAdapter);
+    return new Grid(grid);
   }
 }

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/support/World.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/support/World.java
@@ -6,7 +6,6 @@ import org.code.protocol.*;
 public class World {
   private static World worldInstance;
   private final Grid grid;
-  private final OutputAdapter outputAdapter;
 
   private static class CloseListener implements LifecycleListener {
     @Override
@@ -17,15 +16,13 @@ public class World {
 
   public World(int size) {
     this.registerLifecycleListener();
-    this.outputAdapter = GlobalProtocol.getInstance().getOutputAdapter();
-    GridFactory gridFactory = new GridFactory(this.outputAdapter);
+    GridFactory gridFactory = new GridFactory();
     this.grid = gridFactory.createEmptyGrid(size);
   }
 
   public World(String s) {
     this.registerLifecycleListener();
-    this.outputAdapter = GlobalProtocol.getInstance().getOutputAdapter();
-    GridFactory gridFactory = new GridFactory(this.outputAdapter);
+    GridFactory gridFactory = new GridFactory();
     try {
       this.grid = gridFactory.createGridFromString(s);
     } catch (IOException e) {
@@ -35,8 +32,7 @@ public class World {
 
   private World() {
     this.registerLifecycleListener();
-    this.outputAdapter = GlobalProtocol.getInstance().getOutputAdapter();
-    GridFactory gridFactory = new GridFactory(this.outputAdapter);
+    GridFactory gridFactory = new GridFactory();
     try {
       this.grid = gridFactory.createGridFromJSON("grid.txt");
     } catch (IOException e) {
@@ -53,10 +49,6 @@ public class World {
 
   public Grid getGrid() {
     return this.grid;
-  }
-
-  public OutputAdapter getOutputAdapter() {
-    return this.outputAdapter;
   }
 
   public static void setInstance(World world) {

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/support/GridFactoryTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/support/GridFactoryTest.java
@@ -1,10 +1,8 @@
 package org.code.neighborhood.support;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
-import org.code.protocol.OutputAdapter;
 import org.junit.jupiter.api.Test;
 
 public class GridFactoryTest {
@@ -13,7 +11,7 @@ public class GridFactoryTest {
 
   @Test
   void createGridFromString() {
-    GridFactory gridFactory = new GridFactory(mock(OutputAdapter.class));
+    GridFactory gridFactory = new GridFactory();
     Grid grid = null;
     try {
       grid = gridFactory.createGridFromString(sampleGrid);
@@ -26,7 +24,7 @@ public class GridFactoryTest {
 
   @Test
   void createEmptyGrid() {
-    GridFactory gridFactory = new GridFactory(mock(OutputAdapter.class));
+    GridFactory gridFactory = new GridFactory();
     Grid grid = gridFactory.createEmptyGrid(2);
     assertTrue(grid instanceof Grid);
     assertTrue(grid.validLocation(1, 1));
@@ -34,7 +32,7 @@ public class GridFactoryTest {
 
   @Test
   void createGridFromStringWithInvalidJSONThrowsException() {
-    GridFactory gridFactory = new GridFactory(mock(OutputAdapter.class));
+    GridFactory gridFactory = new GridFactory();
     Exception exception =
         assertThrows(
             NeighborhoodRuntimeException.class,
@@ -48,7 +46,7 @@ public class GridFactoryTest {
 
   @Test
   void createGridFromStringWithInvalidGridShapeThrowsException() {
-    GridFactory gridFactory = new GridFactory(mock(OutputAdapter.class));
+    GridFactory gridFactory = new GridFactory();
     Exception exception =
         assertThrows(
             NeighborhoodRuntimeException.class,
@@ -62,7 +60,7 @@ public class GridFactoryTest {
 
   @Test
   void createGridFromNotSquareGridThrowsException() {
-    GridFactory gridFactory = new GridFactory(mock(OutputAdapter.class));
+    GridFactory gridFactory = new GridFactory();
     Exception exception =
         assertThrows(
             NeighborhoodRuntimeException.class,
@@ -76,7 +74,7 @@ public class GridFactoryTest {
 
   @Test
   void createGridFromStringWithInvalidTileTypeThrowsException() {
-    GridFactory gridFactory = new GridFactory(mock(OutputAdapter.class));
+    GridFactory gridFactory = new GridFactory();
     Exception exception =
         assertThrows(
             NeighborhoodRuntimeException.class,
@@ -89,7 +87,7 @@ public class GridFactoryTest {
 
   @Test
   void createGridFromStringWithInvalidAssetIdThrowsException() {
-    GridFactory gridFactory = new GridFactory(mock(OutputAdapter.class));
+    GridFactory gridFactory = new GridFactory();
     Exception exception =
         assertThrows(
             NeighborhoodRuntimeException.class,
@@ -102,7 +100,7 @@ public class GridFactoryTest {
 
   @Test
   void createGridFromStringWithInvalidValueThrowsException() {
-    GridFactory gridFactory = new GridFactory(mock(OutputAdapter.class));
+    GridFactory gridFactory = new GridFactory();
     Exception exception =
         assertThrows(
             NeighborhoodRuntimeException.class,
@@ -116,7 +114,7 @@ public class GridFactoryTest {
 
   @Test
   void creatingEmptyGridThrowsException() {
-    GridFactory gridFactory = new GridFactory(mock(OutputAdapter.class));
+    GridFactory gridFactory = new GridFactory();
     Exception exception =
         assertThrows(
             NeighborhoodRuntimeException.class,

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/support/GridTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/support/GridTest.java
@@ -1,9 +1,7 @@
 package org.code.neighborhood.support;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
 
-import org.code.protocol.OutputAdapter;
 import org.junit.jupiter.api.Test;
 
 public class GridTest {
@@ -13,7 +11,7 @@ public class GridTest {
     GridSquare s = new GridSquare(1, 0);
     GridSquare[][] squares = new GridSquare[1][1];
     squares[0][0] = s;
-    Grid grid = new Grid(squares, mock(OutputAdapter.class));
+    Grid grid = new Grid(squares);
   }
 
   @Test
@@ -21,7 +19,7 @@ public class GridTest {
     GridSquare s = new GridSquare(1, 0);
     GridSquare[][] squares = new GridSquare[1][1];
     squares[0][0] = s;
-    Grid grid = new Grid(squares, mock(OutputAdapter.class));
+    Grid grid = new Grid(squares);
     assertTrue(grid.validLocation(0, 0));
     assertFalse(grid.validLocation(0, 1));
     assertFalse(grid.validLocation(1, 0));
@@ -34,7 +32,7 @@ public class GridTest {
     GridSquare s = new GridSquare(1, 0);
     GridSquare[][] squares = new GridSquare[1][1];
     squares[0][0] = s;
-    Grid grid = new Grid(squares, mock(OutputAdapter.class));
+    Grid grid = new Grid(squares);
     GridSquare sq = grid.getSquare(0, 0);
     assertEquals(sq, s);
   }
@@ -44,7 +42,7 @@ public class GridTest {
     GridSquare s = new GridSquare(1, 0);
     GridSquare[][] squares = new GridSquare[1][1];
     squares[0][0] = s;
-    Grid grid = new Grid(squares, mock(OutputAdapter.class));
+    Grid grid = new Grid(squares);
     Exception exception =
         assertThrows(
             NeighborhoodRuntimeException.class,


### PR DESCRIPTION
When working on [this change](https://codedotorg.atlassian.net/browse/JAVA-600) and trying to refactor `World.java`, I noticed we only pass `outputAdapter` around from `World` to `GridFactory` to `Grid` so we can output the show/hide bucket methods. We moved these methods up to the painter since we only expose the painter to students. I removed the show/hide painter methods from `Grid` and instead send the output message directly from `Painter` and was able to remove all references to `outputAdapter` from `World`, `GridFactory`, and `Grid`.

With this change `painter` now gets `outputAdapter` directly from `GlobalProtocol`, similar to our other mini apps.

I also updated the gitignore to ignore a neighborhood file that is auto-generated locally that we never want to commit.