### PR TITLE
Add table definition for unhealthy containers table

### DIFF
--- a/cicd/3-app/javabuilder/template.yml.erb
+++ b/cicd/3-app/javabuilder/template.yml.erb
@@ -985,9 +985,6 @@ Resources:
         AttributeDefinitions:
           - AttributeName: <%=CONTAINER_ID_AND_TRIGGER_COMPOSITE_ATTRIBUTE_NAME%>
             AttributeType: S
-        TimeToLiveSpecification:
-          AttributeName: <%=TIME_TO_LIVE_ATTRIBUTE_NAME%>
-          Enabled: true
 
   HighUsersBlockedAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/cicd/3-app/javabuilder/template.yml.erb
+++ b/cicd/3-app/javabuilder/template.yml.erb
@@ -905,6 +905,7 @@ Resources:
   TOKEN_ID_ATTRIBUTE_NAME = 'token_id'
   ISSUED_AT_TIMESTAMP_ATTRIBUTE_NAME = 'issued_at'
   TIME_TO_LIVE_ATTRIBUTE_NAME = 'ttl'
+  CONTAINER_ID_AND_TRIGGER_COMPOSITE_ATTRIBUTE_NAME = 'container_id'
 -%>
   BlockedUsersTable:
     Type: AWS::DynamoDB::Table
@@ -972,6 +973,21 @@ Resources:
       TimeToLiveSpecification:
         AttributeName: <%=TIME_TO_LIVE_ATTRIBUTE_NAME%>
         Enabled: true
+
+  UnhealthyContainersTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: !Sub "${SubDomainName}_unhealthy_containers"
+        KeySchema:
+          - AttributeName: <%=CONTAINER_ID_AND_TRIGGER_COMPOSITE_ATTRIBUTE_NAME%>
+            KeyType: HASH
+        BillingMode: PAY_PER_REQUEST
+        AttributeDefinitions:
+          - AttributeName: <%=CONTAINER_ID_AND_TRIGGER_COMPOSITE_ATTRIBUTE_NAME%>
+            AttributeType: S
+        TimeToLiveSpecification:
+          AttributeName: <%=TIME_TO_LIVE_ATTRIBUTE_NAME%>
+          Enabled: true
 
   HighUsersBlockedAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
Adds the DynamoDB table definition for the "unhealthy_containers" table, which will be used to log unhealthy container IDs. The build and run lambda will read from this table and shut itself down if it encounters its own ID.

My thinking is that the key will be a composite of the container ID and the shutdown trigger (either "start" or "end"). This is because we may run into situations where we need to shut down a container before code execution, in case there's something that goes seriously wrong during execution and prevents the container from cleaning up normally. Ideally this shouldn't happen very often, but I figured it would be good to have the option just in case. In the more common scenario, we'd log the container ID with a trigger of "end", and the container will fully exit and shut itself down during the cleanup phase.

These composite keys will look something like `fcf181b1-2c3e-42cc-8b06-015e54777173#start` or `2833d1b6-a68e-4e2f-b517-9d2a16310fc0#end`.

JIRA: https://codedotorg.atlassian.net/browse/JAVA-673

Tested on adhoc.