### PR TITLE
Bump concurrency and limits for javabuilder-test

### DIFF
--- a/cicd/3-app/javabuilder/config/test.config.json
+++ b/cicd/3-app/javabuilder/config/test.config.json
@@ -2,10 +2,10 @@
   "Parameters": {
     "BaseDomainName": "code.org",
     "BaseDomainNameHostedZonedID": "Z2LCOI49SCXUGU",
-    "ProvisionedConcurrentExecutions": "1",
-    "ReservedConcurrentExecutions": "3",
-    "LimitPerHour": "15",
-    "LimitPerDay": "40",
+    "ProvisionedConcurrentExecutions": "5",
+    "ReservedConcurrentExecutions": "25",
+    "LimitPerHour": "50",
+    "LimitPerDay": "150",
     "SilenceAlerts": "false"
   }
 }


### PR DESCRIPTION
Bumping up the hourly/daily limits and concurrency on the javabuilder-test stack a bit so that multiple developers can develop against it without too easily running into throttling or rate limiting. I matched the daily and hourly limits to the adhoc config, but the concurrency is just a ballpark estimate based on how many developers might be working on it concurrently, so let me know if these should be adjusted.

For reference - [this change](https://github.com/code-dot-org/code-dot-org/pull/47886) makes the javabuilder-test stack the default for local development, so we would expect its usage to increase.