### PR TITLE
Add NO_AUDIO signal to theater

### DIFF
--- a/cicd/README.md
+++ b/cicd/README.md
@@ -56,9 +56,13 @@ Notes:
 * your branch name cannot contain the character `/`, as this causes issues in AWS. Note that resources will be deployed with the tags `{EnvType = development}`.
 * for now, these must deployed to the production AWS account. There is planned work to enable these to be deployed to the Dev AWS account.
 
-```
-TARGET_BRANCH=mybranch ENVIRONMENT_TYPE=development cicd/2-cicd/deploy-cicd.sh
-```
+Steps
+
+- First, login to the AWS production account. You can follow steps 1-3 [here](https://docs.google.com/document/d/1mMQK6HhniLsz9lynzhUcm7Tcw_2WVLBxADe0WzqL6rM/edit#bookmark=id.wtrskofu4rb9) to do so.
+- Then, run the following command with your branch name:
+   ```
+   TARGET_BRANCH=mybranch ENVIRONMENT_TYPE=development cicd/2-cicd/deploy-cicd.sh
+   ```
 
 ### Deploying a full CI/CD pipeline for a different branch
 

--- a/org-code-javabuilder/media/src/main/java/org/code/media/support/AudioWriter.java
+++ b/org-code-javabuilder/media/src/main/java/org/code/media/support/AudioWriter.java
@@ -76,7 +76,6 @@ public class AudioWriter {
   public void writeToAudioStream() {
     if (this.audioSamples.length == 0) {
       // Add a silent audio sample so we can build a valid wav file.
-      // TODO: Send a "No audio" signal instead
       this.audioSamples = new double[] {0};
     }
 

--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/support/TheaterSignalKey.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/support/TheaterSignalKey.java
@@ -6,5 +6,7 @@ public enum TheaterSignalKey {
   // This message contains the url to an audio element
   AUDIO_URL,
   // Get an image from the user via Prompter
-  GET_IMAGE
+  GET_IMAGE,
+  // There is no audio for this Theater
+  NO_AUDIO
 }


### PR DESCRIPTION
DO NOT MERGE until [this PR](https://github.com/code-dot-org/code-dot-org/pull/49732) is deployed.

This PR adds a `NO_AUDIO` signal to theater if there is no audio, replacing our previous behavior of sending an empty audio file. This empty file did not work for Safari, so Theater projects without audio on Safari would not run.

I also updated our dev deploy instructions to link out to our AWS login instructions, as that tripped me up when I deployed a dev javabuilder instance for the first time in months.