### PR TITLE
Notify slack upon pipeline progress

### DIFF
--- a/cicd/2-cicd/cicd.template.yml
+++ b/cicd/2-cicd/cicd.template.yml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: 2012-10-17
+AWSTemplateFormatVersion: 2010-09-09
 Transform: AWS::Serverless-2016-10-31
 Description: Javabulder Continuous Integration pipeline
 
@@ -372,7 +372,7 @@ Resources:
       Topics:
         - !Ref PipelineNotificationTopic
       PolicyDocument:
-        Version: '2008-10-17'
+        Version: '2012-10-17'
         Statement:
         - Sid: AWSCodeStarNotifications_publish
           Effect: Allow

--- a/cicd/2-cicd/cicd.template.yml
+++ b/cicd/2-cicd/cicd.template.yml
@@ -327,34 +327,60 @@ Resources:
               OutputArtifacts:
                 - Name: integrationTestResultsPOC
   
+  # Send pipeline events to an SNS topic.
+  # Note: Integration with Slack via AWS ChatBot is configured manually via AWS Console.
   PipelineNotificationRule:
     Type: AWS::CodeStarNotifications::NotificationRule
     Properties:
-      Name: !Sub ${StackName}-pipeline
+      Name: !Sub ${AWS::StackName}-pipeline
       DetailType: FULL
-      Resource: !Ref Pipeline
+      Resource: !Sub "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${Pipeline}"
       EventTypeIds: 
-        - codepipeline-pipeline-action-execution-succeeded
-        - codepipeline-pipeline-action-execution-failed
-        - codepipeline-pipeline-action-execution-canceled
-        - codepipeline-pipeline-action-execution-started
-        - codepipeline-pipeline-stage-execution-started
-        - codepipeline-pipeline-stage-execution-succeeded
-        - codepipeline-pipeline-stage-execution-resumed
-        - codepipeline-pipeline-stage-execution-canceled
-        - codepipeline-pipeline-stage-execution-failed
+        # Pipeline events
         - codepipeline-pipeline-pipeline-execution-failed
-        - codepipeline-pipeline-pipeline-execution-canceled
-        - codepipeline-pipeline-pipeline-execution-started
-        - codepipeline-pipeline-pipeline-execution-resumed
         - codepipeline-pipeline-pipeline-execution-succeeded
-        - codepipeline-pipeline-pipeline-execution-superseded
-        - codepipeline-pipeline-manual-approval-failed
+        # - codepipeline-pipeline-pipeline-execution-canceled
+        # - codepipeline-pipeline-pipeline-execution-superseded
+        # - codepipeline-pipeline-pipeline-execution-started
+        # - codepipeline-pipeline-pipeline-execution-resumed
+        # Stage Events
+        # - codepipeline-pipeline-stage-execution-started
+        # - codepipeline-pipeline-stage-execution-succeeded
+        # - codepipeline-pipeline-stage-execution-resumed
+        # - codepipeline-pipeline-stage-execution-canceled
+        - codepipeline-pipeline-stage-execution-failed
+        # Action Events
+        # - codepipeline-pipeline-action-execution-succeeded
+        # - codepipeline-pipeline-action-execution-failed
+        # - codepipeline-pipeline-action-execution-canceled
+        # - codepipeline-pipeline-action-execution-started
+        # Approval Events (we don't use approvals yet)
         - codepipeline-pipeline-manual-approval-needed
-        - codepipeline-pipeline-manual-approval-succeeded
+        # - codepipeline-pipeline-manual-approval-failed
+        # - codepipeline-pipeline-manual-approval-succeeded
       Targets: 
         - TargetType: SNS 
           TargetAddress: !Ref PipelineNotificationTopic
 
   PipelineNotificationTopic:
     Type: AWS::SNS::Topic
+
+  # This policy is necessary for CodePipeline to be allowed to publish to the Topic.
+  PipelineNotificationTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties: 
+      Topics:
+        - !Ref PipelineNotificationTopic
+      PolicyDocument:
+        Version: '2008-10-17'
+        Statement:
+        - Sid: AWSCodeStarNotifications_publish
+          Effect: Allow
+          Principal:
+            Service:
+            - codestar-notifications.amazonaws.com
+          Action: SNS:Publish
+          Resource: !Ref PipelineNotificationTopic
+          Condition:
+            StringEquals:
+              aws:SourceAccount: !Ref AWS::AccountId

--- a/cicd/2-cicd/cicd.template.yml
+++ b/cicd/2-cicd/cicd.template.yml
@@ -326,3 +326,35 @@ Resources:
                     SUBDOMAIN: !If [TargetsMainBranch, "javabuilder-test", !Sub "javabuilder-${GitHubBranch}-test"]
               OutputArtifacts:
                 - Name: integrationTestResultsPOC
+  
+  PipelineNotificationRule:
+    Type: AWS::CodeStarNotifications::NotificationRule
+    Properties:
+      Name: !Sub ${StackName}-pipeline
+      DetailType: FULL
+      Resource: !Ref Pipeline
+      EventTypeIds: 
+        - codepipeline-pipeline-action-execution-succeeded
+        - codepipeline-pipeline-action-execution-failed
+        - codepipeline-pipeline-action-execution-canceled
+        - codepipeline-pipeline-action-execution-started
+        - codepipeline-pipeline-stage-execution-started
+        - codepipeline-pipeline-stage-execution-succeeded
+        - codepipeline-pipeline-stage-execution-resumed
+        - codepipeline-pipeline-stage-execution-canceled
+        - codepipeline-pipeline-stage-execution-failed
+        - codepipeline-pipeline-pipeline-execution-failed
+        - codepipeline-pipeline-pipeline-execution-canceled
+        - codepipeline-pipeline-pipeline-execution-started
+        - codepipeline-pipeline-pipeline-execution-resumed
+        - codepipeline-pipeline-pipeline-execution-succeeded
+        - codepipeline-pipeline-pipeline-execution-superseded
+        - codepipeline-pipeline-manual-approval-failed
+        - codepipeline-pipeline-manual-approval-needed
+        - codepipeline-pipeline-manual-approval-succeeded
+      Targets: 
+        - TargetType: SNS 
+          TargetAddress: !Ref PipelineNotificationTopic
+
+  PipelineNotificationTopic:
+    Type: AWS::SNS::Topic

--- a/cicd/2-cicd/cicd.template.yml
+++ b/cicd/2-cicd/cicd.template.yml
@@ -339,25 +339,25 @@ Resources:
         # Pipeline events
         - codepipeline-pipeline-pipeline-execution-failed
         - codepipeline-pipeline-pipeline-execution-succeeded
-        # - codepipeline-pipeline-pipeline-execution-canceled
-        # - codepipeline-pipeline-pipeline-execution-superseded
-        # - codepipeline-pipeline-pipeline-execution-started
-        # - codepipeline-pipeline-pipeline-execution-resumed
+        - codepipeline-pipeline-pipeline-execution-canceled
+        - codepipeline-pipeline-pipeline-execution-superseded
+        - codepipeline-pipeline-pipeline-execution-started
+        - codepipeline-pipeline-pipeline-execution-resumed
         # Stage Events
-        # - codepipeline-pipeline-stage-execution-started
-        # - codepipeline-pipeline-stage-execution-succeeded
-        # - codepipeline-pipeline-stage-execution-resumed
-        # - codepipeline-pipeline-stage-execution-canceled
+        - codepipeline-pipeline-stage-execution-started
+        - codepipeline-pipeline-stage-execution-succeeded
+        - codepipeline-pipeline-stage-execution-resumed
+        - codepipeline-pipeline-stage-execution-canceled
         - codepipeline-pipeline-stage-execution-failed
         # Action Events
-        # - codepipeline-pipeline-action-execution-succeeded
-        # - codepipeline-pipeline-action-execution-failed
-        # - codepipeline-pipeline-action-execution-canceled
-        # - codepipeline-pipeline-action-execution-started
+        - codepipeline-pipeline-action-execution-succeeded
+        - codepipeline-pipeline-action-execution-failed
+        - codepipeline-pipeline-action-execution-canceled
+        - codepipeline-pipeline-action-execution-started
         # Approval Events (we don't use approvals yet)
         - codepipeline-pipeline-manual-approval-needed
-        # - codepipeline-pipeline-manual-approval-failed
-        # - codepipeline-pipeline-manual-approval-succeeded
+        - codepipeline-pipeline-manual-approval-failed
+        - codepipeline-pipeline-manual-approval-succeeded
       Targets: 
         - TargetType: SNS 
           TargetAddress: !Ref PipelineNotificationTopic

--- a/cicd/2-cicd/cicd.template.yml
+++ b/cicd/2-cicd/cicd.template.yml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: 2012-10-17
 Transform: AWS::Serverless-2016-10-31
 Description: Javabulder Continuous Integration pipeline
 

--- a/cicd/README.md
+++ b/cicd/README.md
@@ -53,3 +53,7 @@ Finally, all of the above need some Roles to exist in the AWS accounts before we
 
 * "deploy-setup.sh"
 * "setup.template.yml" - AWS resources for the Setup infrastructure
+
+## Opportunities
+
+- Design more granular notifications by calling Slack webhooks _within_ steps.


### PR DESCRIPTION
This PR creates the notification rule and SNS topic for pipeline status changes. A separate, manually managed resource, handles the connection to slack channels. This is configured to hit the `#infra-javabuilder` channel.