### PR TITLE
Fix template configuration for composite alarm

### DIFF
--- a/template.yml.erb
+++ b/template.yml.erb
@@ -652,6 +652,12 @@ Resources:
 
   HighUsageCompositeAlarm:
     Type: AWS::CloudWatch::CompositeAlarm
+    DependsOn:
+      - HighHttpRequestsAlarm
+      -  HighWebsocketConnectionsAlarm
+      -  NeighborhoodHighInvocationsAlarm
+      -  TheaterHighInvocationsAlarm
+      -  PlaygroundHighInvocationsAlarm
     Properties:
         ActionsEnabled: true
         AlarmActions:


### PR DESCRIPTION
The new composite alarm fails to deploy if in a stack that does not already contain the alarms it depends on. Fix this by adding a `DependsOn` clause to the alarm configuration in cloudformation.