### PR TITLE
Make mockito available to users

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
@@ -126,7 +126,8 @@ public class UserClassLoader extends URLClassLoader {
         "org.code.media.",
         "org.code.neighborhood.",
         "org.code.theater.",
-        "org.code.lang"
+        "org.code.lang",
+        "org.mockito."
       };
 
   // Allowed packages for code with elevated permissions, such as validation code.

--- a/org-code-javabuilder/studentlib/build.gradle
+++ b/org-code-javabuilder/studentlib/build.gradle
@@ -14,6 +14,7 @@ java {
 dependencies {
     // Required to compile student unit tests
     implementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
+    implementation group: 'org.mockito', name: 'mockito-inline', version: '3.9.0'
 }
 
 test {


### PR DESCRIPTION
We would like mockito to be available for validation tests. This change makes it available for both validation and users, since there's no harm making it available to users.