### PR TITLE
Part 1 of adding global JavabuilderContext

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketServer.java
@@ -53,6 +53,7 @@ public class WebSocketServer {
   @OnOpen
   public void onOpen(Session session) {
     this.finishedExecution = false;
+    JavabuilderContext.getInstance().destroyAndReset();
     PerformanceTracker.resetTracker();
     PerformanceTracker.getInstance().trackInstanceStart(Clock.systemUTC().instant());
     // Decode the authorization token

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilderRunnable.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeBuilderRunnable.java
@@ -34,7 +34,10 @@ public class CodeBuilderRunnable {
     UserProjectFiles validationFiles = fileLoader.getValidation();
     CodeBuilder codeBuilder =
         new CodeBuilder(
-            GlobalProtocol.getInstance(), userProjectFiles, validationFiles, this.tempFolder);
+            JavabuilderContext.getInstance().getGlobalProtocol(),
+            userProjectFiles,
+            validationFiles,
+            this.tempFolder);
     switch (this.executionType) {
       case COMPILE_ONLY:
         codeBuilder.buildUserCode(this.compileList);

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeExecutionManager.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeExecutionManager.java
@@ -125,8 +125,12 @@ public class CodeExecutionManager {
    */
   private void onPreExecute() throws InternalServerException {
     // Create the Global Protocol instance
-    GlobalProtocol protocolInstance = new GlobalProtocol(
-        this.outputAdapter, new InputHandler(this.inputAdapter), this.lifecycleNotifier, this.contentManager);
+    GlobalProtocol protocolInstance =
+        new GlobalProtocol(
+            this.outputAdapter,
+            new InputHandler(this.inputAdapter),
+            this.lifecycleNotifier,
+            this.contentManager);
     JavabuilderContext.getInstance().register(GlobalProtocol.class, protocolInstance);
 
     // Create temp folder
@@ -139,8 +143,7 @@ public class CodeExecutionManager {
     // Save System in/out and replace with custom in/out
     this.systemInputStream = System.in;
     this.systemOutputStream = System.out;
-    this.overrideInputStream =
-        new InputRedirectionStream(protocolInstance.getInputHandler());
+    this.overrideInputStream = new InputRedirectionStream(protocolInstance.getInputHandler());
     this.overrideOutputStream = new OutputPrintStream(this.outputAdapter);
     System.setOut(this.overrideOutputStream);
     System.setIn(this.overrideInputStream);
@@ -157,7 +160,7 @@ public class CodeExecutionManager {
     LambdaUtils.safelySendMessage(
         this.outputAdapter, new StatusMessage(StatusMessageKey.EXITED), false);
     this.lifecycleNotifier.onExecutionEnded();
-    JavabuilderContext.getInstance().getGlobalProtocol().cleanUpResources();
+    JavabuilderContext.getInstance().onExecutionEnded();
     try {
       // Close custom input/output streams
       this.overrideInputStream.close();

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -99,11 +99,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
   public String handleRequest(Map<String, String> lambdaInput, Context context) {
     this.isSessionInitialized = false;
     this.trackStartupPerformance();
-    if (JavabuilderContext.getInstance() == null) {
-      JavabuilderContext.create();
-    } else {
-      JavabuilderContext.getInstance().destroyAndReset();
-    }
+    JavabuilderContext.getInstance().destroyAndReset();
 
     // TODO: Because we reference the logger object throughout the codebase via
     // Logger.getLogger(MAIN_LOGGER), we need to set it up in the same scope as code execution to

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -99,6 +99,11 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
   public String handleRequest(Map<String, String> lambdaInput, Context context) {
     this.isSessionInitialized = false;
     this.trackStartupPerformance();
+    if (JavabuilderContext.getInstance() == null) {
+      JavabuilderContext.create();
+    } else {
+      JavabuilderContext.getInstance().destroyAndReset();
+    }
 
     // TODO: Because we reference the logger object throughout the codebase via
     // Logger.getLogger(MAIN_LOGGER), we need to set it up in the same scope as code execution to

--- a/org-code-javabuilder/media/src/main/java/org/code/media/Image.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/Image.java
@@ -8,7 +8,7 @@ import java.net.URL;
 import javax.imageio.ImageIO;
 import org.code.media.support.MediaRuntimeException;
 import org.code.media.support.MediaRuntimeExceptionKeys;
-import org.code.protocol.GlobalProtocol;
+import org.code.protocol.JavabuilderContext;
 
 public class Image {
   private Pixel[][] pixels;
@@ -179,7 +179,11 @@ public class Image {
   public static BufferedImage getImageAssetFromFile(String filename) throws FileNotFoundException {
     try {
       return Image.getImageFromUrl(
-          new URL(GlobalProtocol.getInstance().getContentManager().getAssetUrl(filename)));
+          new URL(
+              JavabuilderContext.getInstance()
+                  .getGlobalProtocol()
+                  .getContentManager()
+                  .getAssetUrl(filename)));
     } catch (IOException e) {
       throw new FileNotFoundException(filename);
     }

--- a/org-code-javabuilder/media/src/main/java/org/code/media/util/AudioUtils.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/util/AudioUtils.java
@@ -6,9 +6,9 @@ import java.util.Arrays;
 import javax.sound.sampled.*;
 import org.code.media.SoundException;
 import org.code.media.support.SoundExceptionKeys;
-import org.code.protocol.GlobalProtocol;
 import org.code.protocol.InternalExceptionKey;
 import org.code.protocol.InternalServerRuntimeException;
+import org.code.protocol.JavabuilderContext;
 
 public final class AudioUtils {
   private AudioUtils() {
@@ -180,7 +180,11 @@ public final class AudioUtils {
   public static double[] readSamplesFromAssetFile(String filename) throws FileNotFoundException {
     try {
       final URL audioFileUrl =
-          new URL(GlobalProtocol.getInstance().getContentManager().getAssetUrl(filename));
+          new URL(
+              JavabuilderContext.getInstance()
+                  .getGlobalProtocol()
+                  .getContentManager()
+                  .getAssetUrl(filename));
       final AudioInputStream audioInputStream =
           AudioUtils.convertStreamToDefaultAudioFormat(
               AudioSystem.getAudioInputStream(audioFileUrl));

--- a/org-code-javabuilder/media/src/test/java/org/code/media/ImageTest.java
+++ b/org-code-javabuilder/media/src/test/java/org/code/media/ImageTest.java
@@ -8,7 +8,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import org.code.protocol.ContentManager;
 import org.code.protocol.GlobalProtocolTestFactory;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -19,11 +18,6 @@ public class ImageTest {
   public void setUp() {
     contentManager = mock(ContentManager.class);
     GlobalProtocolTestFactory.builder().withContentManager(contentManager).create();
-  }
-
-  @AfterEach
-  public void tearDown() {
-    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test

--- a/org-code-javabuilder/media/src/test/java/org/code/media/support/AudioUtilsTest.java
+++ b/org-code-javabuilder/media/src/test/java/org/code/media/support/AudioUtilsTest.java
@@ -56,7 +56,6 @@ class AudioUtilsTest {
 
   @AfterEach
   public void tearDown() {
-    GlobalProtocolTestFactory.tearDown();
     audioSystem.close();
   }
 

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/support/World.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/support/World.java
@@ -3,25 +3,15 @@ package org.code.neighborhood.support;
 import java.io.IOException;
 import org.code.protocol.*;
 
-public class World {
-  private static World worldInstance;
+public class World extends JavabuilderSharedObject {
   private final Grid grid;
 
-  private static class CloseListener implements LifecycleListener {
-    @Override
-    public void onExecutionEnded() {
-      World.setInstance(null);
-    }
-  }
-
   public World(int size) {
-    this.registerLifecycleListener();
     GridFactory gridFactory = new GridFactory();
     this.grid = gridFactory.createEmptyGrid(size);
   }
 
   public World(String s) {
-    this.registerLifecycleListener();
     GridFactory gridFactory = new GridFactory();
     try {
       this.grid = gridFactory.createGridFromString(s);
@@ -30,8 +20,7 @@ public class World {
     }
   }
 
-  private World() {
-    this.registerLifecycleListener();
+  public World() {
     GridFactory gridFactory = new GridFactory();
     try {
       this.grid = gridFactory.createGridFromJSON("grid.txt");
@@ -40,22 +29,7 @@ public class World {
     }
   }
 
-  public static World getInstance() {
-    if (worldInstance == null) {
-      worldInstance = new World();
-    }
-    return worldInstance;
-  }
-
   public Grid getGrid() {
     return this.grid;
-  }
-
-  public static void setInstance(World world) {
-    worldInstance = world;
-  }
-
-  private void registerLifecycleListener() {
-    GlobalProtocol.getInstance().registerLifecycleListener(new CloseListener());
   }
 }

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
@@ -19,7 +19,6 @@ public class PainterTest {
   String singleSquareGrid = "[[\n{\"tileType\": 1, \"assetId\": 0}]]";
   String multiSquareGrid =
       "[[\n{\"tileType\": 1, \"value\": 1, \"assetId\": 0}, {\"tileType\": 1, \"value\": 1, \"assetId\": 0}], \n[{\"tileType\": 1, \"value\": 1, \"assetId\": 0}, {\"tileType\": 1, \"value\": 1, \"assetId\": 0}]]";
-  private World world;
 
   @BeforeEach
   public void setUp() {

--- a/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
+++ b/org-code-javabuilder/neighborhood/src/test/java/org/code/neighborhood/PainterTest.java
@@ -19,19 +19,19 @@ public class PainterTest {
   String singleSquareGrid = "[[\n{\"tileType\": 1, \"assetId\": 0}]]";
   String multiSquareGrid =
       "[[\n{\"tileType\": 1, \"value\": 1, \"assetId\": 0}, {\"tileType\": 1, \"value\": 1, \"assetId\": 0}], \n[{\"tileType\": 1, \"value\": 1, \"assetId\": 0}, {\"tileType\": 1, \"value\": 1, \"assetId\": 0}]]";
+  private World world;
 
   @BeforeEach
   public void setUp() {
     GlobalProtocolTestFactory.builder().withOutputAdapter(outputAdapter).create();
     System.setOut(new PrintStream(outputStreamCaptor));
-    World w = new World(singleSquareGrid);
-    World.setInstance(w);
+    World world = new World(singleSquareGrid);
+    JavabuilderContext.getInstance().register(World.class, world);
   }
 
   @AfterEach
   public void tearDown() {
     System.setOut(standardOut);
-    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test
@@ -82,7 +82,7 @@ public class PainterTest {
 
   @Test
   void canMoveReturnsTrueIfCurrentDirectionValid() {
-    World.setInstance(new World(multiSquareGrid));
+    JavabuilderContext.getInstance().register(World.class, new World(multiSquareGrid));
     Painter painter = new Painter(0, 0, "South", 5);
     assertTrue(painter.canMove());
   }
@@ -103,7 +103,7 @@ public class PainterTest {
   @Test
   void moveSignalsNewLocationIfValidMovement() {
     World w = new World(multiSquareGrid);
-    World.setInstance(w);
+    JavabuilderContext.getInstance().register(World.class, w);
     Painter painter = new Painter(0, 0, "West", 5);
     painter.turnLeft();
     ArgumentCaptor<NeighborhoodSignalMessage> message =
@@ -125,7 +125,7 @@ public class PainterTest {
   @Test
   void takePaintIncrementsPaint() {
     World w = new World(multiSquareGrid);
-    World.setInstance(w);
+    JavabuilderContext.getInstance().register(World.class, w);
     Painter painter = new Painter(0, 0, "North", 5);
     assertEquals(painter.getMyPaint(), 5);
     painter.takePaint();
@@ -154,7 +154,7 @@ public class PainterTest {
   @Test
   void largeGridInfinitePaintDefaultConstructor() {
     World w = new World(20);
-    World.setInstance(w);
+    JavabuilderContext.getInstance().register(World.class, w);
     Painter painter = new Painter();
     assertTrue(painter.hasPaint());
   }
@@ -162,7 +162,7 @@ public class PainterTest {
   @Test
   void noInfinitePaintDefaultConstructor() {
     World w = new World(19);
-    World.setInstance(w);
+    JavabuilderContext.getInstance().register(World.class, w);
     Painter painter = new Painter();
     assertFalse(painter.hasPaint());
   }
@@ -170,7 +170,7 @@ public class PainterTest {
   @Test
   void largeGridNoInfinitePaintWhenPaintSpecified() {
     World w = new World(20);
-    World.setInstance(w);
+    JavabuilderContext.getInstance().register(World.class, w);
     Painter painter = new Painter(0, 0, "North", 1);
     assertTrue(painter.hasPaint());
     painter.paint("red");
@@ -180,7 +180,7 @@ public class PainterTest {
   @Test
   void noInfinitePaint() {
     World w = new World(19);
-    World.setInstance(w);
+    JavabuilderContext.getInstance().register(World.class, w);
     Painter painter = new Painter(0, 0, "North", 1);
     assertTrue(painter.hasPaint());
     painter.paint("red");
@@ -190,7 +190,7 @@ public class PainterTest {
   @Test
   void testGetXReturnsXPos() {
     World w = new World(20);
-    World.setInstance(w);
+    JavabuilderContext.getInstance().register(World.class, w);
 
     final int xPos = 10;
     Painter painter = new Painter(xPos, 0, "East", 1);
@@ -204,7 +204,7 @@ public class PainterTest {
   @Test
   void testGetYReturnsYPos() {
     World w = new World(20);
-    World.setInstance(w);
+    JavabuilderContext.getInstance().register(World.class, w);
 
     final int yPos = 5;
     Painter painter = new Painter(0, yPos, "South", 1);
@@ -218,7 +218,7 @@ public class PainterTest {
   @Test
   void testGetDirectionReturnsDirectionString() {
     World w = new World(20);
-    World.setInstance(w);
+    JavabuilderContext.getInstance().register(World.class, w);
 
     final String direction = "North";
     Painter painter = new Painter(0, 0, direction, 1);
@@ -228,7 +228,7 @@ public class PainterTest {
   @Test
   void testSetPaintDoesNothingIfNegative() {
     World w = new World(20);
-    World.setInstance(w);
+    JavabuilderContext.getInstance().register(World.class, w);
 
     final int originalPaint = 10;
     Painter painter = new Painter(0, 0, "North", originalPaint);
@@ -239,7 +239,7 @@ public class PainterTest {
   @Test
   void testSetPaintDoesNothingIfHasInfinitePaint() {
     World w = new World(20);
-    World.setInstance(w);
+    JavabuilderContext.getInstance().register(World.class, w);
 
     Painter painter = new Painter();
     painter.setPaint(30);
@@ -249,7 +249,7 @@ public class PainterTest {
   @Test
   void testSetPaintUpdatesAmount() {
     World w = new World(20);
-    World.setInstance(w);
+    JavabuilderContext.getInstance().register(World.class, w);
 
     final int newPaint = 20;
     Painter painter = new Painter(0, 0, "North", 10);

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/Board.java
@@ -23,8 +23,8 @@ public class Board {
   protected Board() {
     this(
         PlaygroundMessageHandler.getInstance(),
-        GlobalProtocol.getInstance().getInputHandler(),
-        GlobalProtocol.getInstance().getContentManager());
+        JavabuilderContext.getInstance().getGlobalProtocol().getInputHandler(),
+        JavabuilderContext.getInstance().getGlobalProtocol().getContentManager());
   }
 
   Board(

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
@@ -4,7 +4,6 @@ import java.io.FileNotFoundException;
 import java.util.HashMap;
 import org.code.protocol.ClientMessageDetailKeys;
 import org.code.protocol.ContentManager;
-import org.code.protocol.GlobalProtocol;
 import org.code.protocol.JavabuilderContext;
 
 public class ImageItem extends Item {
@@ -27,7 +26,13 @@ public class ImageItem extends Item {
    */
   public ImageItem(String filename, int x, int y, int width, int height)
       throws FileNotFoundException {
-    this(filename, x, y, width, height, JavabuilderContext.getInstance().getGlobalProtocol().getContentManager());
+    this(
+        filename,
+        x,
+        y,
+        width,
+        height,
+        JavabuilderContext.getInstance().getGlobalProtocol().getContentManager());
   }
 
   // Visible for testing only

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/ImageItem.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import org.code.protocol.ClientMessageDetailKeys;
 import org.code.protocol.ContentManager;
 import org.code.protocol.GlobalProtocol;
+import org.code.protocol.JavabuilderContext;
 
 public class ImageItem extends Item {
   private final ContentManager contentManager;
@@ -26,7 +27,7 @@ public class ImageItem extends Item {
    */
   public ImageItem(String filename, int x, int y, int width, int height)
       throws FileNotFoundException {
-    this(filename, x, y, width, height, GlobalProtocol.getInstance().getContentManager());
+    this(filename, x, y, width, height, JavabuilderContext.getInstance().getGlobalProtocol().getContentManager());
   }
 
   // Visible for testing only

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundMessageHandler.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundMessageHandler.java
@@ -2,10 +2,8 @@ package org.code.playground;
 
 import java.util.LinkedList;
 import java.util.Queue;
-import org.code.protocol.ClientMessageDetailKeys;
-import org.code.protocol.GlobalProtocol;
-import org.code.protocol.MessageHandler;
-import org.code.protocol.OutputAdapter;
+
+import org.code.protocol.*;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -27,8 +25,8 @@ class PlaygroundMessageHandler implements MessageHandler {
   private final OutputAdapter outputAdapter;
 
   private PlaygroundMessageHandler() {
-    this(GlobalProtocol.getInstance().getOutputAdapter());
-    GlobalProtocol.getInstance().registerMessageHandler(this);
+    this(JavabuilderContext.getInstance().getGlobalProtocol().getOutputAdapter());
+    JavabuilderContext.getInstance().getGlobalProtocol().registerMessageHandler(this);
   }
 
   // Visible for testing only

--- a/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundMessageHandler.java
+++ b/org-code-javabuilder/playground/src/main/java/org/code/playground/PlaygroundMessageHandler.java
@@ -2,7 +2,6 @@ package org.code.playground;
 
 import java.util.LinkedList;
 import java.util.Queue;
-
 import org.code.protocol.*;
 import org.json.JSONArray;
 import org.json.JSONObject;

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/BoardTest.java
@@ -9,7 +9,6 @@ import org.code.media.Color;
 import org.code.media.Font;
 import org.code.media.FontStyle;
 import org.code.protocol.*;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -31,11 +30,6 @@ class BoardTest {
 
     GlobalProtocolTestFactory.builder().withContentManager(contentManager).create();
     unitUnderTest = new Board(playgroundMessageHandler, inputHandler, contentManager);
-  }
-
-  @AfterEach
-  public void tearDown() {
-    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/ImageItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/ImageItemTest.java
@@ -33,7 +33,6 @@ public class ImageItemTest {
   @AfterEach
   public void tearDown() {
     messageHandlerMockedStatic.close();
-    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/ItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/ItemTest.java
@@ -31,7 +31,6 @@ public class ItemTest {
   @AfterEach
   public void tearDown() {
     messageHandlerMockedStatic.close();
-    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test

--- a/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
+++ b/org-code-javabuilder/playground/src/test/java/org/code/playground/TextItemTest.java
@@ -35,7 +35,6 @@ public class TextItemTest {
   @AfterEach
   public void tearDown() {
     messageHandlerMockedStatic.close();
-    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
@@ -1,10 +1,7 @@
 package org.code.protocol;
 
-import static org.code.protocol.LoggerNames.MAIN_LOGGER;
-
 import java.util.HashSet;
 import java.util.Set;
-import java.util.logging.Logger;
 
 /**
  * This sets up the protocols that are used across jars in Javabuilder. It allows the input and
@@ -14,8 +11,8 @@ import java.util.logging.Logger;
  * allows these APIs to communicate with their Client-side counterparts while using the correct IO
  * adapters.
  */
-public class GlobalProtocol implements JavabuilderSharedObject {
-  //private static GlobalProtocol protocolInstance;
+public class GlobalProtocol extends JavabuilderSharedObject {
+  // private static GlobalProtocol protocolInstance;
   private final OutputAdapter outputAdapter;
   private final InputHandler inputHandler;
   private final Set<MessageHandler> messageHandlers;
@@ -32,37 +29,6 @@ public class GlobalProtocol implements JavabuilderSharedObject {
     this.messageHandlers = new HashSet<>();
     this.lifecycleNotifier = lifecycleNotifier;
     this.contentManager = contentManager;
-  }
-
-//  public static void create(
-//      OutputAdapter outputAdapter,
-//      InputAdapter inputAdapter,
-//      LifecycleNotifier lifecycleNotifier,
-//      ContentManager contentManager) {
-//    if (GlobalProtocol.protocolInstance != null) {
-//      Logger.getLogger(MAIN_LOGGER)
-//          .warning("Tried to create GlobalProtocol instance when one already exists.");
-//    }
-//    GlobalProtocol.protocolInstance =
-//        new GlobalProtocol(
-//            outputAdapter, new InputHandler(inputAdapter), lifecycleNotifier, contentManager);
-//  }
-
-//  public static GlobalProtocol getInstance() {
-//    if (GlobalProtocol.protocolInstance == null) {
-//      throw new InternalServerRuntimeException(InternalExceptionKey.INTERNAL_EXCEPTION);
-//    }
-//
-//    return GlobalProtocol.protocolInstance;
-//  }
-
-  public void destroy() {
-//    if (GlobalProtocol.protocolInstance == null) {
-//      Logger.getLogger(MAIN_LOGGER)
-//          .warning("Tried to destroy GlobalProtocol instance when one does not exist.");
-//    }
-//
-//    GlobalProtocol.protocolInstance = null;
   }
 
   public ContentManager getContentManager() {
@@ -85,8 +51,9 @@ public class GlobalProtocol implements JavabuilderSharedObject {
     this.lifecycleNotifier.registerListener(listener);
   }
 
+  @Override
   // Clean up resources that require explicit clean up before exiting
-  public void cleanUpResources() {
+  public void onExecutionEnded() {
     for (MessageHandler handler : this.messageHandlers) {
       handler.exit();
     }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
@@ -14,15 +14,15 @@ import java.util.logging.Logger;
  * allows these APIs to communicate with their Client-side counterparts while using the correct IO
  * adapters.
  */
-public class GlobalProtocol {
-  private static GlobalProtocol protocolInstance;
+public class GlobalProtocol implements JavabuilderSharedObject {
+  //private static GlobalProtocol protocolInstance;
   private final OutputAdapter outputAdapter;
   private final InputHandler inputHandler;
   private final Set<MessageHandler> messageHandlers;
   private final LifecycleNotifier lifecycleNotifier;
   private final ContentManager contentManager;
 
-  private GlobalProtocol(
+  public GlobalProtocol(
       OutputAdapter outputAdapter,
       InputHandler inputHandler,
       LifecycleNotifier lifecycleNotifier,
@@ -34,35 +34,35 @@ public class GlobalProtocol {
     this.contentManager = contentManager;
   }
 
-  public static void create(
-      OutputAdapter outputAdapter,
-      InputAdapter inputAdapter,
-      LifecycleNotifier lifecycleNotifier,
-      ContentManager contentManager) {
-    if (GlobalProtocol.protocolInstance != null) {
-      Logger.getLogger(MAIN_LOGGER)
-          .warning("Tried to create GlobalProtocol instance when one already exists.");
-    }
-    GlobalProtocol.protocolInstance =
-        new GlobalProtocol(
-            outputAdapter, new InputHandler(inputAdapter), lifecycleNotifier, contentManager);
-  }
+//  public static void create(
+//      OutputAdapter outputAdapter,
+//      InputAdapter inputAdapter,
+//      LifecycleNotifier lifecycleNotifier,
+//      ContentManager contentManager) {
+//    if (GlobalProtocol.protocolInstance != null) {
+//      Logger.getLogger(MAIN_LOGGER)
+//          .warning("Tried to create GlobalProtocol instance when one already exists.");
+//    }
+//    GlobalProtocol.protocolInstance =
+//        new GlobalProtocol(
+//            outputAdapter, new InputHandler(inputAdapter), lifecycleNotifier, contentManager);
+//  }
 
-  public static GlobalProtocol getInstance() {
-    if (GlobalProtocol.protocolInstance == null) {
-      throw new InternalServerRuntimeException(InternalExceptionKey.INTERNAL_EXCEPTION);
-    }
+//  public static GlobalProtocol getInstance() {
+//    if (GlobalProtocol.protocolInstance == null) {
+//      throw new InternalServerRuntimeException(InternalExceptionKey.INTERNAL_EXCEPTION);
+//    }
+//
+//    return GlobalProtocol.protocolInstance;
+//  }
 
-    return GlobalProtocol.protocolInstance;
-  }
-
-  public static void destroy() {
-    if (GlobalProtocol.protocolInstance == null) {
-      Logger.getLogger(MAIN_LOGGER)
-          .warning("Tried to destroy GlobalProtocol instance when one does not exist.");
-    }
-
-    GlobalProtocol.protocolInstance = null;
+  public void destroy() {
+//    if (GlobalProtocol.protocolInstance == null) {
+//      Logger.getLogger(MAIN_LOGGER)
+//          .warning("Tried to destroy GlobalProtocol instance when one does not exist.");
+//    }
+//
+//    GlobalProtocol.protocolInstance = null;
   }
 
   public ContentManager getContentManager() {

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
@@ -12,7 +12,6 @@ import java.util.Set;
  * adapters.
  */
 public class GlobalProtocol extends JavabuilderSharedObject {
-  // private static GlobalProtocol protocolInstance;
   private final OutputAdapter outputAdapter;
   private final InputHandler inputHandler;
   private final Set<MessageHandler> messageHandlers;

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderContext.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderContext.java
@@ -5,10 +5,10 @@ import java.util.Map;
 
 public class JavabuilderContext {
   private static JavabuilderContext contextInstance;
-  private Map<Class, Object> singletons;
+  private Map<Class, JavabuilderSharedObject> sharedObjects;
 
   private JavabuilderContext() {
-    this.singletons = new HashMap<>();
+    this.sharedObjects = new HashMap<>();
   }
 
   public static void create() {
@@ -16,24 +16,34 @@ public class JavabuilderContext {
   }
 
   public static JavabuilderContext getInstance() {
+    if (contextInstance == null) {
+      JavabuilderContext.create();
+    }
     return contextInstance;
   }
 
-  public void reset() {
-    this.singletons = new HashMap<>();
+  public void destroyAndReset() {
+    for(JavabuilderSharedObject sharedObject: sharedObjects.values()) {
+      sharedObject.destroy();
+    }
+    this.sharedObjects = new HashMap<>();
   }
 
-  public void destroy() {
-    this.reset();
+  public void register(Class objectClass, JavabuilderSharedObject sharedObject) {
+    this.sharedObjects.put(objectClass, sharedObject);
   }
 
-  public void registerSingleton(Class singletonClass, Object singleton) {
-    this.singletons.put(singletonClass, singleton);
+  public JavabuilderSharedObject get(Class objectClass) {
+    if (this.sharedObjects.containsKey(objectClass)) {
+      return this.sharedObjects.get(objectClass);
+    }
+    return null;
   }
 
-  public Object getSingleton(Class singletonClass) {
-    if (this.singletons.containsKey(singletonClass)) {
-      return this.singletons.get(singletonClass);
+  // Convenience method for getting Global Protocol, if it exists.
+  public GlobalProtocol getGlobalProtocol() {
+    if (this.sharedObjects.containsKey(GlobalProtocol.class)) {
+      return (GlobalProtocol) this.sharedObjects.get(GlobalProtocol.class);
     }
     return null;
   }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderContext.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderContext.java
@@ -22,8 +22,14 @@ public class JavabuilderContext {
     return contextInstance;
   }
 
+  public void onExecutionEnded() {
+    for (JavabuilderSharedObject sharedObject : sharedObjects.values()) {
+      sharedObject.onExecutionEnded();
+    }
+  }
+
   public void destroyAndReset() {
-    for(JavabuilderSharedObject sharedObject: sharedObjects.values()) {
+    for (JavabuilderSharedObject sharedObject : sharedObjects.values()) {
       sharedObject.destroy();
     }
     this.sharedObjects = new HashMap<>();

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderContext.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderContext.java
@@ -1,0 +1,40 @@
+package org.code.protocol;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class JavabuilderContext {
+  private static JavabuilderContext contextInstance;
+  private Map<Class, Object> singletons;
+
+  private JavabuilderContext() {
+    this.singletons = new HashMap<>();
+  }
+
+  public static void create() {
+    contextInstance = new JavabuilderContext();
+  }
+
+  public static JavabuilderContext getInstance() {
+    return contextInstance;
+  }
+
+  public void reset() {
+    this.singletons = new HashMap<>();
+  }
+
+  public void destroy() {
+    this.reset();
+  }
+
+  public void registerSingleton(Class singletonClass, Object singleton) {
+    this.singletons.put(singletonClass, singleton);
+  }
+
+  public Object getSingleton(Class singletonClass) {
+    if (this.singletons.containsKey(singletonClass)) {
+      return this.singletons.get(singletonClass);
+    }
+    return null;
+  }
+}

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderContext.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderContext.java
@@ -3,6 +3,11 @@ package org.code.protocol;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * This class is meant to keep track of shared singletons that should only exist for the lifetime of
+ * one Javabuilder session. Any class can be registered as long as it extends
+ * JavabuilderSharedObject, but only one object per class can be registered.
+ */
 public class JavabuilderContext {
   private static JavabuilderContext contextInstance;
   private Map<Class, JavabuilderSharedObject> sharedObjects;

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderContext.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderContext.java
@@ -36,6 +36,13 @@ public class JavabuilderContext {
   }
 
   public void register(Class objectClass, JavabuilderSharedObject sharedObject) {
+    if (!objectClass.isAssignableFrom(sharedObject.getClass())) {
+      String message =
+          String.format(
+              "Attempting to add a class, %s to JavabuilderContext that cannot be converted to its key, %s",
+              sharedObject.getClass(), objectClass);
+      throw new IllegalArgumentException(message);
+    }
     this.sharedObjects.put(objectClass, sharedObject);
   }
 

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderSharedObject.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderSharedObject.java
@@ -1,0 +1,5 @@
+package org.code.protocol;
+
+public interface JavabuilderSharedObject {
+    void destroy();
+}

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderSharedObject.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/JavabuilderSharedObject.java
@@ -1,5 +1,9 @@
 package org.code.protocol;
 
-public interface JavabuilderSharedObject {
-    void destroy();
+public abstract class JavabuilderSharedObject {
+  // Do any end of code execution clean up. By default this is a no-op.
+  public void onExecutionEnded() {}
+
+  // Destroy this object. By default this is a no-op.
+  public void destroy() {}
 }

--- a/org-code-javabuilder/protocol/src/test/java/org/code/protocol/JavabuilderContextTest.java
+++ b/org-code-javabuilder/protocol/src/test/java/org/code/protocol/JavabuilderContextTest.java
@@ -1,0 +1,54 @@
+package org.code.protocol;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+
+public class JavabuilderContextTest {
+  @Test
+  public void canRegisterAndGetGlobalProtocol() {
+    GlobalProtocol protocol = mock(GlobalProtocol.class);
+    JavabuilderContext.create();
+    JavabuilderContext.getInstance().register(GlobalProtocol.class, protocol);
+    GlobalProtocol result = JavabuilderContext.getInstance().getGlobalProtocol();
+    assertNotNull(result);
+    assertEquals(protocol, result);
+  }
+
+  @Test
+  public void cannotRegisterMismatchedClass() {
+    JavabuilderContext.create();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          JavabuilderContext.getInstance().register(TestObject2.class, new TestObject1());
+        });
+  }
+
+  @Test
+  public void canRegisterSubclass() {
+    JavabuilderContext.create();
+    TestObject3 testObject3 = new TestObject3();
+    JavabuilderContext.getInstance().register(TestObject1.class, testObject3);
+    JavabuilderSharedObject result = JavabuilderContext.getInstance().get(TestObject1.class);
+    assertNotNull(result);
+    assertEquals(testObject3, result);
+  }
+
+  @Test
+  public void canRegisterAndGetClass() {
+    JavabuilderContext.create();
+    TestObject2 testObject2 = new TestObject2();
+    JavabuilderContext.getInstance().register(TestObject2.class, testObject2);
+    JavabuilderSharedObject result = JavabuilderContext.getInstance().get(TestObject2.class);
+    assertNotNull(result);
+    assertEquals(testObject2, result);
+  }
+
+  private class TestObject1 extends JavabuilderSharedObject {}
+
+  private class TestObject2 extends JavabuilderSharedObject {}
+
+  private class TestObject3 extends TestObject1 {}
+}

--- a/org-code-javabuilder/protocol/src/testFixtures/java/org/code/protocol/GlobalProtocolTestFactory.java
+++ b/org-code-javabuilder/protocol/src/testFixtures/java/org/code/protocol/GlobalProtocolTestFactory.java
@@ -29,13 +29,13 @@ public class GlobalProtocolTestFactory {
       return this;
     }
 
-    public Builder withContentManager(ContentManager contentManager) {
-      this.contentManager = contentManager;
+    public Builder withLifecycleNotifier(LifecycleNotifier lifecycleNotifier) {
+      this.lifecycleNotifier = lifecycleNotifier;
       return this;
     }
 
-    public Builder withLifecycleNotifier(LifecycleNotifier lifecycleNotifier) {
-      this.lifecycleNotifier = lifecycleNotifier;
+    public Builder withContentManager(ContentManager contentManager) {
+      this.contentManager = contentManager;
       return this;
     }
 

--- a/org-code-javabuilder/protocol/src/testFixtures/java/org/code/protocol/GlobalProtocolTestFactory.java
+++ b/org-code-javabuilder/protocol/src/testFixtures/java/org/code/protocol/GlobalProtocolTestFactory.java
@@ -16,6 +16,7 @@ public class GlobalProtocolTestFactory {
     private Builder() {
       this.outputAdapter = mock(OutputAdapter.class);
       this.inputAdapter = mock(InputAdapter.class);
+      this.lifecycleNotifier = mock(LifecycleNotifier.class);
       this.contentManager = mock(ContentManager.class);
     }
 

--- a/org-code-javabuilder/protocol/src/testFixtures/java/org/code/protocol/GlobalProtocolTestFactory.java
+++ b/org-code-javabuilder/protocol/src/testFixtures/java/org/code/protocol/GlobalProtocolTestFactory.java
@@ -7,10 +7,6 @@ public class GlobalProtocolTestFactory {
     return new Builder();
   }
 
-  public static void tearDown() {
-    GlobalProtocol.destroy();
-  }
-
   public static class Builder {
     private OutputAdapter outputAdapter;
     private InputAdapter inputAdapter;
@@ -20,7 +16,6 @@ public class GlobalProtocolTestFactory {
     private Builder() {
       this.outputAdapter = mock(OutputAdapter.class);
       this.inputAdapter = mock(InputAdapter.class);
-      this.lifecycleNotifier = mock(LifecycleNotifier.class);
       this.contentManager = mock(ContentManager.class);
     }
 
@@ -34,19 +29,24 @@ public class GlobalProtocolTestFactory {
       return this;
     }
 
-    public Builder withLifecycleNotifier(LifecycleNotifier lifecycleNotifier) {
-      this.lifecycleNotifier = lifecycleNotifier;
-      return this;
-    }
-
     public Builder withContentManager(ContentManager contentManager) {
       this.contentManager = contentManager;
       return this;
     }
 
+    public Builder withLifecycleNotifier(LifecycleNotifier lifecycleNotifier) {
+      this.lifecycleNotifier = lifecycleNotifier;
+      return this;
+    }
+
     public void create() {
-      GlobalProtocol.create(
-          this.outputAdapter, this.inputAdapter, this.lifecycleNotifier, this.contentManager);
+      GlobalProtocol protocol =
+          new GlobalProtocol(
+              this.outputAdapter,
+              new InputHandler(this.inputAdapter),
+              this.lifecycleNotifier,
+              this.contentManager);
+      JavabuilderContext.getInstance().register(GlobalProtocol.class, protocol);
     }
   }
 }

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Prompter.java
@@ -31,9 +31,9 @@ public class Prompter {
   // accessed by students.
   protected Prompter() {
     this(
-        GlobalProtocol.getInstance().getOutputAdapter(),
-        GlobalProtocol.getInstance().getContentManager(),
-        GlobalProtocol.getInstance().getInputHandler(),
+        JavabuilderContext.getInstance().getGlobalProtocol().getOutputAdapter(),
+        JavabuilderContext.getInstance().getGlobalProtocol().getContentManager(),
+        JavabuilderContext.getInstance().getGlobalProtocol().getInputHandler(),
         new ImageCreator());
   }
 

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/Stage.java
@@ -79,8 +79,9 @@ public class Stage {
       TheaterProgressPublisher progressPublisher) {
     this.image = image;
     this.graphics = this.image.createGraphics();
-    this.outputAdapter = GlobalProtocol.getInstance().getOutputAdapter();
-    this.contentManager = GlobalProtocol.getInstance().getContentManager();
+    GlobalProtocol globalProtocol = JavabuilderContext.getInstance().getGlobalProtocol();
+    this.outputAdapter = globalProtocol.getOutputAdapter();
+    this.contentManager = globalProtocol.getContentManager();
     this.imageOutputStream = new ByteArrayOutputStream();
     this.gifWriter = gifWriterFactory.createGifWriter(this.imageOutputStream);
     this.audioOutputStream = new ByteArrayOutputStream();
@@ -95,7 +96,7 @@ public class Stage {
     this.clear(Color.WHITE);
 
     System.setProperty("java.awt.headless", "true");
-    GlobalProtocol.getInstance().registerLifecycleListener(new CloseListener(this));
+    globalProtocol.registerLifecycleListener(new CloseListener(this));
   }
 
   /** Returns the width of the theater canvas. */

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/support/ConcertCreator.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/support/ConcertCreator.java
@@ -44,8 +44,8 @@ public class ConcertCreator implements AutoCloseable {
         new GraphicsHelper.Factory(),
         new InstrumentSampleLoader(),
         new TheaterProgressPublisher(),
-        GlobalProtocol.getInstance().getOutputAdapter(),
-        GlobalProtocol.getInstance().getContentManager());
+        JavabuilderContext.getInstance().getGlobalProtocol().getOutputAdapter(),
+        JavabuilderContext.getInstance().getGlobalProtocol().getContentManager());
   }
 
   // Visible for testing

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/support/TheaterPlayer.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/support/TheaterPlayer.java
@@ -1,7 +1,7 @@
 package org.code.theater.support;
 
 import java.util.List;
-import org.code.protocol.GlobalProtocol;
+import org.code.protocol.JavabuilderContext;
 import org.code.protocol.LifecycleListener;
 
 /**
@@ -35,7 +35,7 @@ public class TheaterPlayer implements LifecycleListener {
   TheaterPlayer(ConcertCreatorFactory concertCreatorFactory) {
     this.concertCreatorFactory = concertCreatorFactory;
     this.hasPlayed = false;
-    GlobalProtocol.getInstance().registerLifecycleListener(this);
+    JavabuilderContext.getInstance().getGlobalProtocol().registerLifecycleListener(this);
   }
 
   public void play(List<SceneAction> actions) {

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/support/TheaterProgressPublisher.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/support/TheaterProgressPublisher.java
@@ -16,7 +16,7 @@ public class TheaterProgressPublisher {
   private double lastUpdateTimeSeconds;
 
   public TheaterProgressPublisher() {
-    this(GlobalProtocol.getInstance().getOutputAdapter());
+    this(JavabuilderContext.getInstance().getGlobalProtocol().getOutputAdapter());
   }
 
   TheaterProgressPublisher(OutputAdapter outputAdapter) {

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/StageTest.java
@@ -78,7 +78,6 @@ public class StageTest {
   @AfterEach
   public void tearDown() {
     System.setOut(standardOut);
-    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test

--- a/org-code-javabuilder/theater/src/test/java/org/code/theater/support/TheaterPlayerTest.java
+++ b/org-code-javabuilder/theater/src/test/java/org/code/theater/support/TheaterPlayerTest.java
@@ -10,7 +10,6 @@ import org.code.protocol.InternalExceptionKey;
 import org.code.protocol.InternalServerRuntimeException;
 import org.code.protocol.LifecycleNotifier;
 import org.code.theater.support.TheaterPlayer.ConcertCreatorFactory;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,11 +32,6 @@ class TheaterPlayerTest {
     actions = new ArrayList<>();
 
     unitUnderTest = new TheaterPlayer(concertCreatorFactory);
-  }
-
-  @AfterEach
-  public void tearDown() {
-    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test

--- a/org-code-javabuilder/validation/src/main/java/org/code/validation/support/NeighborhoodTracker.java
+++ b/org-code-javabuilder/validation/src/main/java/org/code/validation/support/NeighborhoodTracker.java
@@ -11,6 +11,7 @@ import org.code.neighborhood.support.NeighborhoodSignalKey;
 import org.code.neighborhood.support.World;
 import org.code.protocol.ClientMessage;
 import org.code.protocol.ClientMessageType;
+import org.code.protocol.JavabuilderContext;
 import org.code.validation.NeighborhoodLog;
 import org.code.validation.PainterEvent;
 import org.code.validation.PainterLog;
@@ -81,7 +82,8 @@ public class NeighborhoodTracker {
   }
 
   private void initializeGrid() {
-    final int gridSize = World.getInstance().getGrid().getSize();
+    World world = (World) JavabuilderContext.getInstance().get(World.class);
+    final int gridSize = world.getGrid().getSize();
     this.neighborhoodState = new String[gridSize][gridSize];
     this.isInitialized = true;
   }

--- a/org-code-javabuilder/validation/src/test/java/org/code/validation/support/NeighborhoodTrackerTest.java
+++ b/org-code-javabuilder/validation/src/test/java/org/code/validation/support/NeighborhoodTrackerTest.java
@@ -10,9 +10,9 @@ import org.code.neighborhood.support.NeighborhoodSignalMessage;
 import org.code.neighborhood.support.World;
 import org.code.protocol.ClientMessageType;
 import org.code.protocol.GlobalProtocolTestFactory;
+import org.code.protocol.JavabuilderContext;
 import org.code.validation.ClientMessageHelper;
 import org.code.validation.PainterLog;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -23,13 +23,8 @@ class NeighborhoodTrackerTest {
   @BeforeEach
   public void setUp() {
     GlobalProtocolTestFactory.builder().create();
-    World.setInstance(new World(GRID_SIZE));
+    JavabuilderContext.getInstance().register(World.class, new World(GRID_SIZE));
     unitUnderTest = new NeighborhoodTracker();
-  }
-
-  @AfterEach
-  public void tearDown() {
-    GlobalProtocolTestFactory.tearDown();
   }
 
   @Test


### PR DESCRIPTION
Add a new object, `JavabuilderContext`, which tracks all singletons across Javabuilder and cleans them up at the end of code execution. In this PR I added the new object and moved `GlobalProtocol` and `World` into it to ensure the pattern worked for a couple of interesting cases. The way the object works is:
- Any class can register a singleton with it, which will be stored in a hashmap with a key of the class. The class must extend  `JavabuilderSharedObject`, which provides `destroy` and `onExecutionEnded` methods. The class can override those methods to perform any specific behavior when code is complete (`onExecutionEnded`) and we are about to exit (`destroy`). We need both of these functions since some class cleanup requires sending messages, which we want to do before we destroy any of our message adapters.
- When a class is registered, it must be either the same class or a subclass of the given key.
- You can get any class registered with the `get` function. `GlobalProtocol` has a dedicated `getGlobalProtocol` function in order to take care of casting the object, as `GlobalProtocol` is used so frequently.
 
## Links
- [jira ticket](https://codedotorg.atlassian.net/browse/JAVA-600)
- [initial slack conversation](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1652827910656259)

## Next Steps
Add all singletons to `JavabuilderContext`. Once we do this we should be able to get rid of `LifecycleNotifier`, as all lifecycle handling will be done via `JavabuilderContext`.