### PR TITLE
Neighborhood Validation Updates

### DIFF
--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
@@ -143,12 +143,20 @@ public class Painter {
 
   /** @return True if there is paint in the square where the painter is standing. */
   public boolean isOnPaint() {
-    return this.grid.getSquare(this.xLocation, this.yLocation).hasColor();
+    boolean isOnPaint = this.grid.getSquare(this.xLocation, this.yLocation).hasColor();
+    this.outputAdapter.sendMessage(
+        new NeighborhoodSignalMessage(
+            NeighborhoodSignalKey.IS_ON_PAINT, this.getSignalDetailsForBooleanMethod(isOnPaint)));
+    return isOnPaint;
   }
 
   /** @return True if there is a paint bucket in the square where the painter is standing. */
   public boolean isOnBucket() {
-    return this.grid.getSquare(this.xLocation, this.yLocation).containsPaint();
+    boolean isOnBucket = this.grid.getSquare(this.xLocation, this.yLocation).containsPaint();
+    this.outputAdapter.sendMessage(
+        new NeighborhoodSignalMessage(
+            NeighborhoodSignalKey.IS_ON_BUCKET, this.getSignalDetailsForBooleanMethod(isOnBucket)));
+    return isOnBucket;
   }
 
   /** @return True if the painter's personal bucket has paint in it. */
@@ -161,12 +169,16 @@ public class Painter {
 
   /** @return True if there is no barrier one square ahead in the requested direction. */
   public boolean canMove(String direction) {
-    return this.isValidMovement(Direction.fromString(direction));
+    boolean canMove = this.isValidMovement(Direction.fromString(direction));
+    this.outputAdapter.sendMessage(
+        new NeighborhoodSignalMessage(
+            NeighborhoodSignalKey.CAN_MOVE, this.getSignalDetailsForBooleanMethod(canMove)));
+    return canMove;
   }
 
   /** @return True if there is no barrier one square ahead in the current direction. */
   public boolean canMove() {
-    return this.isValidMovement(this.direction);
+    return this.canMove(this.direction.toString());
   }
 
   /** @return the color of the square where the painter is standing. */
@@ -290,6 +302,13 @@ public class Painter {
   private HashMap<String, String> getSignalDetails() {
     HashMap<String, String> details = new HashMap<>();
     details.put(ID, this.id);
+    return details;
+  }
+
+  private HashMap<String, String> getSignalDetailsForBooleanMethod(boolean result) {
+    HashMap<String, String> details = this.getSignalDetails();
+    String resultString = result ? "true" : "false";
+    details.put(BOOLEAN_RESULT, resultString);
     return details;
   }
 

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/Painter.java
@@ -144,18 +144,14 @@ public class Painter {
   /** @return True if there is paint in the square where the painter is standing. */
   public boolean isOnPaint() {
     boolean isOnPaint = this.grid.getSquare(this.xLocation, this.yLocation).hasColor();
-    this.outputAdapter.sendMessage(
-        new NeighborhoodSignalMessage(
-            NeighborhoodSignalKey.IS_ON_PAINT, this.getSignalDetailsForBooleanMethod(isOnPaint)));
+    this.sendBooleanMessage(NeighborhoodSignalKey.IS_ON_PAINT, isOnPaint);
     return isOnPaint;
   }
 
   /** @return True if there is a paint bucket in the square where the painter is standing. */
   public boolean isOnBucket() {
     boolean isOnBucket = this.grid.getSquare(this.xLocation, this.yLocation).containsPaint();
-    this.outputAdapter.sendMessage(
-        new NeighborhoodSignalMessage(
-            NeighborhoodSignalKey.IS_ON_BUCKET, this.getSignalDetailsForBooleanMethod(isOnBucket)));
+    this.sendBooleanMessage(NeighborhoodSignalKey.IS_ON_BUCKET, isOnBucket);
     return isOnBucket;
   }
 
@@ -170,9 +166,7 @@ public class Painter {
   /** @return True if there is no barrier one square ahead in the requested direction. */
   public boolean canMove(String direction) {
     boolean canMove = this.isValidMovement(Direction.fromString(direction));
-    this.outputAdapter.sendMessage(
-        new NeighborhoodSignalMessage(
-            NeighborhoodSignalKey.CAN_MOVE, this.getSignalDetailsForBooleanMethod(canMove)));
+    this.sendBooleanMessage(NeighborhoodSignalKey.CAN_MOVE, canMove);
     return canMove;
   }
 
@@ -305,15 +299,15 @@ public class Painter {
     return details;
   }
 
-  private HashMap<String, String> getSignalDetailsForBooleanMethod(boolean result) {
-    HashMap<String, String> details = this.getSignalDetails();
-    String resultString = result ? "true" : "false";
-    details.put(BOOLEAN_RESULT, resultString);
-    return details;
-  }
-
   private void sendOutputMessage(NeighborhoodSignalKey signalKey, HashMap<String, String> details) {
     this.outputAdapter.sendMessage(new NeighborhoodSignalMessage(signalKey, details));
+  }
+
+  private void sendBooleanMessage(NeighborhoodSignalKey signalKey, boolean result) {
+    HashMap<String, String> details = this.getSignalDetails();
+    String resultString = String.valueOf(result);
+    details.put(BOOLEAN_RESULT, resultString);
+    this.sendOutputMessage(signalKey, details);
   }
 
   private void sendInitializationMessage() {

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/support/NeighborhoodSignalKey.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/support/NeighborhoodSignalKey.java
@@ -20,5 +20,11 @@ public enum NeighborhoodSignalKey {
   // Hide all paint buckets
   HIDE_BUCKETS,
   // Show all paint buckets
-  SHOW_BUCKETS
+  SHOW_BUCKETS,
+  // isOnBucket was called (used for validation only)
+  IS_ON_BUCKET,
+  // isOnPaint was called (used for validation only)
+  IS_ON_PAINT,
+  // canMove was called (used for validation only)
+  CAN_MOVE
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessageDetailKeys.java
@@ -41,4 +41,6 @@ public class ClientMessageDetailKeys {
   public static final String DIRECTION = "direction";
   public static final String COLOR = "color";
   public static final String PAINT = "paint";
+  // Used to report the result of calling a boolean method
+  public static final String BOOLEAN_RESULT = "booleanResult";
 }

--- a/org-code-javabuilder/validation/src/main/java/org/code/validation/NeighborhoodActionType.java
+++ b/org-code-javabuilder/validation/src/main/java/org/code/validation/NeighborhoodActionType.java
@@ -11,5 +11,8 @@ public enum NeighborhoodActionType {
   SHOW_PAINTER,
   TURN_LEFT,
   HIDE_BUCKETS,
-  SHOW_BUCKETS
+  SHOW_BUCKETS,
+  CAN_MOVE,
+  IS_ON_BUCKET,
+  IS_ON_PAINT
 }

--- a/org-code-javabuilder/validation/src/main/java/org/code/validation/Position.java
+++ b/org-code-javabuilder/validation/src/main/java/org/code/validation/Position.java
@@ -1,13 +1,15 @@
 package org.code.validation;
 
-/** User-facing class representing an (x, y) position. */
+/** User-facing class representing an (x, y) position and a direction. */
 public class Position {
   private final int x;
   private final int y;
+  private final String direction;
 
-  public Position(int x, int y) {
+  public Position(int x, int y, String direction) {
     this.x = x;
     this.y = y;
+    this.direction = direction;
   }
 
   public int getX() {
@@ -16,5 +18,9 @@ public class Position {
 
   public int getY() {
     return this.y;
+  }
+
+  public String getDirection() {
+    return this.direction;
   }
 }

--- a/org-code-javabuilder/validation/src/main/java/org/code/validation/support/NeighborhoodActionTypeMapper.java
+++ b/org-code-javabuilder/validation/src/main/java/org/code/validation/support/NeighborhoodActionTypeMapper.java
@@ -35,6 +35,12 @@ public class NeighborhoodActionTypeMapper {
         return NeighborhoodActionType.HIDE_BUCKETS;
       case SHOW_BUCKETS:
         return NeighborhoodActionType.SHOW_BUCKETS;
+      case CAN_MOVE:
+        return NeighborhoodActionType.CAN_MOVE;
+      case IS_ON_BUCKET:
+        return NeighborhoodActionType.IS_ON_BUCKET;
+      case IS_ON_PAINT:
+        return NeighborhoodActionType.IS_ON_PAINT;
       default:
         return null;
     }

--- a/org-code-javabuilder/validation/src/main/java/org/code/validation/support/NeighborhoodTracker.java
+++ b/org-code-javabuilder/validation/src/main/java/org/code/validation/support/NeighborhoodTracker.java
@@ -50,7 +50,9 @@ public class NeighborhoodTracker {
       final int x = message.getDetail().getInt(X);
       final int y = message.getDetail().getInt(Y);
       final int paint = message.getDetail().getInt(PAINT);
-      final PainterTracker painterTracker = new PainterTracker(id, new Position(x, y), paint);
+      final String direction = message.getDetail().getString(DIRECTION);
+      final PainterTracker painterTracker =
+          new PainterTracker(id, new Position(x, y, direction), paint);
       this.painterTrackers.put(id, painterTracker);
       return;
     }

--- a/org-code-javabuilder/validation/src/main/java/org/code/validation/support/PainterTracker.java
+++ b/org-code-javabuilder/validation/src/main/java/org/code/validation/support/PainterTracker.java
@@ -39,16 +39,16 @@ public class PainterTracker {
           final int currentY = this.currentPosition.getY();
           switch (Direction.fromString(directionString)) {
             case NORTH:
-              this.currentPosition = new Position(currentX, currentY - 1);
+              this.currentPosition = new Position(currentX, currentY - 1, directionString);
               break;
             case EAST:
-              this.currentPosition = new Position(currentX + 1, currentY);
+              this.currentPosition = new Position(currentX + 1, currentY, directionString);
               break;
             case SOUTH:
-              this.currentPosition = new Position(currentX, currentY + 1);
+              this.currentPosition = new Position(currentX, currentY + 1, directionString);
               break;
             case WEST:
-              this.currentPosition = new Position(currentX - 1, currentY);
+              this.currentPosition = new Position(currentX - 1, currentY, directionString);
               break;
           }
         }

--- a/org-code-javabuilder/validation/src/test/java/org/code/validation/NeighborhoodLogTest.java
+++ b/org-code-javabuilder/validation/src/test/java/org/code/validation/NeighborhoodLogTest.java
@@ -79,7 +79,8 @@ public class NeighborhoodLogTest {
   }
 
   private PainterLog createPainterLog(List<PainterEvent> events) {
-    return new PainterLog("sampleId", new Position(0, 0), new Position(5, 5), 0, 5, events);
+    return new PainterLog(
+        "sampleId", new Position(0, 0, "East"), new Position(5, 5, "East"), 0, 5, events);
   }
 
   private String[][] getSampleFinalOutput() {

--- a/org-code-javabuilder/validation/src/test/java/org/code/validation/NeighborhoodLogTest.java
+++ b/org-code-javabuilder/validation/src/test/java/org/code/validation/NeighborhoodLogTest.java
@@ -80,7 +80,7 @@ public class NeighborhoodLogTest {
 
   private PainterLog createPainterLog(List<PainterEvent> events) {
     return new PainterLog(
-        "sampleId", new Position(0, 0, "East"), new Position(5, 5, "East"), 0, 5, events);
+        "sampleId", new Position(0, 0, "east"), new Position(5, 5, "east"), 0, 5, events);
   }
 
   private String[][] getSampleFinalOutput() {

--- a/org-code-javabuilder/validation/src/test/java/org/code/validation/PainterLogTest.java
+++ b/org-code-javabuilder/validation/src/test/java/org/code/validation/PainterLogTest.java
@@ -26,8 +26,8 @@ public class PainterLogTest {
     unitUnderTest =
         new PainterLog(
             "sampleId",
-            new Position(0, 0, "East"),
-            new Position(5, 5, "North"),
+            new Position(0, 0, "east"),
+            new Position(5, 5, "north"),
             0,
             5,
             sampleEvents);

--- a/org-code-javabuilder/validation/src/test/java/org/code/validation/PainterLogTest.java
+++ b/org-code-javabuilder/validation/src/test/java/org/code/validation/PainterLogTest.java
@@ -24,7 +24,13 @@ public class PainterLogTest {
     sampleEvents.add(new PainterEvent(NeighborhoodActionType.PAINT, null));
     sampleEvents.add(new PainterEvent(NeighborhoodActionType.TAKE_PAINT, null));
     unitUnderTest =
-        new PainterLog("sampleId", new Position(0, 0), new Position(5, 5), 0, 5, sampleEvents);
+        new PainterLog(
+            "sampleId",
+            new Position(0, 0, "East"),
+            new Position(5, 5, "North"),
+            0,
+            5,
+            sampleEvents);
   }
 
   @Test

--- a/org-code-javabuilder/validation/src/test/java/org/code/validation/support/NeighborhoodTrackerTest.java
+++ b/org-code-javabuilder/validation/src/test/java/org/code/validation/support/NeighborhoodTrackerTest.java
@@ -138,7 +138,7 @@ class NeighborhoodTrackerTest {
 
     final HashMap<String, String> isOnBucketDetails = new HashMap<>();
     isOnBucketDetails.put(ID, id);
-    // Take paint
+    // Check is on bucket
     unitUnderTest.trackEvent(
         new NeighborhoodSignalMessage(NeighborhoodSignalKey.IS_ON_BUCKET, isOnBucketDetails));
 

--- a/org-code-javabuilder/validation/src/test/java/org/code/validation/support/NeighborhoodTrackerTest.java
+++ b/org-code-javabuilder/validation/src/test/java/org/code/validation/support/NeighborhoodTrackerTest.java
@@ -12,6 +12,7 @@ import org.code.protocol.ClientMessageType;
 import org.code.protocol.GlobalProtocolTestFactory;
 import org.code.protocol.JavabuilderContext;
 import org.code.validation.ClientMessageHelper;
+import org.code.validation.NeighborhoodActionType;
 import org.code.validation.PainterLog;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -127,6 +128,25 @@ class NeighborhoodTrackerTest {
         findPainterLogById(unitUnderTest.getNeighborhoodLog().getPainterLogs(), id3);
     assertNotNull(painter3Log);
     assertEquals(2, painter3Log.getEndingPosition().getX());
+  }
+
+  @Test
+  public void testUpdatesPainterLogWithNonAnimatedMoves() {
+    final String id = "id";
+    // Initialize
+    unitUnderTest.trackEvent(createInitEvent(id, Direction.EAST, 5, 10, 20));
+
+    final HashMap<String, String> isOnBucketDetails = new HashMap<>();
+    isOnBucketDetails.put(ID, id);
+    // Take paint
+    unitUnderTest.trackEvent(
+        new NeighborhoodSignalMessage(NeighborhoodSignalKey.IS_ON_BUCKET, isOnBucketDetails));
+
+    final PainterLog painterLog = unitUnderTest.getNeighborhoodLog().getPainterLogs()[0];
+
+    assertEquals(ID, painterLog.getPainterId());
+    assertTrue(painterLog.didActionOnce(NeighborhoodActionType.IS_ON_BUCKET));
+    assertFalse(painterLog.didActionAtLeast(NeighborhoodActionType.CAN_MOVE, 1));
   }
 
   private NeighborhoodSignalMessage createInitEvent(

--- a/org-code-javabuilder/validation/src/test/java/org/code/validation/support/PainterTrackerTest.java
+++ b/org-code-javabuilder/validation/src/test/java/org/code/validation/support/PainterTrackerTest.java
@@ -2,6 +2,7 @@ package org.code.validation.support;
 
 import static org.code.protocol.ClientMessageDetailKeys.DIRECTION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -15,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 public class PainterTrackerTest {
   private static final String ID = "id";
-  private static final Position POSITION = new Position(1, 1);
+  private static final Position POSITION = new Position(1, 1, "East");
   private static final int PAINT_COUNT = 10;
 
   private PainterTracker unitUnderTest;
@@ -88,6 +89,24 @@ public class PainterTrackerTest {
     assertEquals(3, log.getEndingPosition().getY());
     assertEquals(PAINT_COUNT - 1, log.getEndingPaintCount());
     assertEquals(events, log.getEvents());
+  }
+
+  @Test
+  public void testTracksNonAnimatedEvents() {
+    final PainterEvent event1 = new PainterEvent(NeighborhoodActionType.CAN_MOVE, Map.of());
+    final PainterEvent event2 = new PainterEvent(NeighborhoodActionType.IS_ON_BUCKET, Map.of());
+    final PainterEvent event3 = new PainterEvent(NeighborhoodActionType.IS_ON_PAINT, Map.of());
+
+    final List<PainterEvent> events = List.of(event1, event2, event3);
+
+    for (PainterEvent event : events) {
+      unitUnderTest.trackEvent(event);
+    }
+
+    final PainterLog log = unitUnderTest.getPainterLog();
+    assertTrue(log.didActionAtLeast(NeighborhoodActionType.CAN_MOVE, 1));
+    assertTrue(log.didActionOnce(NeighborhoodActionType.IS_ON_PAINT));
+    assertTrue(log.didActionOnce(NeighborhoodActionType.IS_ON_BUCKET));
   }
 
   private PainterEvent createMoveEvent(Direction direction) {

--- a/org-code-javabuilder/validation/src/test/java/org/code/validation/support/PainterTrackerTest.java
+++ b/org-code-javabuilder/validation/src/test/java/org/code/validation/support/PainterTrackerTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 public class PainterTrackerTest {
   private static final String ID = "id";
-  private static final Position POSITION = new Position(1, 1, "East");
+  private static final Position POSITION = new Position(1, 1, "east");
   private static final int PAINT_COUNT = 10;
 
   private PainterTracker unitUnderTest;

--- a/org-code-javabuilder/validation/src/test/java/org/code/validation/support/PainterTrackerTest.java
+++ b/org-code-javabuilder/validation/src/test/java/org/code/validation/support/PainterTrackerTest.java
@@ -32,21 +32,25 @@ public class PainterTrackerTest {
     // Should move to (2, 1)
     assertEquals(2, unitUnderTest.getCurrentPosition().getX());
     assertEquals(1, unitUnderTest.getCurrentPosition().getY());
+    assertEquals("east", unitUnderTest.getCurrentPosition().getDirection());
 
     unitUnderTest.trackEvent(createMoveEvent(Direction.SOUTH));
     // Should move to (2, 2)
     assertEquals(2, unitUnderTest.getCurrentPosition().getX());
     assertEquals(2, unitUnderTest.getCurrentPosition().getY());
+    assertEquals("south", unitUnderTest.getCurrentPosition().getDirection());
 
     unitUnderTest.trackEvent(createMoveEvent(Direction.WEST));
     // Should move to (1, 2)
     assertEquals(1, unitUnderTest.getCurrentPosition().getX());
     assertEquals(2, unitUnderTest.getCurrentPosition().getY());
+    assertEquals("west", unitUnderTest.getCurrentPosition().getDirection());
 
     unitUnderTest.trackEvent(createMoveEvent(Direction.NORTH));
     // Should move to (1, 1)
     assertEquals(1, unitUnderTest.getCurrentPosition().getX());
     assertEquals(1, unitUnderTest.getCurrentPosition().getY());
+    assertEquals("north", unitUnderTest.getCurrentPosition().getDirection());
   }
 
   @Test


### PR DESCRIPTION
We wanted to be able to track the following in validation code:
- the Painter's start and end direction
- If `canMove`, `isOnBucket` and/or `isOnPaint` were called.

To track direction I've extended `Position` to also include direction and have a getter for direction.

The reason we didn't previously see events for `canMove`, etc. is they do not trigger an animation and therefore were not sent over the output adapter. We only look at output adapter methods in our neighborhood tracking. To fix this I've added output events for these methods.

I also added the result of the method call (true or false) to the output message even though it wasn't necessary for this use case. The result makes the message over the websocket less confusing, because we would send something such as `CAN_MOVE` with no more information when `canMove` was called and it was false. Adding the result makes this message less confusing and opens up the ability to add some indicator of the function call on the frontend if we chose to in the future.