### PR TITLE
Reduce demo concurrency - step 2

### DIFF
--- a/cicd/3-app/javabuilder/config/production-demo.config.json
+++ b/cicd/3-app/javabuilder/config/production-demo.config.json
@@ -4,7 +4,7 @@
     "SubdomainName": "javabuilder-demo",
     "BaseDomainNameHostedZonedID": "Z2LCOI49SCXUGU",
     "ProvisionedConcurrentExecutions": "1",
-    "ReservedConcurrentExecutions": "500",
+    "ReservedConcurrentExecutions": "5",
     "LimitPerHour": "25",
     "LimitPerDay": "100",
     "SilenceAlerts": "false"


### PR DESCRIPTION
Reducing concurrency to save costs.

This step 2 of a two step change, follows #390  to correctly apply #388