### PR TITLE
Update hourly user limit and silence classroom limit

### DIFF
--- a/cicd/3-app/javabuilder/config/dev.config.json
+++ b/cicd/3-app/javabuilder/config/dev.config.json
@@ -4,8 +4,9 @@
     "BaseDomainNameHostedZonedID": "Z2LCOI49SCXUGU",
     "ProvisionedConcurrentExecutions": "1",
     "ReservedConcurrentExecutions": "3",
-    "LimitPerHour": "50",
+    "LimitPerHour": "10",
     "LimitPerDay": "150",
+    "TeacherLimitPerHour": "5",
     "SilenceAlerts": "true"
   },
   "Tags" : {

--- a/cicd/3-app/javabuilder/config/dev.config.json
+++ b/cicd/3-app/javabuilder/config/dev.config.json
@@ -4,9 +4,8 @@
     "BaseDomainNameHostedZonedID": "Z2LCOI49SCXUGU",
     "ProvisionedConcurrentExecutions": "1",
     "ReservedConcurrentExecutions": "3",
-    "LimitPerHour": "10",
+    "LimitPerHour": "50",
     "LimitPerDay": "150",
-    "TeacherLimitPerHour": "5",
     "SilenceAlerts": "true"
   },
   "Tags" : {

--- a/cicd/3-app/javabuilder/config/production.config.json
+++ b/cicd/3-app/javabuilder/config/production.config.json
@@ -4,8 +4,8 @@
     "BaseDomainNameHostedZonedID": "Z2LCOI49SCXUGU",
     "ProvisionedConcurrentExecutions": "150",
     "ReservedConcurrentExecutions": "1650",
-    "LimitPerHour": "150",
-    "LimitPerDay": "300",
+    "LimitPerHour": "1000",
+    "LimitPerDay": "5000",
     "SilenceAlerts": "false"
   },
   "Tags" : {

--- a/cicd/3-app/javabuilder/template.yml.erb
+++ b/cicd/3-app/javabuilder/template.yml.erb
@@ -38,7 +38,7 @@ Parameters:
     Type: Number
     Description: The number of Javabuilder invocations allowed for all students in a classroom per hour.
     MinValue: 1
-    Default: 1000
+    Default: 10000
   StageName:
     Type: String
     Description: The default stage name in the API Gateway APIs

--- a/cicd/3-app/javabuilder/template.yml.erb
+++ b/cicd/3-app/javabuilder/template.yml.erb
@@ -38,7 +38,7 @@ Parameters:
     Type: Number
     Description: The number of Javabuilder invocations allowed for all students in a classroom per hour.
     MinValue: 1
-    Default: 10000
+    Default: 5000
   StageName:
     Type: String
     Description: The default stage name in the API Gateway APIs

--- a/javabuilder-authorizer/token_validator.rb
+++ b/javabuilder-authorizer/token_validator.rb
@@ -26,11 +26,16 @@ class TokenValidator
     # TODO: uncomment other throttling thresholds once we have fine-tuned those limits
     return error(TOKEN_USED) unless log_token
     return error(USER_BLOCKED) if user_blocked?
-    return error(CLASSROOM_BLOCKED) if teachers_blocked?
+    # return error(CLASSROOM_BLOCKED) if teachers_blocked?
     hourly_usage_response = user_usage(ONE_HOUR_SECONDS)
     return error(USER_BLOCKED) if user_over_hourly_limit?(hourly_usage_response)
     # return error(USER_BLOCKED) if user_over_daily_limit?
-    return error(CLASSROOM_BLOCKED) if teachers_over_hourly_limit?
+    # return error(CLASSROOM_BLOCKED) if teachers_over_hourly_limit?
+    
+    # for now, check and log if the teacher is over the hourly limit, but still 
+    # allow those users through until we fine tune the limit
+    teachers_over_hourly_limit?
+
 
     near_limit_detail = get_user_near_hourly_limit_detail(hourly_usage_response.count)
     log_requests


### PR DESCRIPTION
We have seen some users hit or get close to the hourly limit and multiple classrooms hit the classroom limit. Since these limits block users completely from using Javabuilder this PR does the following:
- increase the production hourly user limit to 1000 runs per hour. I chose 1000 because if you constantly ran hello world you could theoretically run it 1440 times per hour. 1000 seems like a limit a reasonable user would not hit.
- Increase the per-classroom limit to 5000 per hour (was previously 1000) and silence that limit. We will still log if a classroom hits the limit but won't block them. We can monitor this for a while and see if it's a reasonable limit or not, or if we should be blocking whole classrooms at all.
- I also increased the daily user limit to 5000, but this is not currently used.