### PR TITLE
increase neighborhood time limit to 120s

### DIFF
--- a/cicd/3-app/javabuilder/template.yml.erb
+++ b/cicd/3-app/javabuilder/template.yml.erb
@@ -428,7 +428,7 @@ Resources:
 
 <%{
   Theater: {MemorySize: 1769, Timeout: 90},
-  Neighborhood: {MemorySize: 512, Timeout: 90},
+  Neighborhood: {MemorySize: 512, Timeout: 120},
   Console: {MemorySize: 512, Timeout: 90}
 }.each do |name, config| -%>
   BuildAndRunJava<%=name%>ProjectFunction:


### PR DESCRIPTION
This PR increases the time limit for Java Lab neighborhood levels from 90 sec to 120 sec.
This is in response to a request from a user who wrote a program that took more than 90 seconds to run to completion at [this level](https://studio.code.org/s/csa1-2022/lessons/17/levels/2/sublevel/4) for which students were assigned to create a design on a 32x32 grid: 

[jira ticket - Java Lab - Increase Neighborhood time limit to 2 minutes](https://codedotorg.atlassian.net/browse/SL-290)
[Slack discussion](https://codedotorg.slack.com/archives/C03DBDN67B7/p1664902269683119)

Before the time limit was increased:

![Screen Shot 2022-10-04 at 10 03 49 AM](https://user-images.githubusercontent.com/107423305/194423165-bb15aa8d-cafd-4b4d-89a8-1d46d8cc2f20.png)


After the time limit was increased: (~ 1 min 45 sec to complete)

![Screen Shot 2022-10-06 at 4 26 32 PM](https://user-images.githubusercontent.com/107423305/194423098-d5f16dda-3563-416f-844f-9e93e4a1ee01.png)

## Follow-up
There was discussion in the [Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1664902269683119) that a longer-term solution is to try to optimize the way signals are sent. 

