### PR TITLE
Ignore unused output messages in basic output adapters

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketOutputAdapter.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketOutputAdapter.java
@@ -20,7 +20,7 @@ public class WebSocketOutputAdapter implements OutputAdapter {
 
   @Override
   public void sendMessage(ClientMessage message) {
-    if (message.shouldSendInRunMode()) {
+    if (message.shouldAlwaysSend()) {
       try {
         endpoint.sendText(message.getFormattedMessage());
       } catch (IOException e) {
@@ -32,7 +32,7 @@ public class WebSocketOutputAdapter implements OutputAdapter {
   }
 
   public void sendDebuggingMessage(ClientMessage message) {
-    if (message.shouldSendInRunMode()) {
+    if (message.shouldAlwaysSend()) {
       try {
         endpoint.sendText(message.getFormattedMessage());
       } catch (IOException e) {

--- a/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketOutputAdapter.java
+++ b/org-code-javabuilder/lib/src/main/java/dev/javabuilder/WebSocketOutputAdapter.java
@@ -20,22 +20,26 @@ public class WebSocketOutputAdapter implements OutputAdapter {
 
   @Override
   public void sendMessage(ClientMessage message) {
-    try {
-      endpoint.sendText(message.getFormattedMessage());
-    } catch (IOException e) {
-      e.printStackTrace();
-    } catch (IllegalStateException e) {
-      throw new InternalServerRuntimeException(InternalExceptionKey.CONNECTION_TERMINATED, e);
+    if (message.shouldSendInRunMode()) {
+      try {
+        endpoint.sendText(message.getFormattedMessage());
+      } catch (IOException e) {
+        e.printStackTrace();
+      } catch (IllegalStateException e) {
+        throw new InternalServerRuntimeException(InternalExceptionKey.CONNECTION_TERMINATED, e);
+      }
     }
   }
 
   public void sendDebuggingMessage(ClientMessage message) {
-    try {
-      endpoint.sendText(message.getFormattedMessage());
-    } catch (IOException e) {
-      e.printStackTrace();
-    } catch (IllegalStateException e) {
-      throw new InternalServerRuntimeException(InternalExceptionKey.CONNECTION_TERMINATED, e);
+    if (message.shouldSendInRunMode()) {
+      try {
+        endpoint.sendText(message.getFormattedMessage());
+      } catch (IOException e) {
+        e.printStackTrace();
+      } catch (IllegalStateException e) {
+        throw new InternalServerRuntimeException(InternalExceptionKey.CONNECTION_TERMINATED, e);
+      }
     }
   }
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSOutputAdapter.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSOutputAdapter.java
@@ -25,18 +25,22 @@ public class AWSOutputAdapter implements OutputAdapter {
    */
   @Override
   public void sendMessage(ClientMessage message) {
-    PostToConnectionRequest post = new PostToConnectionRequest();
-    post.setConnectionId(connectionId);
-    post.setData(ByteBuffer.wrap((message.getFormattedMessage()).getBytes()));
-    this.sendMessageHelper(post);
+    if (message.shouldSendInRunMode()) {
+      PostToConnectionRequest post = new PostToConnectionRequest();
+      post.setConnectionId(connectionId);
+      post.setData(ByteBuffer.wrap((message.getFormattedMessage()).getBytes()));
+      this.sendMessageHelper(post);
+    }
   }
 
   public void sendDebuggingMessage(ClientMessage message) {
-    String time = String.valueOf(java.time.Clock.systemUTC().instant());
-    PostToConnectionRequest post = new PostToConnectionRequest();
-    post.setConnectionId(connectionId);
-    post.setData(ByteBuffer.wrap((message + " " + time).getBytes()));
-    this.sendMessageHelper(post);
+    if (message.shouldSendInRunMode()) {
+      String time = String.valueOf(java.time.Clock.systemUTC().instant());
+      PostToConnectionRequest post = new PostToConnectionRequest();
+      post.setConnectionId(connectionId);
+      post.setData(ByteBuffer.wrap((message + " " + time).getBytes()));
+      this.sendMessageHelper(post);
+    }
   }
 
   private void sendMessageHelper(PostToConnectionRequest post) {

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSOutputAdapter.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSOutputAdapter.java
@@ -25,7 +25,7 @@ public class AWSOutputAdapter implements OutputAdapter {
    */
   @Override
   public void sendMessage(ClientMessage message) {
-    if (message.shouldSendInRunMode()) {
+    if (message.shouldAlwaysSend()) {
       PostToConnectionRequest post = new PostToConnectionRequest();
       post.setConnectionId(connectionId);
       post.setData(ByteBuffer.wrap((message.getFormattedMessage()).getBytes()));
@@ -34,7 +34,7 @@ public class AWSOutputAdapter implements OutputAdapter {
   }
 
   public void sendDebuggingMessage(ClientMessage message) {
-    if (message.shouldSendInRunMode()) {
+    if (message.shouldAlwaysSend()) {
       String time = String.valueOf(java.time.Clock.systemUTC().instant());
       PostToConnectionRequest post = new PostToConnectionRequest();
       post.setConnectionId(connectionId);

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/support/NeighborhoodSignalMessage.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/support/NeighborhoodSignalMessage.java
@@ -15,7 +15,7 @@ public class NeighborhoodSignalMessage extends ClientMessage {
   public boolean shouldAlwaysSend() {
     String signalKey = this.getValue();
     Set<String> ignoredSignalKeys = new HashSet<>();
-    // These keys are only used for testing, don't send in run mode.
+    // These keys are only used for validation testing, by default don't send them.
     ignoredSignalKeys.add(NeighborhoodSignalKey.CAN_MOVE.toString());
     ignoredSignalKeys.add(NeighborhoodSignalKey.IS_ON_BUCKET.toString());
     ignoredSignalKeys.add(NeighborhoodSignalKey.IS_ON_PAINT.toString());

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/support/NeighborhoodSignalMessage.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/support/NeighborhoodSignalMessage.java
@@ -12,7 +12,7 @@ public class NeighborhoodSignalMessage extends ClientMessage {
   }
 
   @Override
-  public boolean shouldSendInRunMode() {
+  public boolean shouldAlwaysSend() {
     String signalKey = this.getValue();
     Set<String> ignoredSignalKeys = new HashSet<>();
     // These keys are only used for testing, don't send in run mode.

--- a/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/support/NeighborhoodSignalMessage.java
+++ b/org-code-javabuilder/neighborhood/src/main/java/org/code/neighborhood/support/NeighborhoodSignalMessage.java
@@ -1,11 +1,27 @@
 package org.code.neighborhood.support;
 
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 import org.code.protocol.ClientMessage;
 import org.code.protocol.ClientMessageType;
 
 public class NeighborhoodSignalMessage extends ClientMessage {
   public NeighborhoodSignalMessage(NeighborhoodSignalKey key, HashMap<String, String> detail) {
     super(ClientMessageType.NEIGHBORHOOD, key.toString(), detail);
+  }
+
+  @Override
+  public boolean shouldSendInRunMode() {
+    String signalKey = this.getValue();
+    Set<String> ignoredSignalKeys = new HashSet<>();
+    // These keys are only used for testing, don't send in run mode.
+    ignoredSignalKeys.add(NeighborhoodSignalKey.CAN_MOVE.toString());
+    ignoredSignalKeys.add(NeighborhoodSignalKey.IS_ON_BUCKET.toString());
+    ignoredSignalKeys.add(NeighborhoodSignalKey.IS_ON_PAINT.toString());
+    if (ignoredSignalKeys.contains(signalKey)) {
+      return false;
+    }
+    return true;
   }
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessage.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessage.java
@@ -69,10 +69,10 @@ public abstract class ClientMessage {
   }
 
   /**
-   * @return whether or not this message should be sent in run mode. Some messages are only relevant
-   *     for test mode.
+   * @return whether or not this message should always be sent by any output adapter. Some messages
+   *     are only relevant for the test output adapter
    */
-  public boolean shouldSendInRunMode() {
+  public boolean shouldAlwaysSend() {
     return true;
   }
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessage.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/ClientMessage.java
@@ -67,4 +67,12 @@ public abstract class ClientMessage {
     }
     return formattedMessage.toString();
   }
+
+  /**
+   * @return whether or not this message should be sent in run mode. Some messages are only relevant
+   *     for test mode.
+   */
+  public boolean shouldSendInRunMode() {
+    return true;
+  }
 }


### PR DESCRIPTION
I added additional painter output messages in [this PR](https://github.com/code-dot-org/javabuilder/pull/357) that are only used in validation runs. Sending these over the websocket had a performance impact for large neighborhood projects. In this PR I added a method that sets the default send status for a client message. For every message but the new neighborhood ones that method returns true, and for the new neighborhood messages it returns false.

## Testing
Tested locally and on an adhoc. Tested that normal execution no longer receives these messages and validation on them still works.