### PR TITLE
Add DynamoDB permissions to Build and Run role

### DIFF
--- a/iam.yml
+++ b/iam.yml
@@ -63,7 +63,15 @@ Resources:
                   - 'cloudwatch:PutMetricData'
                 Resource:
                   - '*'
-  
+              # Build and Run lambdas need read and delete DynamoDB records to check container health status
+              - Effect: Allow
+                Action:
+                  - 'dynamodb:GetItem'
+                  - 'dynamodb:Query'
+                  - 'dynamodb:DeleteItem'
+                Resource:
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*_unhealthy_containers"
+
   # Permissions for the synchronous Lambda that invokes the long-running Lambda
   # and then relays web messages to it
   SessionManagerMessageRelayLambdaRole:


### PR DESCRIPTION
Adds DynamoDB get, query, and delete permissions to the Build and Run lambda role. This will be used by the build and run lambda to read from a DynamoDB table that will list unhealthy lambda container IDs. This is part of a mechanism to manually force-shut down specific lambda containers if we notice any persistent issues with them.

Note: after merging this change, we'll need to work with an infra engineer to deploy the updates. I'll ping about that separately once this is merged.