### PR TITLE
Revert "Make mockito available to users"

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
@@ -126,8 +126,7 @@ public class UserClassLoader extends URLClassLoader {
         "org.code.media.",
         "org.code.neighborhood.",
         "org.code.theater.",
-        "org.code.lang",
-        "org.mockito."
+        "org.code.lang"
       };
 
   // Allowed packages for code with elevated permissions, such as validation code.

--- a/org-code-javabuilder/studentlib/build.gradle
+++ b/org-code-javabuilder/studentlib/build.gradle
@@ -14,7 +14,6 @@ java {
 dependencies {
     // Required to compile student unit tests
     implementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    implementation group: 'org.mockito', name: 'mockito-inline', version: '3.9.0'
 }
 
 test {


### PR DESCRIPTION
Reverts code-dot-org/javabuilder#342. This package is causing memory issues. This change should not be merged until the next code-dot-org DTP is complete.