### PR TITLE
Add access to EasyMock

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
@@ -4,6 +4,7 @@ import static org.code.protocol.LoggerNames.MAIN_LOGGER;
 
 import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.StringConcatFactory;
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.HashSet;
@@ -112,7 +113,10 @@ public class UserClassLoader extends URLClassLoader {
           String.class.getName(),
           StringBuffer.class.getName(),
           StringBuilder.class.getName(),
-          Throwable.class.getName());
+          Throwable.class.getName(),
+          ThreadLocal.class.getName(),
+          CloneNotSupportedException.class.getName(),
+          Method.class.getName());
 
   // Allowed packages (any individual class is allowed from these classes)
   private static final String[] allowedPackages =
@@ -126,7 +130,9 @@ public class UserClassLoader extends URLClassLoader {
         "org.code.media.",
         "org.code.neighborhood.",
         "org.code.theater.",
-        "org.code.lang"
+        "org.code.lang",
+        "org.easymock.",
+        "jdk.internal.reflect.SerializationConstructorAccessorImpl"
       };
 
   // Allowed packages for code with elevated permissions, such as validation code.

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
@@ -4,6 +4,7 @@ import static org.code.protocol.LoggerNames.MAIN_LOGGER;
 
 import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.StringConcatFactory;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -114,9 +115,10 @@ public class UserClassLoader extends URLClassLoader {
           StringBuffer.class.getName(),
           StringBuilder.class.getName(),
           Throwable.class.getName(),
-          ThreadLocal.class.getName(),
-          CloneNotSupportedException.class.getName(),
-          Method.class.getName());
+          ThreadLocal.class.getName(), // EasyMock support
+          CloneNotSupportedException.class.getName(), // EasyMock support
+          Method.class.getName(), // EasyMock support
+          InvocationTargetException.class.getName()); // EasyMock support
 
   // Allowed packages (any individual class is allowed from these classes)
   private static final String[] allowedPackages =
@@ -132,7 +134,7 @@ public class UserClassLoader extends URLClassLoader {
         "org.code.theater.",
         "org.code.lang",
         "org.easymock.",
-        "jdk.internal.reflect.SerializationConstructorAccessorImpl"
+        "jdk.internal.reflect.SerializationConstructorAccessorImpl" // EasyMock support
       };
 
   // Allowed packages for code with elevated permissions, such as validation code.

--- a/org-code-javabuilder/studentlib/build.gradle
+++ b/org-code-javabuilder/studentlib/build.gradle
@@ -14,6 +14,9 @@ java {
 dependencies {
     // Required to compile student unit tests
     implementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
+    // https://mvnrepository.com/artifact/org.easymock/easymock
+    implementation group: 'org.easymock', name: 'easymock', version: '4.3'
+
 }
 
 test {


### PR DESCRIPTION
We need a mocking library for validation tests. EasyMock worked better than mockito because it does not have the same memory leak issues. This PR adds EasyMock to studentlib and adds support for it to the class loader.

I've kept it available for both validation and non-validation tests for now, because I can't think of a good reason to prevent students from using it. But we can re-evaluate if we decide it's a problem and move it to only validation test support.