### PR TITLE
Verify api client still exists on startup

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -385,7 +385,10 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
       this.apiClient.getConnection(connectionRequest);
     } catch (IllegalStateException e) {
       // This can occur if the api client has been shut down, which we have seen happen on occasion.
-      // Recreate the api client in this case.
+      // Recreate the api client in this case. Log a warning so we can track when this happens.
+      Logger.getLogger(MAIN_LOGGER)
+          .warning(
+              "Received illegal state exception when trying to talk to API Gateway. Recreating api client.");
       this.apiClient =
           AmazonApiGatewayManagementApiClientBuilder.standard()
               .withEndpointConfiguration(


### PR DESCRIPTION
We have seen the api client go away the last couple mornings. This causes subsequent invocations of a container to fail. This verifies the client exists when an instance starts, and recreates it if necessary.

Tested on a dev instance. If I manually called shutdown on the api client the check will catch the error and recreate itself, and the end user will not see any errors.

We could also do this for our other aws clients (SQS and S3), but we haven't seen those have issues yet so I've left them as-is.