### PR TITLE
Validate full main method signature

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserInitiatedExceptionKey.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserInitiatedExceptionKey.java
@@ -10,6 +10,11 @@ public enum UserInitiatedExceptionKey {
   TWO_MAIN_METHODS,
   // The user's code does not contain a main method.
   NO_MAIN_METHOD,
+  INVALID_MAIN_METHOD,
+  MAIN_METHOD_NOT_PUBLIC,
+  MAIN_METHOD_NOT_STATIC,
+  MAIN_METHOD_NOT_VOID,
+  MAIN_METHOD_WRONG_ARGUMENTS,
   // The user's code has a compiler error.
   COMPILER_ERROR,
   // The user tried to include a source file that did not end in .java

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserInitiatedExceptionKey.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserInitiatedExceptionKey.java
@@ -10,11 +10,8 @@ public enum UserInitiatedExceptionKey {
   TWO_MAIN_METHODS,
   // The user's code does not contain a main method.
   NO_MAIN_METHOD,
+  // The user's main method has an invalid signature.
   INVALID_MAIN_METHOD,
-  MAIN_METHOD_NOT_PUBLIC,
-  MAIN_METHOD_NOT_STATIC,
-  MAIN_METHOD_NOT_VOID,
-  MAIN_METHOD_WRONG_ARGUMENTS,
   // The user's code has a compiler error.
   COMPILER_ERROR,
   // The user tried to include a source file that did not end in .java

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/util/ProjectLoadUtils.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/util/ProjectLoadUtils.java
@@ -1,6 +1,7 @@
 package org.code.javabuilder.util;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.net.URLClassLoader;
 import java.util.List;
 import org.code.javabuilder.JavaProjectFile;
@@ -18,8 +19,8 @@ public final class ProjectLoadUtils {
    * @param classLoader class loader pointing to location of compiled classes
    * @param javaFiles a list of JavaProjectFiles
    * @return the main method if it is found
-   * @throws UserInitiatedException if there is more than one main method or no main method, or if
-   *     the class definition is empty
+   * @throws UserInitiatedException if there is more than one main method, no main method, an error
+   *     with the main method signature, or if the class definition is empty
    */
   public static Method findMainMethod(URLClassLoader classLoader, List<JavaProjectFile> javaFiles)
       throws UserInitiatedException {
@@ -28,10 +29,7 @@ public final class ProjectLoadUtils {
       try {
         Method[] declaredMethods = classLoader.loadClass(file.getClassName()).getDeclaredMethods();
         for (Method method : declaredMethods) {
-          Class[] parameterTypes = method.getParameterTypes();
-          if (method.getName().equals("main")
-              && parameterTypes.length == 1
-              && parameterTypes[0].equals(String[].class)) {
+          if (method.getName().equals("main")) {
             if (mainMethod != null) {
               throw new UserInitiatedException(UserInitiatedExceptionKey.TWO_MAIN_METHODS);
             }
@@ -43,6 +41,20 @@ public final class ProjectLoadUtils {
         throw new UserInitiatedException(UserInitiatedExceptionKey.CLASS_NOT_FOUND, e);
       } catch (NoClassDefFoundError e) {
         ProjectLoadUtils.convertAndThrowInvalidClassException(e);
+      }
+    }
+
+    // If we found a main method, make sure the method signature is valid
+    // (public, static, void return type, one argument which should be a String[]).
+    if (mainMethod != null) {
+      final Class<?>[] parameterTypes = mainMethod.getParameterTypes();
+      final int modifiers = mainMethod.getModifiers();
+      if (!Modifier.isPublic(modifiers)
+          || !Modifier.isStatic(modifiers)
+          || mainMethod.getGenericReturnType() != Void.TYPE
+          || parameterTypes.length != 1
+          || !parameterTypes[0].equals(String[].class)) {
+        throw new UserInitiatedException(UserInitiatedExceptionKey.INVALID_MAIN_METHOD);
       }
     }
 


### PR DESCRIPTION
Validates the main method signature (if present) to ensure we don't hit any unexpected null pointer exceptions, or other exceptions related to visibility and static modifiers. We will now throw a user facing exception unless the method is public, static, void return type, and has only one argument of a String[].

Javalab PR to translate this message: https://github.com/code-dot-org/code-dot-org/pull/47718

https://codedotorg.atlassian.net/browse/JAVA-665

Tested locally.