### PR TITLE
Catch exceptions during AWS resource cleanup

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSSystemExitHelper.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSSystemExitHelper.java
@@ -8,6 +8,7 @@ import com.amazonaws.services.apigatewaymanagementapi.model.GoneException;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
 import org.code.protocol.JavabuilderContext;
+import org.code.protocol.JavabuilderThrowableMessageUtils;
 
 public class AWSSystemExitHelper implements SystemExitHelper {
   private final String connectionId;
@@ -37,6 +38,11 @@ public class AWSSystemExitHelper implements SystemExitHelper {
       api.deleteConnection(deleteConnectionRequest);
     } catch (GoneException e) {
       // if the connection is already gone, we don't need to delete the connection.
+    } catch (Exception e) {
+      // Handle any other exceptions so that shut down proceeds normally. If this is an
+      // IllegalStateException, it indicates that the connection was already shut down for
+      // some reason.
+      Logger.getLogger(MAIN_LOGGER).warning(JavabuilderThrowableMessageUtils.getLoggingString(e));
     }
     // clean up log handler to avoid duplicate logs in future runs.
     Handler[] allHandlers = Logger.getLogger(MAIN_LOGGER).getHandlers();

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -364,6 +364,11 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
       api.deleteConnection(deleteConnectionRequest);
     } catch (GoneException e) {
       // if the connection is already gone, we don't need to delete the connection.
+    } catch (Exception e) {
+      // Handle any other exceptions so that shut down proceeds normally. If this is an
+      // IllegalStateException, it indicates that the connection was already shut down for
+      // some reason.
+      Logger.getLogger(MAIN_LOGGER).warning(JavabuilderThrowableMessageUtils.getLoggingString(e));
     }
     // clean up log handler to avoid duplicate logs in future runs.
     Handler[] allHandlers = Logger.getLogger(MAIN_LOGGER).getHandlers();


### PR DESCRIPTION
More context on Slack: https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1661173644365149. 
We've been seeing a bunch of `connection pool shut down` exceptions being thrown and logged. One possible reason for the abnormally high volume of exception logs is that this exception gets thrown during `api.deleteConnection` in the AWS cleanup resources steps, and since it's not caught, we don't remove log handlers leading to duplicate logging. We should catch this and any exceptions during AWS resource cleanup to make sure we always shut down normally.