### PR TITLE
Fix throttling alarms

### DIFF
--- a/cicd/3-app/javabuilder/template.yml.erb
+++ b/cicd/3-app/javabuilder/template.yml.erb
@@ -969,14 +969,14 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
         AlarmName: !Sub "${SubDomainName}_high_users_blocked"
-        AlarmDescription: Unusually high number of users being blocked by our throttling
+        AlarmDescription: Unusually high number of users being newly blocked by our throttling
             thresholds.
         ActionsEnabled: true
         OKActions: []
         AlarmActions:
           - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-high-throttling"]
         InsufficientDataActions: []
-        MetricName: UserBlocked
+        MetricName: NewUserBlocked
         Namespace: Javabuilder
         Statistic: Sum
         Dimensions:
@@ -993,14 +993,14 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
         AlarmName: !Sub "${SubDomainName}_high_classrooms_blocked"
-        AlarmDescription: Unusually high number of classrooms being blocked by our throttling
+        AlarmDescription: Unusually high number of classrooms being newly blocked by our throttling
             thresholds.
         ActionsEnabled: true
         OKActions: []
         AlarmActions:
           - !If [SilenceAlertsCondition, !Ref AWS::NoValue, !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:javabuilder-high-throttling"]
         InsufficientDataActions: []
-        MetricName: ClassroomBlocked
+        MetricName: NewClassroomBlocked
         Namespace: Javabuilder
         Statistic: Sum
         Dimensions:

--- a/javabuilder-authorizer/metrics_reporter.rb
+++ b/javabuilder-authorizer/metrics_reporter.rb
@@ -11,8 +11,13 @@ class MetricsReporter
 
   def log_token_error(status, error_message)
     puts error_message
+    metric_name = TOKEN_STATUS_METRIC_NAMES[status]
+    log(metric_name)
+  end
+
+  def log(metric_name)
     metric_data = {
-      metric_name: TOKEN_STATUS_METRIC_NAMES[status],
+      metric_name: metric_name,
       dimensions: [
         {
           name: "functionName",

--- a/javabuilder-authorizer/token_status.rb
+++ b/javabuilder-authorizer/token_status.rb
@@ -40,4 +40,7 @@ module TokenStatus
     NOT_VETTED => 'TokenNotVetted',
     TOKEN_USED => 'TokenUsed'
   }.freeze
+
+  NEW_USER_BLOCKED = 'NewUserBlocked'.freeze
+  NEW_CLASSROOM_BLOCKED = 'NewClassroomBlocked'.freeze
 end

--- a/javabuilder-authorizer/token_validator.rb
+++ b/javabuilder-authorizer/token_validator.rb
@@ -136,6 +136,7 @@ class TokenValidator
             },
             condition_expression: 'attribute_not_exists(user_id)'
           )
+          @metrics_reporter.log(NEW_CLASSROOM_BLOCKED)
         rescue Aws::DynamoDB::Errors::ConditionalCheckFailedException
           # Do nothing if this teacher has already been added to blocked table
           # (possible if throttling limit was reached by a user on another lambda simultaneously)
@@ -244,6 +245,7 @@ class TokenValidator
           },
           condition_expression: 'attribute_not_exists(user_id)'
         )
+        @metrics_reporter.log(NEW_USER_BLOCKED)
       rescue Aws::DynamoDB::Errors::ConditionalCheckFailedException
         # Do nothing if this user has already been added to blocked table
         # (possible if throttling limit was reached by the same user executing code on another lambda simultaneously)


### PR DESCRIPTION
Adds new metrics (`NewClassroomBlocked`, `NewUserBlocked`) to track when a classroom or user is blocked for the first time. Sets up our alarms to use these metrics, rather than our existing metrics, which track whenever we get a request that is blocked because the user or the user's classroom is blocked. These existing metrics will continue to generate data any time we block a request, but will not be used in our alarms.

## Testing story

I deployed these changes to my dev instance. I was able to see data generated for each of these new metrics (only once per user), and saw that the old metrics generated more than one event as I repeatedly made requests with an account that had been blocked. I also observed javabuilder functioning normally when no throttling thresholds were breached.