### PR TITLE
Update to latest amazon linux image

### DIFF
--- a/cicd/2-cicd/cicd.template.yml
+++ b/cicd/2-cicd/cicd.template.yml
@@ -121,7 +121,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
+        Image: aws/codebuild/standard:5.0
         PrivilegedMode: true
         EnvironmentVariables:
           - Name: ARTIFACT_STORE
@@ -160,7 +160,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
+        Image: aws/codebuild/standard:5.0
         PrivilegedMode: true
         EnvironmentVariables:
           - Name: ARTIFACT_STORE
@@ -183,7 +183,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
+        Image: aws/codebuild/standard:5.0
         PrivilegedMode: true
         EnvironmentVariables:
           - Name: ARTIFACT_STORE

--- a/cicd/2-cicd/cicd.template.yml
+++ b/cicd/2-cicd/cicd.template.yml
@@ -160,7 +160,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         PrivilegedMode: true
         EnvironmentVariables:
           - Name: ARTIFACT_STORE
@@ -183,7 +183,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         PrivilegedMode: true
         EnvironmentVariables:
           - Name: ARTIFACT_STORE

--- a/cicd/2-cicd/cicd.template.yml
+++ b/cicd/2-cicd/cicd.template.yml
@@ -121,7 +121,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         PrivilegedMode: true
         EnvironmentVariables:
           - Name: ARTIFACT_STORE

--- a/cicd/README.md
+++ b/cicd/README.md
@@ -20,7 +20,7 @@ We also keep some CodeBuild configuration here, as this code tends to be more co
 
 ### 2 - CI/CD
 
-In order to trigger the application resources to be updated upon changes to the source code, we need CI/CD resources. This is accomplished by a CloudFormation template that defines a stack of resources, primarily including a CodeBuild project and a CodePipeline pipeline which update the [App Stack](#3---app). These CI/CD resources only need to be deployed once per deployable branch, `main` in our case (we might choose to create development environments by launching a new CI/CD stack targeting a different branch).
+In order to trigger the application resources to be updated upon changes to the source code, we need CI/CD resources. This is accomplished by a CloudFormation template that defines a stack of resources, primarily including a CodeBuild project and a CodePipeline pipeline which update the [App Stack](#3---app). These CI/CD resources only need to be created once per deployable branch, `main` in our case (we might choose to create development environments by launching a new CI/CD stack targeting a different branch).
 
 These resources are deployed manually when changes occur. We could make yet another CodePipeline resource in the [Setup](#1---setup) section, but not today.
 


### PR DESCRIPTION
The Amazon Linux 2 3.0 image will go out of support in April, after which our pipeline may be slowed or eventually stop working.

- updates the CI image to "aws/codebuild/standard:5.0", which is not a required upgrade, just taking the opportunity to move to the Ubuntu 20 image.
- updates the CD image to the same "aws/codebuild/standard:5.0" from the Amazon Linux image. Switching to Ubuntu 20 from Amazon Linux because the newer Amazon Linux image does not support Java 11 without extra setup.

Note that all environments will need to have `deploy-cicd.sh` run after this is merged. See [cicd/README.md](https://github.com/code-dot-org/javabuilder/blob/main/cicd/README.md)

## Testing

- [x] creating a [new development environment](https://us-east-1.console.aws.amazon.com/codesuite/codepipeline/pipelines/javabuilder-upgrade-codebuild-image-cicd/view?region=us-east-1) from this branch to confirm the new image works

## Next Steps

- When we eventually update to Java 17, we could consider switching back to Amazon Linux, which may make builds faster.