### PR TITLE
updated dev doc description

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@ Javabuilder is a serverless AWS application with three main parts:
 1. The code execution layer, handled by AWS Lambda
 1. The data layer, handled by Code.org's Dashboard server
 
-For an in-depth description of how these three parts work together, see the
-[Code.org Javabuilder Service Infrastructure](https://docs.google.com/document/d/196aKj947BYZXZH3nGvzHprgWPOoy2Kw1x3sKgziUaSo/edit)
-doc.
+The Javabuilder dev doc can be found at
+[Code.org Javabuilder Service Infrastructure](https://docs.google.com/document/d/196aKj947BYZXZH3nGvzHprgWPOoy2Kw1x3sKgziUaSo/edit).
 
 ### Directory
 * [api-gateway-routes](https://github.com/code-dot-org/javabuilder/tree/main/api-gateway-routes)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Javabuilder is a serverless AWS application with three main parts:
 1. The data layer, handled by Code.org's Dashboard server
 
 The Javabuilder dev doc can be found at
-[Code.org Javabuilder Service Infrastructure](https://docs.google.com/document/d/196aKj947BYZXZH3nGvzHprgWPOoy2Kw1x3sKgziUaSo/edit).
+[Code.org Javabuilder Service Infrastructure](https://docs.google.com/document/d/196aKj947BYZXZH3nGvzHprgWPOoy2Kw1x3sKgziUaSo/edit). This doc includes an in-depth description of how the three main parts of Javabuilder work together.
 
 ### Directory
 * [api-gateway-routes](https://github.com/code-dot-org/javabuilder/tree/main/api-gateway-routes)


### PR DESCRIPTION
This small PR revises the sentence in the javabuilder README doc that refers to the javabuilder dev doc.

[Slack thread discussion](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1663171875986829) about this revision.