### PR TITLE
Add validation api for checking system out messages

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ValidationRunner.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ValidationRunner.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.code.javabuilder.util.ProjectLoadUtils;
 import org.code.protocol.*;
 import org.code.validation.support.NeighborhoodTracker;
+import org.code.validation.support.SystemOutTracker;
 import org.code.validation.support.ValidationProtocol;
 
 public class ValidationRunner extends BaseTestRunner {
@@ -49,6 +50,6 @@ public class ValidationRunner extends BaseTestRunner {
     JavabuilderContext.getInstance()
         .register(
             ValidationProtocol.class,
-            new ValidationProtocol(mainMethod, new NeighborhoodTracker()));
+            new ValidationProtocol(mainMethod, new NeighborhoodTracker(), new SystemOutTracker()));
   }
 }

--- a/org-code-javabuilder/validation/src/main/java/org/code/validation/SystemOutTestRunner.java
+++ b/org-code-javabuilder/validation/src/main/java/org/code/validation/SystemOutTestRunner.java
@@ -5,6 +5,8 @@ import org.code.protocol.JavabuilderContext;
 import org.code.validation.support.ValidationProtocol;
 
 public class SystemOutTestRunner {
+  // Run the main method of the user's program and return a list
+  // of all system.out messages in order.
   public static List<String> run() {
     ValidationProtocol protocolInstance =
         (ValidationProtocol) JavabuilderContext.getInstance().get(ValidationProtocol.class);

--- a/org-code-javabuilder/validation/src/main/java/org/code/validation/SystemOutTestRunner.java
+++ b/org-code-javabuilder/validation/src/main/java/org/code/validation/SystemOutTestRunner.java
@@ -1,0 +1,14 @@
+package org.code.validation;
+
+import java.util.List;
+import org.code.protocol.JavabuilderContext;
+import org.code.validation.support.ValidationProtocol;
+
+public class SystemOutTestRunner {
+  public static List<String> run() {
+    ValidationProtocol protocolInstance =
+        (ValidationProtocol) JavabuilderContext.getInstance().get(ValidationProtocol.class);
+    protocolInstance.invokeMainMethod();
+    return protocolInstance.getSystemOutMessages();
+  }
+}

--- a/org-code-javabuilder/validation/src/main/java/org/code/validation/support/NeighborhoodTracker.java
+++ b/org-code-javabuilder/validation/src/main/java/org/code/validation/support/NeighborhoodTracker.java
@@ -18,7 +18,7 @@ import org.code.validation.PainterLog;
 import org.code.validation.Position;
 
 public class NeighborhoodTracker {
-  private final Map<String, PainterTracker> painterTrackers;
+  private Map<String, PainterTracker> painterTrackers;
   private String[][] neighborhoodState;
   private boolean isInitialized;
 
@@ -81,6 +81,11 @@ public class NeighborhoodTracker {
       default:
         break;
     }
+  }
+
+  public void reset() {
+    this.painterTrackers = new HashMap<>();
+    this.isInitialized = false;
   }
 
   private void initializeGrid() {

--- a/org-code-javabuilder/validation/src/main/java/org/code/validation/support/SystemOutTracker.java
+++ b/org-code-javabuilder/validation/src/main/java/org/code/validation/support/SystemOutTracker.java
@@ -1,0 +1,25 @@
+package org.code.validation.support;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.code.protocol.ClientMessage;
+import org.code.protocol.ClientMessageType;
+
+public class SystemOutTracker {
+  private List<String> messages;
+
+  public SystemOutTracker() {
+    this.messages = new ArrayList<>();
+  }
+
+  public List<String> getSystemOutMessages() {
+    return this.messages;
+  }
+
+  public void trackEvent(ClientMessage message) {
+    if (message.getType() != ClientMessageType.SYSTEM_OUT) {
+      return;
+    }
+    this.messages.add(message.getValue());
+  }
+}

--- a/org-code-javabuilder/validation/src/main/java/org/code/validation/support/SystemOutTracker.java
+++ b/org-code-javabuilder/validation/src/main/java/org/code/validation/support/SystemOutTracker.java
@@ -16,6 +16,8 @@ public class SystemOutTracker {
     return this.messages;
   }
 
+  // Track a single client message event. It will only be tracked if it is a system out message
+  // that is not just a newline, otherwise it will be ignored.
   public void trackEvent(ClientMessage message) {
     if (message.getType() != ClientMessageType.SYSTEM_OUT) {
       return;

--- a/org-code-javabuilder/validation/src/main/java/org/code/validation/support/SystemOutTracker.java
+++ b/org-code-javabuilder/validation/src/main/java/org/code/validation/support/SystemOutTracker.java
@@ -20,6 +20,15 @@ public class SystemOutTracker {
     if (message.getType() != ClientMessageType.SYSTEM_OUT) {
       return;
     }
-    this.messages.add(message.getValue());
+    String value = message.getValue();
+    // Ignore new lines as those are indications of a println vs a print.
+    // For validation we don't care which is used.
+    if (!value.equals("\n")) {
+      this.messages.add(message.getValue());
+    }
+  }
+
+  public void reset() {
+    this.messages = new ArrayList<>();
   }
 }

--- a/org-code-javabuilder/validation/src/main/java/org/code/validation/support/UserTestOutputAdapter.java
+++ b/org-code-javabuilder/validation/src/main/java/org/code/validation/support/UserTestOutputAdapter.java
@@ -29,15 +29,15 @@ public class UserTestOutputAdapter implements OutputAdapter {
           delegateOutputAdapter.sendMessage(message);
         }
         break;
-      case NEIGHBORHOOD:
-        if (this.isValidation) {
-          ValidationProtocol protocolInstance =
-              (ValidationProtocol) JavabuilderContext.getInstance().get(ValidationProtocol.class);
-          protocolInstance.trackEvent(message);
-        }
-        break;
       default:
         break;
+    }
+    // If this is validation, send all messages to the validation protocol, which will decide
+    // whether or not to track them.
+    if (this.isValidation) {
+      ValidationProtocol protocolInstance =
+          (ValidationProtocol) JavabuilderContext.getInstance().get(ValidationProtocol.class);
+      protocolInstance.trackEvent(message);
     }
   }
 

--- a/org-code-javabuilder/validation/src/main/java/org/code/validation/support/ValidationProtocol.java
+++ b/org-code-javabuilder/validation/src/main/java/org/code/validation/support/ValidationProtocol.java
@@ -2,6 +2,7 @@ package org.code.validation.support;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.List;
 import org.code.protocol.ClientMessage;
 import org.code.protocol.JavabuilderSharedObject;
 import org.code.validation.NeighborhoodLog;
@@ -9,18 +10,28 @@ import org.code.validation.NeighborhoodLog;
 public class ValidationProtocol extends JavabuilderSharedObject {
   private final Method mainMethod;
   private final NeighborhoodTracker neighborhoodTracker;
+  private final SystemOutTracker systemOutTracker;
 
-  public ValidationProtocol(Method mainMethod, NeighborhoodTracker neighborhoodTracker) {
+  public ValidationProtocol(
+      Method mainMethod,
+      NeighborhoodTracker neighborhoodTracker,
+      SystemOutTracker systemOutTracker) {
     this.mainMethod = mainMethod;
     this.neighborhoodTracker = neighborhoodTracker;
+    this.systemOutTracker = systemOutTracker;
   }
 
   public NeighborhoodLog getNeighborhoodLog() {
     return this.neighborhoodTracker.getNeighborhoodLog();
   }
 
+  public List<String> getSystemOutMessages() {
+    return this.systemOutTracker.getSystemOutMessages();
+  }
+
   public void trackEvent(ClientMessage message) {
     this.neighborhoodTracker.trackEvent(message);
+    this.systemOutTracker.trackEvent(message);
   }
 
   public void invokeMainMethod() {

--- a/org-code-javabuilder/validation/src/main/java/org/code/validation/support/ValidationProtocol.java
+++ b/org-code-javabuilder/validation/src/main/java/org/code/validation/support/ValidationProtocol.java
@@ -38,6 +38,8 @@ public class ValidationProtocol extends JavabuilderSharedObject {
     if (this.mainMethod == null) {
       throw new ValidationRuntimeException(ExceptionKey.NO_MAIN_METHOD_VALIDATION);
     }
+    this.neighborhoodTracker.reset();
+    this.systemOutTracker.reset();
     try {
       this.mainMethod.invoke(null, new Object[] {null});
     } catch (IllegalAccessException e) {

--- a/org-code-javabuilder/validation/src/test/java/org/code/validation/support/NeighborhoodTrackerTest.java
+++ b/org-code-javabuilder/validation/src/test/java/org/code/validation/support/NeighborhoodTrackerTest.java
@@ -47,7 +47,7 @@ class NeighborhoodTrackerTest {
 
   @Test
   public void testUpdatesPainterTrackerWithPainterMessages() {
-    final String id = "id";
+    final String id = "id1";
     // Initialize
     unitUnderTest.trackEvent(createInitEvent(id, Direction.EAST, 5, 10, 20));
 
@@ -66,7 +66,7 @@ class NeighborhoodTrackerTest {
 
     final PainterLog painterLog = unitUnderTest.getNeighborhoodLog().getPainterLogs()[0];
 
-    assertEquals(ID, painterLog.getPainterId());
+    assertEquals(id, painterLog.getPainterId());
     assertEquals(4, painterLog.getEndingPosition().getX());
     assertEquals(10, painterLog.getEndingPosition().getY());
     assertEquals(21, painterLog.getEndingPaintCount());
@@ -132,7 +132,7 @@ class NeighborhoodTrackerTest {
 
   @Test
   public void testUpdatesPainterLogWithNonAnimatedMoves() {
-    final String id = "id";
+    final String id = "id1";
     // Initialize
     unitUnderTest.trackEvent(createInitEvent(id, Direction.EAST, 5, 10, 20));
 
@@ -144,9 +144,36 @@ class NeighborhoodTrackerTest {
 
     final PainterLog painterLog = unitUnderTest.getNeighborhoodLog().getPainterLogs()[0];
 
-    assertEquals(ID, painterLog.getPainterId());
+    assertEquals(id, painterLog.getPainterId());
     assertTrue(painterLog.didActionOnce(NeighborhoodActionType.IS_ON_BUCKET));
     assertFalse(painterLog.didActionAtLeast(NeighborhoodActionType.CAN_MOVE, 1));
+  }
+
+  @Test
+  public void resetsSuccessfully() {
+    final String id = "id1";
+    // Initialize
+    unitUnderTest.trackEvent(createInitEvent(id, Direction.EAST, 5, 10, 20));
+    // create paint event
+    final HashMap<String, String> paintDetails = new HashMap<>();
+    paintDetails.put(COLOR, "orange");
+    paintDetails.put(ID, id);
+    unitUnderTest.trackEvent(
+        new NeighborhoodSignalMessage(NeighborhoodSignalKey.PAINT, paintDetails));
+    unitUnderTest.reset();
+    // re-initialize
+    unitUnderTest.trackEvent(createInitEvent(id, Direction.EAST, 5, 10, 20));
+    // create move event
+    final HashMap<String, String> moveDetails = new HashMap<>();
+    moveDetails.put(DIRECTION, Direction.WEST.getDirectionString());
+    moveDetails.put(ID, id);
+    unitUnderTest.trackEvent(
+        new NeighborhoodSignalMessage(NeighborhoodSignalKey.MOVE, moveDetails));
+
+    final PainterLog painterLog = unitUnderTest.getNeighborhoodLog().getPainterLogs()[0];
+
+    assertEquals(false, painterLog.didActionOnce(NeighborhoodActionType.PAINT));
+    assertEquals(true, painterLog.didActionOnce(NeighborhoodActionType.MOVE));
   }
 
   private NeighborhoodSignalMessage createInitEvent(

--- a/org-code-javabuilder/validation/src/test/java/org/code/validation/support/SystemOutTrackerTest.java
+++ b/org-code-javabuilder/validation/src/test/java/org/code/validation/support/SystemOutTrackerTest.java
@@ -1,0 +1,44 @@
+package org.code.validation.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.code.protocol.ClientMessageType;
+import org.code.validation.ClientMessageHelper;
+import org.junit.jupiter.api.Test;
+
+public class SystemOutTrackerTest {
+  private SystemOutTracker unitUnderTest;
+
+  @Test
+  public void tracksAllNonNewlineMessages() {
+    unitUnderTest = new SystemOutTracker();
+    // should be tracked
+    unitUnderTest.trackEvent(new ClientMessageHelper(ClientMessageType.SYSTEM_OUT, "hello"));
+    // should be ignored
+    unitUnderTest.trackEvent(new ClientMessageHelper(ClientMessageType.SYSTEM_OUT, "\n"));
+    // should be tracked
+    unitUnderTest.trackEvent(new ClientMessageHelper(ClientMessageType.SYSTEM_OUT, "hello world"));
+
+    List<String> messages = unitUnderTest.getSystemOutMessages();
+    assertEquals(2, messages.size());
+    assertEquals("hello world", messages.get(1));
+  }
+
+  @Test
+  public void resetsSuccessfully() {
+    unitUnderTest = new SystemOutTracker();
+    unitUnderTest.trackEvent(new ClientMessageHelper(ClientMessageType.SYSTEM_OUT, "hello"));
+    // should reset message list
+    unitUnderTest.reset();
+    unitUnderTest.trackEvent(
+        new ClientMessageHelper(ClientMessageType.SYSTEM_OUT, "a new message"));
+    unitUnderTest.trackEvent(new ClientMessageHelper(ClientMessageType.SYSTEM_OUT, "hello world"));
+    unitUnderTest.trackEvent(
+        new ClientMessageHelper(ClientMessageType.SYSTEM_OUT, "a third message"));
+
+    List<String> messages = unitUnderTest.getSystemOutMessages();
+    assertEquals(3, messages.size());
+    assertEquals("a new message", messages.get(0));
+  }
+}

--- a/org-code-javabuilder/validation/src/test/java/org/code/validation/support/UserTestOutputAdapterTest.java
+++ b/org-code-javabuilder/validation/src/test/java/org/code/validation/support/UserTestOutputAdapterTest.java
@@ -14,7 +14,10 @@ public class UserTestOutputAdapterTest {
 
   @BeforeEach
   public void setUp() {
+
     testOutputAdapter = new UserTestOutputAdapter(delegateOutputAdapter);
+    JavabuilderContext.getInstance()
+        .register(ValidationProtocol.class, mock(ValidationProtocol.class));
   }
 
   @Test

--- a/org-code-javabuilder/validation/src/test/java/org/code/validation/support/UserTestOutputAdapterTest.java
+++ b/org-code-javabuilder/validation/src/test/java/org/code/validation/support/UserTestOutputAdapterTest.java
@@ -14,7 +14,6 @@ public class UserTestOutputAdapterTest {
 
   @BeforeEach
   public void setUp() {
-
     testOutputAdapter = new UserTestOutputAdapter(delegateOutputAdapter);
     JavabuilderContext.getInstance()
         .register(ValidationProtocol.class, mock(ValidationProtocol.class));


### PR DESCRIPTION
Levelbuilders would like to be able to check what was written to the console in their tests. This adds a basic api to do that. The usage on the levelbuilder side is:
```
import org.code.validation.*;
...
List<String> messages = SystemOutTestRunner.run();
```

We do this tracking similarly to neighborhood messages. Any system out message goes through `UserTestOutputAdapter`, and instead of ignoring them we parse and track any that are not `\n`. `\n` messages indicate the user used a `println` vs a `print`.

I waffled on whether or not to create an interface for the tracker type (as we now have `NeighborhoodTracker`, `PainterTracker` and `SystemOutTracker`), but ultimately decided against it as the `getLog` method needs a different return type for each version. Therefore adding an interface would really only get us some default methods `trackEvent` and `reset` (which currently isn't useful for `PainterTracker`), which didn't seem helpful enough. I am open to suggestion if we think that adding an interface would gain us other benefits.

I've documented this api (and our other validation api) in [this document](https://docs.google.com/document/d/1t_NEkBEhya70Vl17Ra07Tq3Wk1xYdpU8TYNagGiuOFM/edit).