### PR TITLE
Add ValidationHelper class

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ValidationRunner.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ValidationRunner.java
@@ -2,8 +2,8 @@ package org.code.javabuilder;
 
 import java.lang.reflect.Method;
 import java.net.URLClassLoader;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.code.javabuilder.util.ProjectLoadUtils;
 import org.code.protocol.*;
 import org.code.validation.support.NeighborhoodTracker;
@@ -48,10 +48,11 @@ public class ValidationRunner extends BaseTestRunner {
 
   private void setUpForValidation(URLClassLoader urlClassLoader) throws UserInitiatedException {
     Method mainMethod = ProjectLoadUtils.findMainMethod(urlClassLoader, this.projectFiles);
-    List<String> classNames = new ArrayList<>();
-    for (JavaProjectFile projectFile : this.projectFiles) {
-      classNames.add(projectFile.getClassName());
-    }
+    List<String> classNames =
+        this.projectFiles
+            .stream()
+            .map(projectFile -> projectFile.getClassName())
+            .collect(Collectors.toList());
     JavabuilderContext.getInstance()
         .register(
             ValidationProtocol.class,

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ValidationRunner.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ValidationRunner.java
@@ -2,6 +2,7 @@ package org.code.javabuilder;
 
 import java.lang.reflect.Method;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.List;
 import org.code.javabuilder.util.ProjectLoadUtils;
 import org.code.protocol.*;
@@ -47,9 +48,14 @@ public class ValidationRunner extends BaseTestRunner {
 
   private void setUpForValidation(URLClassLoader urlClassLoader) throws UserInitiatedException {
     Method mainMethod = ProjectLoadUtils.findMainMethod(urlClassLoader, this.projectFiles);
+    List<String> classNames = new ArrayList<>();
+    for (JavaProjectFile projectFile : this.projectFiles) {
+      classNames.add(projectFile.getClassName());
+    }
     JavabuilderContext.getInstance()
         .register(
             ValidationProtocol.class,
-            new ValidationProtocol(mainMethod, new NeighborhoodTracker(), new SystemOutTracker()));
+            new ValidationProtocol(
+                mainMethod, new NeighborhoodTracker(), new SystemOutTracker(), classNames));
   }
 }

--- a/org-code-javabuilder/validation/src/main/java/org/code/validation/ValidationHelper.java
+++ b/org-code-javabuilder/validation/src/main/java/org/code/validation/ValidationHelper.java
@@ -1,0 +1,13 @@
+package org.code.validation;
+
+import java.util.List;
+import org.code.protocol.JavabuilderContext;
+import org.code.validation.support.ValidationProtocol;
+
+public class ValidationHelper {
+  public static List<String> getClassNames() {
+    ValidationProtocol protocolInstance =
+        (ValidationProtocol) JavabuilderContext.getInstance().get(ValidationProtocol.class);
+    return protocolInstance.getUserClassNames();
+  }
+}

--- a/org-code-javabuilder/validation/src/main/java/org/code/validation/support/ValidationProtocol.java
+++ b/org-code-javabuilder/validation/src/main/java/org/code/validation/support/ValidationProtocol.java
@@ -11,14 +11,17 @@ public class ValidationProtocol extends JavabuilderSharedObject {
   private final Method mainMethod;
   private final NeighborhoodTracker neighborhoodTracker;
   private final SystemOutTracker systemOutTracker;
+  private final List<String> userClassNames;
 
   public ValidationProtocol(
       Method mainMethod,
       NeighborhoodTracker neighborhoodTracker,
-      SystemOutTracker systemOutTracker) {
+      SystemOutTracker systemOutTracker,
+      List<String> userClassNames) {
     this.mainMethod = mainMethod;
     this.neighborhoodTracker = neighborhoodTracker;
     this.systemOutTracker = systemOutTracker;
+    this.userClassNames = userClassNames;
   }
 
   public NeighborhoodLog getNeighborhoodLog() {
@@ -53,5 +56,9 @@ public class ValidationProtocol extends JavabuilderSharedObject {
       }
       throw new ValidationRuntimeException(ExceptionKey.ERROR_RUNNING_MAIN, cause);
     }
+  }
+
+  public List<String> getUserClassNames() {
+    return this.userClassNames;
   }
 }


### PR DESCRIPTION
This PR adds a new `ValidationHelper` class that is accessible to levelbuilder validation code. This class has a single method as of now, `getClassNames`, which returns a list of all the class names as strings in the user's project. This will help levelbuilders write tests when there could be multiple different options for class names for a level.

I gave this api a generic name so that we can add to it if we need more validation helper methods in the future. 

This api is documented in [this doc](https://docs.google.com/document/d/1t_NEkBEhya70Vl17Ra07Tq3Wk1xYdpU8TYNagGiuOFM/edit#bookmark=id.ozesjpldtb2k)