### PR TITLE
Update high usage and performance alarms

### DIFF
--- a/cicd/3-app/javabuilder/template.yml.erb
+++ b/cicd/3-app/javabuilder/template.yml.erb
@@ -658,7 +658,9 @@ Resources:
     Properties:
         ActionsEnabled: true
         AlarmActions:
-            - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-high-usage"]
+            # TODO: after we have run at high usage for a while, consider re-enabling this alarm. Right now it is too noisy
+            # - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-high-usage"]
+            - !Ref AWS::NoValue
         AlarmDescription: Send message if abnormally high Javabuilder usage detected.
             Monitors usage across the HTTP API, WebSocket API, and all Build and Run
             Lambdas.
@@ -760,133 +762,98 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${SubDomainName}_<%=name.downcase%>_slow_cleanup_time"
-      AlarmDescription: p(95) cleanup time in Javabuilder's <%=name%> build and run lambda exceeded
-        the normal cleanup time for 15 minutes. Investigate if there has been a performance regression.
+      AlarmDescription: Average cleanup time in Javabuilder's <%=name%> build and run lambda was high for at 
+        least 15 out of the last 20 minutes. Investigate if there has been a performance regression.
       ActionsEnabled: true
       OKActions: []
       AlarmActions:
         - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-slow-performance"]
       InsufficientDataActions: []
+      MetricName: CleanupTime
+      Namespace: Javabuilder
+      Statistic: Average
+      Dimensions:
+        - Name: functionName
+          Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
       EvaluationPeriods: 20
       DatapointsToAlarm: 15
-      ComparisonOperator: GreaterThanUpperThreshold
+      ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
-      Metrics:
-          - Id: m1
-            ReturnData: true
-            MetricStat:
-                Metric:
-                    Namespace: Javabuilder
-                    MetricName: CleanupTime
-                    Dimensions:
-                        - Name: functionName
-                          Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
-                Period: 60
-                Stat: p95
-          - Id: ad1
-            Label: CleanupTime (expected)
-            ReturnData: true
-            Expression: ANOMALY_DETECTION_BAND(m1, 5)
-      ThresholdMetricId: ad1
+      Threshold: 200
+      Period: 60
   
   <%=name%>SlowColdBootTimeAlarm:    
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${SubDomainName}_<%=name.downcase%>_slow_cold_boot_time"
-      AlarmDescription: p(95) cold boot time in Javabuilder's <%=name%> build and run lambda exceeded
-        the normal cleanup time for 15 minutes. Investigate if there has been a performance regression.
+      AlarmDescription: Aerage cold boot time in Javabuilder's <%=name%> build and run lambda was high for at 
+        least 15 out of the last 20 minutes. Investigate if there has been a performance regression.
       ActionsEnabled: true
       OKActions: []
       AlarmActions:
         - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-slow-performance"]
       InsufficientDataActions: []
+      MetricName: ColdBootTime
+      Namespace: Javabuilder
+      Statistic: Average
+      Dimensions:
+        - Name: functionName
+          Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
       EvaluationPeriods: 20
       DatapointsToAlarm: 15
-      ComparisonOperator: GreaterThanUpperThreshold
+      ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
-      Metrics:
-          - Id: m1
-            ReturnData: true
-            MetricStat:
-                Metric:
-                    Namespace: Javabuilder
-                    MetricName: ColdBootTime
-                    Dimensions:
-                        - Name: functionName
-                          Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
-                Period: 60
-                Stat: p95
-          - Id: ad1
-            Label: ColdBootTime (expected)
-            ReturnData: true
-            Expression: ANOMALY_DETECTION_BAND(m1, 2)
-      ThresholdMetricId: ad1
+      Threshold: 10500
+      Period: 60
 
   <%=name%>SlowInitializationTimeAlarm:    
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${SubDomainName}_<%=name.downcase%>_slow_initialization_time"
-      AlarmDescription: p(95) initialization time in Javabuilder's <%=name%> build and run lambda exceeded
-        the normal cleanup time for 15 minutes. Investigate if there has been a performance regression.
+      AlarmDescription: Average initialization time in Javabuilder's <%=name%> build and run lambda was high for at 
+        least 15 out of the last 20 minutes. Investigate if there has been a performance regression.
       ActionsEnabled: true
       OKActions: []
       AlarmActions:
         - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-slow-performance"]
       InsufficientDataActions: []
+      MetricName: InitializationTime
+      Namespace: Javabuilder
+      Statistic: Average
+      Dimensions:
+        - Name: functionName
+          Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
       EvaluationPeriods: 20
       DatapointsToAlarm: 15
-      ComparisonOperator: GreaterThanUpperThreshold
+      ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
-      Metrics:
-          - Id: m1
-            ReturnData: true
-            MetricStat:
-                Metric:
-                    Namespace: Javabuilder
-                    MetricName: InitializationTime
-                    Dimensions:
-                        - Name: functionName
-                          Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
-                Period: 60
-                Stat: p95
-          - Id: ad1
-            Label: InitializationTime (expected)
-            ReturnData: true
-            Expression: ANOMALY_DETECTION_BAND(m1, 5)
-      ThresholdMetricId: ad1
+      Threshold: 5000
+      Period: 60
+
   
   <%=name%>SlowTransitionTimeAlarm:    
     Type: AWS::CloudWatch::Alarm
     Properties:
         AlarmName: !Sub "${SubDomainName}_<%=name.downcase%>_slow_transition_time"
-        AlarmDescription: p(95) transition time in Javabuilder's <%=name%> build and run lambda exceeded
-          the normal cleanup time for 15 minutes. Investigate if there has been a performance regression.
+        AlarmDescription: Average transition time in Javabuilder's <%=name%> build and run lambda was high for at 
+          least 15 out of the last 20 minutes. Investigate if there has been a performance regression.
         ActionsEnabled: true
         OKActions: []
         AlarmActions:
           - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-slow-performance"]
         InsufficientDataActions: []
+        MetricName: TransitionTime
+        Namespace: Javabuilder
+        Statistic: Average
+        Dimensions:
+          - Name: functionName
+            Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
         EvaluationPeriods: 20
         DatapointsToAlarm: 15
-        ComparisonOperator: GreaterThanUpperThreshold
+        ComparisonOperator: GreaterThanThreshold
         TreatMissingData: notBreaching
-        Metrics:
-            - Id: m1
-              ReturnData: true
-              MetricStat:
-                  Metric:
-                      Namespace: Javabuilder
-                      MetricName: TransitionTime
-                      Dimensions:
-                          - Name: functionName
-                            Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
-                  Period: 60
-                  Stat: p95
-            - Id: ad1
-              Label: TransitionTime (expected)
-              ReturnData: true
-              Expression: ANOMALY_DETECTION_BAND(m1, 5)
-        ThresholdMetricId: ad1
+        Threshold: 2500
+        Period: 60
 
   <%=name%>HighInvocationsAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/cicd/3-app/javabuilder/template.yml.erb
+++ b/cicd/3-app/javabuilder/template.yml.erb
@@ -786,7 +786,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${SubDomainName}_<%=name.downcase%>_slow_cold_boot_time"
-      AlarmDescription: Aerage cold boot time in Javabuilder's <%=name%> build and run lambda was high for at 
+      AlarmDescription: Average cold boot time in Javabuilder's <%=name%> build and run lambda was high for at 
         least 15 out of the last 20 minutes. Investigate if there has been a performance regression.
       ActionsEnabled: true
       OKActions: []


### PR DESCRIPTION
Our alarms are too noisy now that schools are coming back. This PR makes the following changes:
- temporarily silence the high usage composite alarm. Our usage is going to continue to increase over the next month so this alarm won't be helpful. We should revisit this once usage is stabilized.
- Update the slow performance alarms to alarm on static thresholds instead of anomaly. The anomaly detection didn't go a good job for our scenario. This is because we often have two sets of performance numbers within a single metric--the cold boot and warm boot numbers. The alarm now goes off if we see 15 out of 20 minutes with an average higher than expected for cold boot. 

I've updated the cloudwatch dashboard to show the performance thresholds. We can adjust them if we find they are too sensitive or not sensitive enough. I biased towards less sensitive numbers since these alarms are intended to tell us if there is a regression.

## Performance Graphs with new thresholds
![Screen Shot 2022-08-05 at 11 10 51 AM](https://user-images.githubusercontent.com/33666587/183137142-6af2eb3e-c4ba-404c-a730-e41639c964b1.png)
![Screen Shot 2022-08-05 at 11 10 43 AM](https://user-images.githubusercontent.com/33666587/183137149-c118865c-08cc-4a51-91f4-c79c0b6f5de3.png)
![Screen Shot 2022-08-05 at 11 10 34 AM](https://user-images.githubusercontent.com/33666587/183137167-2a165c6b-090a-4cd8-8867-a658799dfbe9.png)
![Screen Shot 2022-08-05 at 11 10 24 AM](https://user-images.githubusercontent.com/33666587/183137171-b13a7648-c745-4b0e-818a-7ade56a59d8d.png)

