### PR TITLE
Force recycle container if connection pool has been shut down

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSOutputAdapter.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSOutputAdapter.java
@@ -44,6 +44,12 @@ public class AWSOutputAdapter implements OutputAdapter {
       this.api.postToConnection(post);
     } catch (GoneException e) {
       throw new InternalFacingRuntimeException(CONNECTION_TERMINATED, e);
+    } catch (IllegalStateException e) {
+      // Thrown when the API Gateway client has been unexpectedly shut down.
+      // We are still actively investigating why this happens in the first place,
+      // but this will make the container fail for all subsequent sessions, so it
+      // should be recycled.
+      throw new FatalError(FatalErrorKey.CONNECTION_POOL_SHUT_DOWN, e);
     }
   }
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/FatalErrorKey.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/FatalErrorKey.java
@@ -1,11 +1,11 @@
 package org.code.javabuilder;
 
-import static org.code.javabuilder.LambdaErrorCodes.LOW_DISK_SPACE_ERROR_CODE;
-import static org.code.javabuilder.LambdaErrorCodes.TEMP_DIRECTORY_CLEANUP_ERROR_CODE;
+import static org.code.javabuilder.LambdaErrorCodes.*;
 
 public enum FatalErrorKey {
   LOW_DISK_SPACE(LOW_DISK_SPACE_ERROR_CODE),
-  TEMP_DIRECTORY_CLEANUP_ERROR(TEMP_DIRECTORY_CLEANUP_ERROR_CODE);
+  TEMP_DIRECTORY_CLEANUP_ERROR(TEMP_DIRECTORY_CLEANUP_ERROR_CODE),
+  CONNECTION_POOL_SHUT_DOWN(CONNECTION_POOL_SHUT_DOWN_ERROR_CODE);
 
   private final int errorCode;
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaErrorCodes.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaErrorCodes.java
@@ -8,4 +8,5 @@ public final class LambdaErrorCodes {
   public static final int TEMP_DIRECTORY_CLEANUP_ERROR_CODE = 10;
   public static final int LOW_DISK_SPACE_ERROR_CODE = 50;
   public static final int OUT_OF_MEMORY_ERROR_CODE = 60;
+  public static final int CONNECTION_POOL_SHUT_DOWN_ERROR_CODE = 70;
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/util/LambdaUtils.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/util/LambdaUtils.java
@@ -6,6 +6,7 @@ import static org.code.protocol.LoggerNames.MAIN_LOGGER;
 import java.util.logging.Logger;
 import org.code.javabuilder.InternalFacingRuntimeException;
 import org.code.protocol.ClientMessage;
+import org.code.protocol.JavabuilderThrowableMessageUtils;
 import org.code.protocol.OutputAdapter;
 
 public final class LambdaUtils {
@@ -33,7 +34,7 @@ public final class LambdaUtils {
       }
     } catch (Exception e) {
       // Catch any other exceptions here to prevent them from propagating.
-      Logger.getLogger(MAIN_LOGGER).warning(e.getMessage());
+      Logger.getLogger(MAIN_LOGGER).warning(JavabuilderThrowableMessageUtils.getLoggingString(e));
     }
   }
 }


### PR DESCRIPTION
We've been seeing a flurry of `Connection pool shut down` errors recently, which seem to persist as long as a container is alive. We're still investigating the root cause of this issue, but as a temporary mitigation, this forces us to recycle the container if we catch this exception.

This also includes a minor change to log the full stack trace of any caught exceptions in `LambdaUtils.safelySendMessage` for debugging purposes.

Details in Slack: https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1661173644365149