### PR TITLE
Update error rate alarms

### DIFF
--- a/beta-template.yml.erb
+++ b/beta-template.yml.erb
@@ -700,7 +700,10 @@ Resources:
             MetricStat:
                 Metric:
                     Namespace: Javabuilder
-                    MetricName: Javabuilder <%=name%> "SEVERE" errors
+                    MetricName: SevereError
+                    Dimensions:
+                      - Name: functionName
+                        Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
                 Period: 300
                 Stat: Sum
           - Id: m2
@@ -734,7 +737,7 @@ Resources:
           - Id: e1
             Label: Errors / Invocations
             ReturnData: true
-            Expression: (m1 / m2) * 100
+            Expression: ((m1 - m3) / m2) * 100
           - Id: m1
             ReturnData: false
             MetricStat:
@@ -757,6 +760,17 @@ Resources:
                           Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
                 Period: 300
                 Stat: Sum
+          - Id: m3
+            ReturnData: false
+            MetricStat:
+                Metric:
+                    Namespace: AWS/Lambda
+                    MetricName: Duration
+                    Dimensions:
+                        - Name: FunctionName
+                          Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
+                Period: 300
+                Stat: TC(89000:)
 
   <%=name%>SlowCleanupTimeAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/cicd/2-cicd/deploy-cicd.sh
+++ b/cicd/2-cicd/deploy-cicd.sh
@@ -20,8 +20,6 @@ if [ "$TARGET_BRANCH" == "main" ]
 then
   STACK_NAME="javabuilder-cicd"
 else
-  # replace any "/" characters in the branch name with "-". "/" is not allowed in a stack name.
-  TARGET_BRANCH="${TARGET_BRANCH/\//-}"
   STACK_NAME="javabuilder-${TARGET_BRANCH}-cicd"
 fi
 

--- a/cicd/2-cicd/deploy-cicd.sh
+++ b/cicd/2-cicd/deploy-cicd.sh
@@ -20,7 +20,9 @@ if [ "$TARGET_BRANCH" == "main" ]
 then
   STACK_NAME="javabuilder-cicd"
 else
-  STACK_NAME=${"javabuilder-$TARGET_BRANCH-cicd"}
+  # replace any "/" characters in the branch name with "-". "/" is not allowed in a stack name.
+  TARGET_BRANCH="${TARGET_BRANCH/\//-}"
+  STACK_NAME="javabuilder-${TARGET_BRANCH}-cicd"
 fi
 
 MODE=${MODE-'standard'}

--- a/cicd/3-app/javabuilder/template.yml.erb
+++ b/cicd/3-app/javabuilder/template.yml.erb
@@ -694,7 +694,10 @@ Resources:
             MetricStat:
                 Metric:
                     Namespace: Javabuilder
-                    MetricName: Javabuilder <%=name%> "SEVERE" errors
+                    MetricName: SevereError
+                    Dimensions:
+                      - Name: functionName
+                        Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
                 Period: 300
                 Stat: Sum
           - Id: m2
@@ -728,7 +731,7 @@ Resources:
           - Id: e1
             Label: Errors / Invocations
             ReturnData: true
-            Expression: (m1 / m2) * 100
+            Expression: ((m1 - m3) / m2) * 100
           - Id: m1
             ReturnData: false
             MetricStat:
@@ -751,6 +754,17 @@ Resources:
                           Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
                 Period: 300
                 Stat: Sum
+          - Id: m3
+            ReturnData: false
+            MetricStat:
+                Metric:
+                    Namespace: AWS/Lambda
+                    MetricName: Duration
+                    Dimensions:
+                        - Name: FunctionName
+                          Value: !Ref BuildAndRunJava<%=name%>ProjectFunction
+                Period: 300
+                Stat: TC(89000:)
 
   <%=name%>SlowCleanupTimeAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/cicd/README.md
+++ b/cicd/README.md
@@ -58,6 +58,7 @@ TARGET_BRANCH=mybranch cicd/2-cicd/deploy-cicd.sh
 ### Deploying an Adhoc environment
 
 You can create an Adhoc environment by setting the `MODE` flag on the cicd deploy script. This will create a CI/CD pipeline that will watch for updates to your `TARGET_BRANCH`. The difference between a standard deployment and an adhoc pipeline can be seen in "cicd.template.yml" by following where the `Conditions` are used. In short, an adhoc creates an adhoc environment using "adhoc.config.yml", while a standard deployment will create a Test environment and a Prod environment using the relevent config files.
+Note: your branch name cannot contain the character `\`, as this causes issues in AWS.
 
 ```
 TARGET_BRANCH=mybranch MODE=adhoc cicd/2-cicd/deploy-cicd.sh


### PR DESCRIPTION
Update the error rate and severe error rate alarms:
- The severe error rate alarm was previously using a log filter, but we added a CloudWatch metric to track severe errors a while ago. Use this metric instead, as the log filter only applies to `javabuilderbeta`. 
- Timeouts as reported as errors by AWS. We had updated our dashboard to calculate the error rate by subtracting instances that took close to the timeout time (90 seconds) from the error count to get a more accurate percentage. Since all of our lambdas now have a timeout of 90 seconds we should use that calculation here. This calculation isn't perfect--for some reason it will sometimes report a decimal number instead of an integer. But it gets us closer to the actual error rate so I thought it was a worthwhile change.

In working on this I also tested deploying an adhoc and noticed that the script had an error in the string interpolation for the adhoc stack name, this is fixed in this PR. I also added a note to the README that you can't deploy an adhoc based on a branch with a `\` character in the name. 