### PR TITLE
quote strings to prevent conversion to boolean

### DIFF
--- a/cicd/3-app/javabuilder/template.yml.erb
+++ b/cicd/3-app/javabuilder/template.yml.erb
@@ -902,7 +902,7 @@ Resources:
       BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: <%=DOMAIN_AND_USER_ID_COMPOSITE_ATTRIBUTE_NAME%>
-          AttributeType: S
+          AttributeType: "S"
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
 
@@ -916,7 +916,7 @@ Resources:
       BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: <%=TOKEN_ID_ATTRIBUTE_NAME%>
-          AttributeType: S
+          AttributeType: "S"
       TimeToLiveSpecification:
         AttributeName: <%=TIME_TO_LIVE_ATTRIBUTE_NAME%>
         Enabled: true
@@ -933,9 +933,9 @@ Resources:
       BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: <%=DOMAIN_AND_USER_ID_COMPOSITE_ATTRIBUTE_NAME%>
-          AttributeType: S
+          AttributeType: "S"
         - AttributeName: <%=ISSUED_AT_TIMESTAMP_ATTRIBUTE_NAME%>
-          AttributeType: N
+          AttributeType: "N"
       TimeToLiveSpecification:
         AttributeName: <%=TIME_TO_LIVE_ATTRIBUTE_NAME%>
         Enabled: true
@@ -952,9 +952,9 @@ Resources:
       BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: <%=DOMAIN_AND_SECTION_OWNER_ID_COMPOSITE_ATTRIBUTE_NAME%>
-          AttributeType: S
+          AttributeType: "S"
         - AttributeName: <%=ISSUED_AT_TIMESTAMP_ATTRIBUTE_NAME%>
-          AttributeType: N
+          AttributeType: "N"
       TimeToLiveSpecification:
         AttributeName: <%=TIME_TO_LIVE_ATTRIBUTE_NAME%>
         Enabled: true
@@ -969,7 +969,7 @@ Resources:
         BillingMode: PAY_PER_REQUEST
         AttributeDefinitions:
           - AttributeName: <%=CONTAINER_ID_AND_TRIGGER_COMPOSITE_ATTRIBUTE_NAME%>
-            AttributeType: S
+            AttributeType: "S"
 
   HighUsersBlockedAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
Because of this issue: https://github.com/aws/aws-cli/issues/7805

We are seeing "Y" and "N" strings get converted to booleans if not quoted. This change puts them in quotes to avoid the problem.

Other solutions are:
1. wait for codebuild to update the cli version used in this instance type
2. manually update the aws cli during build