### PR TITLE
Update warning logs

### DIFF
--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSSystemExitHelper.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSSystemExitHelper.java
@@ -42,7 +42,7 @@ public class AWSSystemExitHelper implements SystemExitHelper {
       // Handle any other exceptions so that shut down proceeds normally. If this is an
       // IllegalStateException, it indicates that the connection was already shut down for
       // some reason.
-      LoggerUtils.logTrackingException(e);
+      LoggerUtils.logTrackingExceptionAsWarning(e);
     }
     // clean up log handler to avoid duplicate logs in future runs.
     Handler[] allHandlers = Logger.getLogger(MAIN_LOGGER).getHandlers();

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSSystemExitHelper.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AWSSystemExitHelper.java
@@ -8,7 +8,7 @@ import com.amazonaws.services.apigatewaymanagementapi.model.GoneException;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
 import org.code.protocol.JavabuilderContext;
-import org.code.protocol.JavabuilderThrowableMessageUtils;
+import org.code.protocol.LoggerUtils;
 
 public class AWSSystemExitHelper implements SystemExitHelper {
   private final String connectionId;
@@ -42,7 +42,7 @@ public class AWSSystemExitHelper implements SystemExitHelper {
       // Handle any other exceptions so that shut down proceeds normally. If this is an
       // IllegalStateException, it indicates that the connection was already shut down for
       // some reason.
-      Logger.getLogger(MAIN_LOGGER).warning(JavabuilderThrowableMessageUtils.getLoggingString(e));
+      LoggerUtils.logTrackingException(e);
     }
     // clean up log handler to avoid duplicate logs in future runs.
     Handler[] allHandlers = Logger.getLogger(MAIN_LOGGER).getHandlers();

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AssetFileStubber.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AssetFileStubber.java
@@ -1,8 +1,6 @@
 package org.code.javabuilder;
 
-import static org.code.protocol.LoggerNames.MAIN_LOGGER;
-
-import java.util.logging.Logger;
+import org.code.protocol.LoggerUtils;
 
 /**
  * Generates URLs for local, static asset files that can be used to stub asset file requests when
@@ -38,8 +36,9 @@ public class AssetFileStubber {
       return stubAudioUrl;
     }
 
-    Logger.getLogger(MAIN_LOGGER)
-        .warning(String.format("Unknown file %s. Cannot provide stubbed asset URL.", filename));
+    LoggerUtils.logWarning(
+        "Unknown asset file",
+        String.format("Unknown file %s. Cannot provide stubbed asset URL.", filename));
     return null;
   }
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AssetFileStubber.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/AssetFileStubber.java
@@ -37,7 +37,7 @@ public class AssetFileStubber {
     }
 
     LoggerUtils.logWarning(
-        "Unknown asset file",
+        "Unknown Asset File",
         String.format("Unknown file %s. Cannot provide stubbed asset URL.", filename));
     return null;
   }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeExecutionManager.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/CodeExecutionManager.java
@@ -161,7 +161,7 @@ public class CodeExecutionManager {
       // If there was an issue clearing the temp directory, this may be because too many files are
       // open. Force the JVM to quit in order to release the resources for the next use of the
       // container. Temporarily logging the exception for investigation purposes.
-      LoggerUtils.logTrackingException(e);
+      LoggerUtils.logTrackingExceptionAsWarning(e);
       this.systemExitHelper.exit(TEMP_DIRECTORY_CLEANUP_ERROR_CODE);
     } finally {
       // Replace System in/out with original System in/out

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ExceptionHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ExceptionHandler.java
@@ -1,8 +1,5 @@
 package org.code.javabuilder;
 
-import static org.code.protocol.LoggerNames.MAIN_LOGGER;
-
-import java.util.logging.Logger;
 import org.code.javabuilder.util.LambdaUtils;
 import org.code.protocol.*;
 
@@ -57,7 +54,7 @@ public class ExceptionHandler {
     // Internal facing exceptions are caused by us (essentially an HTTP 5xx error), but don't affect
     // the user. Log only.
     if (e instanceof InternalFacingException || e instanceof InternalFacingRuntimeException) {
-      Logger.getLogger(MAIN_LOGGER).warning(((LoggableProtocol) e).getLoggingString());
+      LoggerUtils.logTrackingException(e);
       return;
     }
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ExceptionHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/ExceptionHandler.java
@@ -54,7 +54,7 @@ public class ExceptionHandler {
     // Internal facing exceptions are caused by us (essentially an HTTP 5xx error), but don't affect
     // the user. Log only.
     if (e instanceof InternalFacingException || e instanceof InternalFacingRuntimeException) {
-      LoggerUtils.logTrackingException(e);
+      LoggerUtils.logTrackingExceptionAsWarning(e);
       return;
     }
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -301,7 +301,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
         // so these don't need to be reported to the user.
         final InternalFacingRuntimeException internal =
             new InternalFacingRuntimeException("Exception during shutdown", e);
-        LoggerUtils.logTrackingException(internal);
+        LoggerUtils.logTrackingExceptionAsWarning(internal);
       }
     }
 
@@ -374,7 +374,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
       // Handle any other exceptions so that shut down proceeds normally. If this is an
       // IllegalStateException, it indicates that the connection was already shut down for
       // some reason.
-      LoggerUtils.logTrackingException(e);
+      LoggerUtils.logTrackingExceptionAsWarning(e);
     }
     // clean up log handler to avoid duplicate logs in future runs.
     Handler[] allHandlers = Logger.getLogger(MAIN_LOGGER).getHandlers();

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -391,9 +391,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     } catch (IllegalStateException e) {
       // This can occur if the api client has been shut down, which we have seen happen on occasion.
       // Recreate the api client in this case. Log a warning so we can track when this happens.
-      String warningType = "API Gateway Client Gone";
-      String detail = e.getMessage();
-      LoggerUtils.logWarning(warningType, detail);
+      LoggerUtils.logWarning("API Gateway Client Gone", e.getMessage());
       this.apiClient =
           AmazonApiGatewayManagementApiClientBuilder.standard()
               .withEndpointConfiguration(

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -301,7 +301,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
         // so these don't need to be reported to the user.
         final InternalFacingRuntimeException internal =
             new InternalFacingRuntimeException("Exception during shutdown", e);
-        Logger.getLogger(MAIN_LOGGER).warning(internal.getLoggingString());
+        LoggerUtils.logTrackingException(internal);
       }
     }
 
@@ -374,7 +374,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
       // Handle any other exceptions so that shut down proceeds normally. If this is an
       // IllegalStateException, it indicates that the connection was already shut down for
       // some reason.
-      Logger.getLogger(MAIN_LOGGER).warning(JavabuilderThrowableMessageUtils.getLoggingString(e));
+      LoggerUtils.logTrackingException(e);
     }
     // clean up log handler to avoid duplicate logs in future runs.
     Handler[] allHandlers = Logger.getLogger(MAIN_LOGGER).getHandlers();
@@ -391,9 +391,9 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     } catch (IllegalStateException e) {
       // This can occur if the api client has been shut down, which we have seen happen on occasion.
       // Recreate the api client in this case. Log a warning so we can track when this happens.
-      Logger.getLogger(MAIN_LOGGER)
-          .warning(
-              "Received illegal state exception when trying to talk to API Gateway. Recreating api client.");
+      String warningType = "API Gateway client gone";
+      String detail = e.getMessage();
+      LoggerUtils.logWarning(warningType, detail);
       this.apiClient =
           AmazonApiGatewayManagementApiClientBuilder.standard()
               .withEndpointConfiguration(

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java
@@ -391,7 +391,7 @@ public class LambdaRequestHandler implements RequestHandler<Map<String, String>,
     } catch (IllegalStateException e) {
       // This can occur if the api client has been shut down, which we have seen happen on occasion.
       // Recreate the api client in this case. Log a warning so we can track when this happens.
-      String warningType = "API Gateway client gone";
+      String warningType = "API Gateway Client Gone";
       String detail = e.getMessage();
       LoggerUtils.logWarning(warningType, detail);
       this.apiClient =

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
@@ -1,7 +1,5 @@
 package org.code.javabuilder;
 
-import static org.code.protocol.LoggerNames.MAIN_LOGGER;
-
 import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.StringConcatFactory;
 import java.lang.reflect.InvocationTargetException;
@@ -11,9 +9,7 @@ import java.net.URLClassLoader;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Logger;
-import org.code.protocol.LoggerConstants;
-import org.json.JSONObject;
+import org.code.protocol.LoggerUtils;
 
 /**
  * Custom class loader for user-provided code. This class loader only allows certain classes to be
@@ -60,10 +56,7 @@ public class UserClassLoader extends URLClassLoader {
 
     // Log that we are going to throw an exception. Log as a warning
     // as it is most likely user error, but we want to track it.
-    JSONObject eventData = new JSONObject();
-    eventData.put(LoggerConstants.TYPE, "invalidClass");
-    eventData.put(LoggerConstants.CLASS_NAME, name);
-    Logger.getLogger(MAIN_LOGGER).warning(eventData.toString());
+    LoggerUtils.logWarning("Invalid Class", String.format("class name: %s", name));
     throw new ClassNotFoundException(name);
   }
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserClassLoader.java
@@ -56,7 +56,7 @@ public class UserClassLoader extends URLClassLoader {
 
     // Log that we are going to throw an exception. Log as a warning
     // as it is most likely user error, but we want to track it.
-    LoggerUtils.logWarning("Invalid Class", String.format("class name: %s", name));
+    LoggerUtils.logWarning("Invalid Class", name);
     throw new ClassNotFoundException(name);
   }
 

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserCodeCompiler.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/UserCodeCompiler.java
@@ -1,12 +1,9 @@
 package org.code.javabuilder;
 
-import static org.code.protocol.LoggerNames.MAIN_LOGGER;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.*;
-import java.util.logging.Logger;
 import javax.tools.*;
 import javax.tools.JavaCompiler.CompilationTask;
 import org.code.javabuilder.util.JarUtils;
@@ -157,10 +154,10 @@ public class UserCodeCompiler {
    */
   private String getCompilerError(Diagnostic<? extends JavaFileObject> diagnostic) {
     if (diagnostic.getSource() == null || diagnostic.getLineNumber() == Diagnostic.NOPOS) {
-      Logger.getLogger(MAIN_LOGGER)
-          .warning(
-              "Falling back to default compiler error, diagnostic source was null or line number was -1. Diagnostic error code is "
-                  + diagnostic.getCode());
+      LoggerUtils.logWarning(
+          "Unknown Compiler Error",
+          "Falling back to default compiler error, diagnostic source was null or line number was -1. Diagnostic error code is "
+              + diagnostic.getCode());
       return diagnostic.toString();
     }
     // Subtract 1 from the line number to account for our auto-import

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/util/LambdaUtils.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/util/LambdaUtils.java
@@ -28,11 +28,11 @@ public final class LambdaUtils {
     } catch (InternalFacingRuntimeException e) {
       // Unless logOnLostConnection is true, only log for messages that aren't CONNECTION_TERMINATED
       if (logOnLostConnection || !e.getMessage().equals(CONNECTION_TERMINATED)) {
-        LoggerUtils.logTrackingException(e);
+        LoggerUtils.logTrackingExceptionAsWarning(e);
       }
     } catch (Exception e) {
       // Catch any other exceptions here to prevent them from propagating.
-      LoggerUtils.logTrackingException(e);
+      LoggerUtils.logTrackingExceptionAsWarning(e);
     }
   }
 }

--- a/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/util/LambdaUtils.java
+++ b/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/util/LambdaUtils.java
@@ -1,12 +1,10 @@
 package org.code.javabuilder.util;
 
 import static org.code.javabuilder.InternalFacingExceptionTypes.CONNECTION_TERMINATED;
-import static org.code.protocol.LoggerNames.MAIN_LOGGER;
 
-import java.util.logging.Logger;
 import org.code.javabuilder.InternalFacingRuntimeException;
 import org.code.protocol.ClientMessage;
-import org.code.protocol.JavabuilderThrowableMessageUtils;
+import org.code.protocol.LoggerUtils;
 import org.code.protocol.OutputAdapter;
 
 public final class LambdaUtils {
@@ -30,11 +28,11 @@ public final class LambdaUtils {
     } catch (InternalFacingRuntimeException e) {
       // Unless logOnLostConnection is true, only log for messages that aren't CONNECTION_TERMINATED
       if (logOnLostConnection || !e.getMessage().equals(CONNECTION_TERMINATED)) {
-        Logger.getLogger(MAIN_LOGGER).warning(e.getLoggingString());
+        LoggerUtils.logTrackingException(e);
       }
     } catch (Exception e) {
       // Catch any other exceptions here to prevent them from propagating.
-      Logger.getLogger(MAIN_LOGGER).warning(JavabuilderThrowableMessageUtils.getLoggingString(e));
+      LoggerUtils.logTrackingException(e);
     }
   }
 }

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerConstants.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerConstants.java
@@ -15,6 +15,7 @@ public class LoggerConstants {
   public static final String MINI_APP_TYPE = "miniAppType";
   public static final String SESSION_METADATA = "sessionMetadata";
   public static final String DETAIL = "detail";
+  public static final String STACK_TRACE = "stackTrace";
 
   // Constants associated with disk space metrics
   public static final String DIRECTORY = "directory";

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerConstants.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerConstants.java
@@ -14,6 +14,7 @@ public class LoggerConstants {
   public static final String CHANNEL_ID = "channelId";
   public static final String MINI_APP_TYPE = "miniAppType";
   public static final String SESSION_METADATA = "sessionMetadata";
+  public static final String DETAIL = "detail";
 
   // Constants associated with disk space metrics
   public static final String DIRECTORY = "directory";

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerUtils.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerUtils.java
@@ -101,7 +101,7 @@ public class LoggerUtils {
    * Exceptions logged in this way are intended to be informative, but should be removed after a
    * period of time.
    */
-  public static void logTrackingException(Throwable e) {
+  public static void logTrackingExceptionAsWarning(Throwable e) {
     JSONObject eventData = new JSONObject();
     eventData.put(LoggerConstants.TYPE, e.getClass().getName());
     eventData.put(LoggerConstants.EXCEPTION_MESSAGE, e.getMessage());

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerUtils.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerUtils.java
@@ -3,6 +3,8 @@ package org.code.protocol;
 import static org.code.protocol.LoggerNames.MAIN_LOGGER;
 
 import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.logging.Logger;
@@ -101,11 +103,15 @@ public class LoggerUtils {
    */
   public static void logTrackingException(Throwable e) {
     JSONObject eventData = new JSONObject();
+    eventData.put(LoggerConstants.TYPE, e.getClass().toString());
     eventData.put(LoggerConstants.EXCEPTION_MESSAGE, e.getMessage());
     if (e.getCause() != null) {
       eventData.put(LoggerConstants.CAUSE, e.getCause());
     }
-    eventData.put(LoggerConstants.TYPE, e.getClass().toString());
+    StringWriter sw = new StringWriter();
+    PrintWriter pw = new PrintWriter(sw);
+    e.printStackTrace(pw);
+    eventData.put(LoggerConstants.STACK_TRACE, sw.toString());
     Logger.getLogger(MAIN_LOGGER).warning(eventData.toString());
   }
 

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerUtils.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerUtils.java
@@ -103,7 +103,7 @@ public class LoggerUtils {
    */
   public static void logTrackingException(Throwable e) {
     JSONObject eventData = new JSONObject();
-    eventData.put(LoggerConstants.TYPE, e.getClass().toString());
+    eventData.put(LoggerConstants.TYPE, e.getClass().getName());
     eventData.put(LoggerConstants.EXCEPTION_MESSAGE, e.getMessage());
     if (e.getCause() != null) {
       eventData.put(LoggerConstants.CAUSE, e.getCause());

--- a/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerUtils.java
+++ b/org-code-javabuilder/protocol/src/main/java/org/code/protocol/LoggerUtils.java
@@ -105,11 +105,19 @@ public class LoggerUtils {
     if (e.getCause() != null) {
       eventData.put(LoggerConstants.CAUSE, e.getCause());
     }
+    eventData.put(LoggerConstants.TYPE, e.getClass().toString());
     Logger.getLogger(MAIN_LOGGER).warning(eventData.toString());
   }
 
   public static void logInfo(String info) {
     Logger.getLogger(MAIN_LOGGER).info(info);
+  }
+
+  public static void logWarning(String type, String detail) {
+    JSONObject eventData = new JSONObject();
+    eventData.put(LoggerConstants.TYPE, type);
+    eventData.put(LoggerConstants.DETAIL, detail);
+    Logger.getLogger(MAIN_LOGGER).warning(eventData.toString());
   }
 
   private static void sendDiskSpaceLogs(String type) {


### PR DESCRIPTION
We discussed adding a view into warnings in the javabuilder dashboard in [this PR](https://github.com/code-dot-org/javabuilder/pull/367#discussion_r965243906). When I looked into this I found our warnings are hard to parse because they are generally very long strings/stack traces. This PR makes them easier to group in logs by adding a `type` field and either a `detail` field or exception-specific fields such as `stackTrace`. This PR also moves us towards only using `LoggerUtils` to generate logs.

Tested on a dev instance.