### PR TITLE
Shutdown lambda if container ID in table

### DIFF
--- a/cicd/3-app/javabuilder/template.yml.erb
+++ b/cicd/3-app/javabuilder/template.yml.erb
@@ -459,6 +459,7 @@ Resources:
           API_ENDPOINT: !Sub
             - "https://${ApiId}.execute-api.${AWS::Region}.amazonaws.com/${StageName}"
             - ApiId: !Ref WebSocketApi
+          UNHEALTHY_CONTAINERS_TABLE_NAME: !Ref UnhealthyContainersTable
 <%end -%>
 
   ContentBucket:

--- a/org-code-javabuilder/lib/build.gradle
+++ b/org-code-javabuilder/lib/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.20'
     // https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-cloudwatch
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-cloudwatch', version: '1.12.218'
+    // https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-dynamodb
+    implementation group: 'com.amazonaws', name: 'aws-java-sdk-dynamodb', version: '1.12.285'
     // https://mvnrepository.com/artifact/org.json/json
     implementation group: 'org.json', name: 'json', version: '20210307'
     // jaxb-api is needed to get rid of warning on run

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaErrorCodes.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaErrorCodes.java
@@ -9,4 +9,5 @@ public final class LambdaErrorCodes {
   public static final int LOW_DISK_SPACE_ERROR_CODE = 50;
   public static final int OUT_OF_MEMORY_ERROR_CODE = 60;
   public static final int CONNECTION_POOL_SHUT_DOWN_ERROR_CODE = 70;
+  public static final int UNHEALTHY_CONTAINER_ERROR_CODE = 80;
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -1,7 +1,6 @@
 package org.code.javabuilder;
 
 import static org.code.javabuilder.InternalFacingExceptionTypes.INVALID_INPUT;
-import static org.code.protocol.InternalExceptionKey.*;
 import static org.code.protocol.LoggerNames.MAIN_LOGGER;
 
 import com.amazonaws.client.builder.AwsClientBuilder;
@@ -190,7 +189,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
    */
   private void initialize(Map<String, String> lambdaInput, String connectionId, Context context) {
     // Check container health status and exit early if container has been marked unhealthy.
-    this.checkContainerHealth(ShutdownTrigger.START);
+    this.shutdownContainerIfUnhealthy(ShutdownTrigger.START);
 
     final boolean canAccessDashboardAssets =
         Boolean.parseBoolean(lambdaInput.get("canAccessDashboardAssets"));
@@ -336,7 +335,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     }
 
     // Check container health status and exit if the container has been marked unhealthy.
-    this.checkContainerHealth(ShutdownTrigger.END);
+    this.shutdownContainerIfUnhealthy(ShutdownTrigger.END);
 
     this.isSessionInitialized = false;
   }
@@ -424,7 +423,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
    * Checks if this container has been marked unhealthy and if so, forces a shutdown via
    * System.exit().
    */
-  private void checkContainerHealth(ShutdownTrigger trigger) {
+  private void shutdownContainerIfUnhealthy(ShutdownTrigger trigger) {
     if (this.unhealthyContainerChecker.shouldForceShutdownContainer(LAMBDA_ID, trigger)) {
       System.exit(LambdaErrorCodes.UNHEALTHY_CONTAINER_ERROR_CODE);
     }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UnhealthyContainerChecker.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UnhealthyContainerChecker.java
@@ -47,9 +47,9 @@ public class UnhealthyContainerChecker {
     try {
       entry = this.dynamoDBClient.getItem(this.tableName, key).getItem();
     } catch (Exception e) {
-      // Indicates an unexpected error (missing entries should return null); log warning and return
+      // Indicates an unexpected error (missing entries should return null); log error and return
       // false silently to be safe.
-      LoggerUtils.logWarning(e.getMessage());
+      LoggerUtils.logSevereException(e);
       return false;
     }
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UnhealthyContainerChecker.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UnhealthyContainerChecker.java
@@ -1,0 +1,58 @@
+package org.code.javabuilder;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import java.util.Map;
+import org.code.protocol.LoggerUtils;
+
+/**
+ * Checks if the current container has been marked unhealthy, so that we can shut it down if needed.
+ */
+public class UnhealthyContainerChecker {
+  static final String CONTAINER_ID_KEY_NAME = "container_id";
+
+  /**
+   * When the health status is being checked. This allows us to choose whether to trigger a shutdown
+   * at the beginning or end of the session.
+   */
+  public enum ShutdownTrigger {
+    START("start"),
+    END("end");
+
+    private final String name;
+
+    ShutdownTrigger(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return this.name;
+    }
+  }
+
+  private final AmazonDynamoDB dynamoDBClient;
+  private final String tableName;
+
+  public UnhealthyContainerChecker(AmazonDynamoDB dynamoDBClient, String tableName) {
+    this.dynamoDBClient = dynamoDBClient;
+    this.tableName = tableName;
+  }
+
+  public boolean shouldForceShutdownContainer(String containerId, ShutdownTrigger trigger) {
+    // The container ID value is a concatenation of the ID and the shutdown trigger type
+    final String containerIdCompositeValue = containerId + "#" + trigger.getName();
+    final Map<String, AttributeValue> key =
+        Map.of(CONTAINER_ID_KEY_NAME, new AttributeValue(containerIdCompositeValue));
+    final Map<String, AttributeValue> entry;
+    try {
+      entry = this.dynamoDBClient.getItem(this.tableName, key).getItem();
+    } catch (Exception e) {
+      // Indicates an unexpected error (missing entries should return null); log warning and return
+      // false silently to be safe.
+      LoggerUtils.logWarning(e.getMessage());
+      return false;
+    }
+
+    return entry != null;
+  }
+}

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/UnhealthyContainerCheckerTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/UnhealthyContainerCheckerTest.java
@@ -1,0 +1,73 @@
+package org.code.javabuilder;
+
+import static org.code.javabuilder.UnhealthyContainerChecker.CONTAINER_ID_KEY_NAME;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.GetItemResult;
+import java.util.Map;
+import org.code.javabuilder.UnhealthyContainerChecker.ShutdownTrigger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class UnhealthyContainerCheckerTest {
+  private static final String TABLE_NAME = "tableName";
+
+  private GetItemResult getItemResult;
+  private ArgumentCaptor<Map<String, AttributeValue>> keyCaptor;
+  private UnhealthyContainerChecker unitUnderTest;
+
+  @BeforeEach
+  public void setUp() {
+    final AmazonDynamoDB dynamoDBClient = mock(AmazonDynamoDB.class);
+    getItemResult = mock(GetItemResult.class);
+    keyCaptor = ArgumentCaptor.forClass(Map.class);
+    when(dynamoDBClient.getItem(anyString(), keyCaptor.capture())).thenReturn(getItemResult);
+
+    unitUnderTest = new UnhealthyContainerChecker(dynamoDBClient, TABLE_NAME);
+  }
+
+  @Test
+  public void testReturnsTrueIfContainerIDFound() {
+    final String containerId = "containerId1234";
+    final ShutdownTrigger trigger = ShutdownTrigger.END;
+    when(getItemResult.getItem()).thenReturn(Map.of());
+
+    assertTrue(unitUnderTest.shouldForceShutdownContainer(containerId, trigger));
+
+    this.verifyKey(containerId, trigger);
+  }
+
+  @Test
+  public void testReturnsFalseIfContainerIDNotFound() {
+    final String containerId = "containerId5678";
+    final ShutdownTrigger trigger = ShutdownTrigger.START;
+    when(getItemResult.getItem()).thenReturn(null);
+
+    assertFalse(unitUnderTest.shouldForceShutdownContainer(containerId, trigger));
+
+    this.verifyKey(containerId, trigger);
+  }
+
+  @Test
+  public void testReturnsFalseIfClientThrowsException() {
+    final String containerId = "containerId9090";
+    final ShutdownTrigger trigger = ShutdownTrigger.END;
+    when(getItemResult.getItem()).thenThrow(new RuntimeException("exception"));
+
+    assertFalse(unitUnderTest.shouldForceShutdownContainer(containerId, trigger));
+
+    this.verifyKey(containerId, trigger);
+  }
+
+  private void verifyKey(String containerId, ShutdownTrigger trigger) {
+    final Map<String, AttributeValue> key = keyCaptor.getValue();
+    final AttributeValue value = key.get(CONTAINER_ID_KEY_NAME);
+    assertEquals(containerId + "#" + trigger.getName(), value.getS());
+  }
+}

--- a/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/UnhealthyContainerCheckerTest.java
+++ b/org-code-javabuilder/lib/src/test/java/org/code/javabuilder/UnhealthyContainerCheckerTest.java
@@ -11,6 +11,8 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.GetItemResult;
 import java.util.Map;
 import org.code.javabuilder.UnhealthyContainerChecker.ShutdownTrigger;
+import org.code.protocol.JavabuilderContext;
+import org.code.protocol.MetricClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -24,6 +26,7 @@ class UnhealthyContainerCheckerTest {
 
   @BeforeEach
   public void setUp() {
+    JavabuilderContext.getInstance().register(MetricClient.class, mock(AWSMetricClient.class));
     final AmazonDynamoDB dynamoDBClient = mock(AmazonDynamoDB.class);
     getItemResult = mock(GetItemResult.class);
     keyCaptor = ArgumentCaptor.forClass(Map.class);

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerUtils.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerUtils.java
@@ -112,6 +112,10 @@ public class LoggerUtils {
     Logger.getLogger(MAIN_LOGGER).info(info);
   }
 
+  public static void logWarning(String info) {
+    Logger.getLogger(MAIN_LOGGER).warning(info);
+  }
+
   private static void sendDiskSpaceLogs(String type) {
     File f = Paths.get(System.getProperty("java.io.tmpdir")).toFile();
     JSONObject eventData = new JSONObject();

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerUtils.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerUtils.java
@@ -112,10 +112,6 @@ public class LoggerUtils {
     Logger.getLogger(MAIN_LOGGER).info(info);
   }
 
-  public static void logWarning(String info) {
-    Logger.getLogger(MAIN_LOGGER).warning(info);
-  }
-
   private static void sendDiskSpaceLogs(String type) {
     File f = Paths.get(System.getProperty("java.io.tmpdir")).toFile();
     JSONObject eventData = new JSONObject();


### PR DESCRIPTION
Adds the logic to check the unhealthy_containers DynamoDB table, and shut down the JVM if the container ID is present. We check during initialization and cleanup, and the desired shutdown trigger (start or end) is part of the DynamoDB key.

JIRA: https://codedotorg.atlassian.net/browse/JAVA-674

Tested on adhoc + unit.