### PR TITLE
Remove the playground Lambda

### DIFF
--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -79,8 +79,6 @@ def on_connect(event, context)
     function_name = ENV['BUILD_AND_RUN_CONSOLE_PROJECT_LAMBDA_ARN']
   elsif authorizer['mini_app_type'] == 'theater'
     function_name = ENV['BUILD_AND_RUN_THEATER_PROJECT_LAMBDA_ARN']
-  elsif authorizer['mini_app_type'] == 'playground'
-    function_name = ENV['BUILD_AND_RUN_PLAYGROUND_PROJECT_LAMBDA_ARN']
   else
     return { statusCode: 400, body: "invalid mini-app" }
   end

--- a/template.yml.erb
+++ b/template.yml.erb
@@ -53,7 +53,6 @@ JAVALAB_APP_TYPES = %w(
   Theater
   Neighborhood
   Console
-  Playground
 )
 -%>
 Globals:
@@ -436,8 +435,7 @@ Resources:
 <%{
   Theater: {MemorySize: 1769, Timeout: 90},
   Neighborhood: {MemorySize: 512, Timeout: 90},
-  Console: {MemorySize: 512, Timeout: 90},
-  Playground: {MemorySize: 512, Timeout: 300}
+  Console: {MemorySize: 512, Timeout: 90}
 }.each do |name, config| -%>
   BuildAndRunJava<%=name%>ProjectFunction:
     Type: AWS::Serverless::Function
@@ -574,7 +572,7 @@ Resources:
           Label: Concurrent Executions Across All Lambdas
           ReturnData: true
           Expression: SUM(METRICS())
-<%{Theater: "m2", Neighborhood: "m3", Console: "m4", Playground: "m5"}.each do |name, id| -%>
+<%{Theater: "m2", Neighborhood: "m3", Console: "m4"}.each do |name, id| -%>
         - Id: <%=id%>
           ReturnData: false
           MetricStat:
@@ -657,7 +655,6 @@ Resources:
       -  HighWebsocketConnectionsAlarm
       -  NeighborhoodHighInvocationsAlarm
       -  TheaterHighInvocationsAlarm
-      -  PlaygroundHighInvocationsAlarm
     Properties:
         ActionsEnabled: true
         AlarmActions:
@@ -670,7 +667,6 @@ Resources:
             ALARM(${SubDomainName}_high_http_requests) OR
             ALARM(${SubDomainName}_high_websocket_connections) OR
             ALARM(${SubDomainName}_neighborhood_high_invocations) OR
-            ALARM(${SubDomainName}_playground_high_invocations) OR
             ALARM(${SubDomainName}_theater_high_invocations)"
         InsufficientDataActions: []
         OKActions: []


### PR DESCRIPTION
Remove the playground lambda and the routing to it. We are no longer supporting playground. A request to javabuilder with `playground` as the mini app type will now return a 400.

## Next Steps
- Remove playground logic from code-dot-org
- Remove playground logic from the build and run Lambda