### PR TITLE
Add temporary per-day user throttling

### DIFF
--- a/cicd/3-app/javabuilder/config/dev.config.json
+++ b/cicd/3-app/javabuilder/config/dev.config.json
@@ -4,8 +4,8 @@
     "BaseDomainNameHostedZonedID": "Z2LCOI49SCXUGU",
     "ProvisionedConcurrentExecutions": "1",
     "ReservedConcurrentExecutions": "3",
-    "LimitPerHour": "50",
-    "LimitPerDay": "150",
+    "LimitPerHour": "0",
+    "LimitPerDay": "50",
     "SilenceAlerts": "true"
   },
   "Tags" : {

--- a/cicd/3-app/javabuilder/config/dev.config.json
+++ b/cicd/3-app/javabuilder/config/dev.config.json
@@ -4,8 +4,8 @@
     "BaseDomainNameHostedZonedID": "Z2LCOI49SCXUGU",
     "ProvisionedConcurrentExecutions": "1",
     "ReservedConcurrentExecutions": "3",
-    "LimitPerHour": "0",
-    "LimitPerDay": "10",
+    "LimitPerHour": "50",
+    "LimitPerDay": "150",
     "SilenceAlerts": "true"
   },
   "Tags" : {

--- a/cicd/3-app/javabuilder/config/dev.config.json
+++ b/cicd/3-app/javabuilder/config/dev.config.json
@@ -5,7 +5,7 @@
     "ProvisionedConcurrentExecutions": "1",
     "ReservedConcurrentExecutions": "3",
     "LimitPerHour": "0",
-    "LimitPerDay": "50",
+    "LimitPerDay": "10",
     "SilenceAlerts": "true"
   },
   "Tags" : {

--- a/cicd/3-app/javabuilder/config/production-demo.config.json
+++ b/cicd/3-app/javabuilder/config/production-demo.config.json
@@ -5,8 +5,8 @@
     "BaseDomainNameHostedZonedID": "Z2LCOI49SCXUGU",
     "ProvisionedConcurrentExecutions": "1",
     "ReservedConcurrentExecutions": "5",
-    "LimitPerHour": "25",
-    "LimitPerDay": "100",
+    "LimitPerHour": "0",
+    "LimitPerDay": "50",
     "SilenceAlerts": "false"
   },
   "Tags": {

--- a/cicd/3-app/javabuilder/config/production-demo.config.json
+++ b/cicd/3-app/javabuilder/config/production-demo.config.json
@@ -5,7 +5,7 @@
     "BaseDomainNameHostedZonedID": "Z2LCOI49SCXUGU",
     "ProvisionedConcurrentExecutions": "1",
     "ReservedConcurrentExecutions": "5",
-    "LimitPerHour": "0",
+    "LimitPerHour": "-1",
     "LimitPerDay": "50",
     "SilenceAlerts": "false"
   },

--- a/cicd/3-app/javabuilder/config/production.config.json
+++ b/cicd/3-app/javabuilder/config/production.config.json
@@ -5,7 +5,7 @@
     "ProvisionedConcurrentExecutions": "50",
     "ReservedConcurrentExecutions": "500",
     "LimitPerHour": "1000",
-    "LimitPerDay": "5000",
+    "LimitPerDay": "0",
     "SilenceAlerts": "false",
     "TeacherLimitPerHour": "25000"
   },

--- a/cicd/3-app/javabuilder/config/production.config.json
+++ b/cicd/3-app/javabuilder/config/production.config.json
@@ -5,7 +5,7 @@
     "ProvisionedConcurrentExecutions": "50",
     "ReservedConcurrentExecutions": "500",
     "LimitPerHour": "1000",
-    "LimitPerDay": "0",
+    "LimitPerDay": "-1",
     "SilenceAlerts": "false",
     "TeacherLimitPerHour": "25000"
   },

--- a/cicd/3-app/javabuilder/template.yml.erb
+++ b/cicd/3-app/javabuilder/template.yml.erb
@@ -26,13 +26,13 @@ Parameters:
     Default: 3
   LimitPerHour:
     Type: Number
-    Description: The number of Javabuilder invocations allowed per user per hour. If the value is 0, then there is no limit on the number of invocations per hour.
-    MinValue: 0
+    Description: The number of Javabuilder invocations allowed per user per hour. If the value is -1, then there is no limit on the number of invocations per hour.
+    MinValue: -1
     Default: 50
   LimitPerDay:
     Type: Number
-    Description: The number of Javabuilder invocations allowed per user per day. If the value is 0, then there is no limit on the number of invocations per day.
-    MinValue: 0
+    Description: The number of Javabuilder invocations allowed per user per day. If the value is -1, then there is no limit on the number of invocations per day.
+    MinValue: -1
     Default: 150
   TeacherLimitPerHour:
     Type: Number

--- a/cicd/3-app/javabuilder/template.yml.erb
+++ b/cicd/3-app/javabuilder/template.yml.erb
@@ -26,13 +26,13 @@ Parameters:
     Default: 3
   LimitPerHour:
     Type: Number
-    Description: The number of Javabuilder invocations allowed per user per hour.
-    MinValue: 1
+    Description: The number of Javabuilder invocations allowed per user per hour. If the value is 0, then there is no limit on the number of invocations per hour.
+    MinValue: 0
     Default: 50
   LimitPerDay:
     Type: Number
-    Description: The number of Javabuilder invocations allowed per user per day.
-    MinValue: 1
+    Description: The number of Javabuilder invocations allowed per user per day. If the value is 0, then there is no limit on the number of invocations per day.
+    MinValue: 0
     Default: 150
   TeacherLimitPerHour:
     Type: Number

--- a/cicd/3-app/javabuilder/template.yml.erb
+++ b/cicd/3-app/javabuilder/template.yml.erb
@@ -480,11 +480,6 @@ Resources:
           - Id: ExpirationRule
             Status: Enabled
             ExpirationInDays: 1
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: false
-        BlockPublicPolicy: false
-        IgnorePublicAcls: false
-        RestrictPublicBuckets: false
 
   ContentBucketPolicy:
     Type: AWS::S3::BucketPolicy

--- a/cicd/3-app/javabuilder/template.yml.erb
+++ b/cicd/3-app/javabuilder/template.yml.erb
@@ -480,6 +480,11 @@ Resources:
           - Id: ExpirationRule
             Status: Enabled
             ExpirationInDays: 1
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
 
   ContentBucketPolicy:
     Type: AWS::S3::BucketPolicy

--- a/javabuilder-authorizer/token_status.rb
+++ b/javabuilder-authorizer/token_status.rb
@@ -44,4 +44,5 @@ module TokenStatus
   NEW_USER_BLOCKED = 'NewUserBlocked'.freeze
   NEW_CLASSROOM_BLOCKED = 'NewClassroomBlocked'.freeze
   CLASSROOM_HOURLY_REQUEST_COUNT = 'ClassroomHourlyRequestCount'.freeze
+  USER_BLOCKED_TEMPORARY = 'UserBlockedTemporary'.freeze
 end

--- a/javabuilder-authorizer/token_status.rb
+++ b/javabuilder-authorizer/token_status.rb
@@ -26,7 +26,7 @@ module TokenStatus
   NOT_VETTED = 'NOT_VETTED'.freeze
   # User has been blocks for violating daily limits. They will be automatically unblocked 
   # once they are no longer over the limit.
-  USER_BLOCKED_TEMPORARY = 'UserBlockedTemporary'.freeze
+  USER_BLOCKED_TEMPORARY = 'USER_BLOCKED_TEMPORARY'.freeze
 
   ### Token status used by both authorizers
   # Token provided to the authorizer has already been used

--- a/javabuilder-authorizer/token_status.rb
+++ b/javabuilder-authorizer/token_status.rb
@@ -45,4 +45,12 @@ module TokenStatus
   NEW_CLASSROOM_BLOCKED = 'NewClassroomBlocked'.freeze
   CLASSROOM_HOURLY_REQUEST_COUNT = 'ClassroomHourlyRequestCount'.freeze
   USER_BLOCKED_TEMPORARY = 'UserBlockedTemporary'.freeze
+
+  # Lockout statuses
+  PERMANENT_LOCKOUT = 'PERMANENT'.freeze
+  TEMPORARY_LOCKOUT = 'TEMPORARY'.freeze
+
+  # Lockout periods
+  DAY = 'DAY'.freeze
+  HOUR = 'HOUR'.freeze
 end

--- a/javabuilder-authorizer/token_status.rb
+++ b/javabuilder-authorizer/token_status.rb
@@ -2,7 +2,7 @@ module TokenStatus
   ### Token statuses used in HTTP authorizer (first step in token validation)
   # Token was validated by HTTP authorizer
   VALID_HTTP = 'VALID_HTTP'.freeze
-  # User has been blocked for violating hourly or daily throttle limits
+  # User has been blocked for violating hourly throttle limits
   USER_BLOCKED = 'USER_BLOCKED'.freeze
   # All of a user's teachers (or the teacher themselves, if the user is a teacher)
   # has been blocked for violating hourly throttle limits
@@ -24,12 +24,15 @@ module TokenStatus
   UNKNOWN_ID = 'UNKNOWN_ID'.freeze
   # Token provided was not vetted by hTTP authorizer
   NOT_VETTED = 'NOT_VETTED'.freeze
+  # User has been blocks for violating daily limits. They will be automatically unblocked 
+  # once they are no longer over the limit.
+  USER_BLOCKED_TEMPORARY = 'UserBlockedTemporary'.freeze
 
   ### Token status used by both authorizers
   # Token provided to the authorizer has already been used
   TOKEN_USED = 'TOKEN_USED'.freeze
 
-  ERROR_STATES = [USER_BLOCKED, CLASSROOM_BLOCKED, USER_OVER_DAILY_LIMIT, USER_OVER_HOURLY_LIMIT, TEACHERS_OVER_HOURLY_LIMIT, UNKNOWN_ID, NOT_VETTED, TOKEN_USED]
+  ERROR_STATES = [USER_BLOCKED, CLASSROOM_BLOCKED, USER_OVER_DAILY_LIMIT, USER_OVER_HOURLY_LIMIT, TEACHERS_OVER_HOURLY_LIMIT, UNKNOWN_ID, NOT_VETTED, TOKEN_USED, USER_BLOCKED_TEMPORARY]
   WARNING_STATES = [NEAR_LIMIT]
   VALID_STATES = [VALID_HTTP, VALID_WEBSOCKET]
 
@@ -38,13 +41,13 @@ module TokenStatus
     CLASSROOM_BLOCKED => 'ClassroomBlocked',
     UNKNOWN_ID => 'TokenUnknownId',
     NOT_VETTED => 'TokenNotVetted',
-    TOKEN_USED => 'TokenUsed'
+    TOKEN_USED => 'TokenUsed',
+    USER_BLOCKED_TEMPORARY => 'UserBlockedTemporary',
   }.freeze
 
   NEW_USER_BLOCKED = 'NewUserBlocked'.freeze
   NEW_CLASSROOM_BLOCKED = 'NewClassroomBlocked'.freeze
   CLASSROOM_HOURLY_REQUEST_COUNT = 'ClassroomHourlyRequestCount'.freeze
-  USER_BLOCKED_TEMPORARY = 'UserBlockedTemporary'.freeze
 
   # Lockout statuses
   PERMANENT_LOCKOUT = 'PERMANENT'.freeze

--- a/javabuilder-authorizer/token_validator.rb
+++ b/javabuilder-authorizer/token_validator.rb
@@ -11,7 +11,7 @@ class TokenValidator
   USER_REQUEST_RECORD_TTL_SECONDS = 25 * ONE_HOUR_SECONDS
   TEACHER_ASSOCIATED_REQUEST_TTL_SECONDS = 25 * ONE_HOUR_SECONDS
   NEAR_LIMIT_BUFFER = 10
-  NO_LIMIT = 0
+  NO_LIMIT = -1
 
   def initialize(payload, origin, context)
     @token_id = payload['sid']
@@ -241,7 +241,7 @@ class TokenValidator
   end
 
   def get_user_near_limit_detail(count, limit, period, lockout_type)
-    if limit > 0 && count <= limit && count >= (limit - NEAR_LIMIT_BUFFER)
+    if limit != NO_LIMIT && count <= limit && count >= (limit - NEAR_LIMIT_BUFFER)
       return {remaining: limit - count, period: period, lockout_type: lockout_type}
     else
       return nil

--- a/javabuilder-authorizer/token_validator.rb
+++ b/javabuilder-authorizer/token_validator.rb
@@ -11,6 +11,7 @@ class TokenValidator
   USER_REQUEST_RECORD_TTL_SECONDS = 25 * ONE_HOUR_SECONDS
   TEACHER_ASSOCIATED_REQUEST_TTL_SECONDS = 25 * ONE_HOUR_SECONDS
   NEAR_LIMIT_BUFFER = 10
+  NO_LIMIT = 0
 
   def initialize(payload, origin, context)
     @token_id = payload['sid']
@@ -93,17 +94,13 @@ class TokenValidator
 
   def user_over_hourly_limit?(hourly_usage_response)
     limit_per_hour =  ENV['limit_per_hour'].to_i
-    # A limit of 0 means there is no limit.
-    if limit_per_hour > 0
-      user_over_limit?(
-        hourly_usage_response,
-        limit_per_hour,
-        USER_OVER_HOURLY_LIMIT,
-        true # Should block permanently if the limit has been reached.
-      )
-    else
-      false
-    end
+    return false if limit_per_hour == NO_LIMIT
+    user_over_limit?(
+      hourly_usage_response,
+      limit_per_hour,
+      USER_OVER_HOURLY_LIMIT,
+      true # Should block permanently if the limit has been reached.
+    )
   end
 
   def get_user_near_hourly_limit_detail(hourly_usage_count)
@@ -116,17 +113,13 @@ class TokenValidator
 
   def user_over_daily_limit?(daily_usage_response)
     limit_per_day = ENV['limit_per_day'].to_i
-    # A limit of 0 means there is no limit.
-    if limit_per_day > 0
-      user_over_limit?(
-        daily_usage_response,
-        limit_per_day,
-        USER_OVER_DAILY_LIMIT,
-        false # Should not block permanently if the limit has been reached.
-      )
-    else
-      false
-    end
+    return false if limit_per_day == NO_LIMIT
+    user_over_limit?(
+      daily_usage_response,
+      limit_per_day,
+      USER_OVER_DAILY_LIMIT,
+      false # Should not block permanently if the limit has been reached.
+    )
   end
 
   def teachers_over_hourly_limit?

--- a/javabuilder-authorizer/token_validator.rb
+++ b/javabuilder-authorizer/token_validator.rb
@@ -247,9 +247,9 @@ class TokenValidator
     response
   end
 
-  def get_user_near_limit_detail(count, limit, period, lock_out_type)
+  def get_user_near_limit_detail(count, limit, period, lockout_type)
     if limit > 0 && count <= limit && count >= (limit - NEAR_LIMIT_BUFFER)
-      return {remaining: limit - count, period: period, lock_out_type: lock_out_type}
+      return {remaining: limit - count, period: period, lockout_type: lockout_type}
     else
       return nil
     end

--- a/javabuilder-authorizer/token_validator.rb
+++ b/javabuilder-authorizer/token_validator.rb
@@ -97,7 +97,7 @@ class TokenValidator
     if limit_per_hour > 0
       user_over_limit?(
         hourly_usage_response,
-        ENV['limit_per_hour'].to_i,
+        limit_per_hour,
         USER_OVER_HOURLY_LIMIT,
         true # Should block permanently if the limit has been reached.
       )
@@ -107,20 +107,20 @@ class TokenValidator
   end
 
   def get_user_near_hourly_limit_detail(hourly_usage_count)
-    get_user_near_limit_detail(hourly_usage_count, ENV['limit_per_hour'].to_i, 'hour', 'permanent')
+    get_user_near_limit_detail(hourly_usage_count, ENV['limit_per_hour'].to_i, HOUR, PERMANENT_LOCKOUT)
   end
 
   def get_user_near_daily_limit_detail(daily_usage_count)
-    get_user_near_limit_detail(daily_usage_count, ENV['limit_per_day'].to_i, 'day', 'temporary')
+    get_user_near_limit_detail(daily_usage_count, ENV['limit_per_day'].to_i, DAY, TEMPORARY_LOCKOUT)
   end
 
   def user_over_daily_limit?(daily_usage_response)
     limit_per_day = ENV['limit_per_day'].to_i
     # A limit of 0 means there is no limit.
-    if limit_per_hour > 0
+    if limit_per_day > 0
       user_over_limit?(
         daily_usage_response,
-        ENV['limit_per_day'].to_i,
+        limit_per_day,
         USER_OVER_DAILY_LIMIT,
         false # Should not block permanently if the limit has been reached.
       )


### PR DESCRIPTION
As part of [Java Lab Eval Mode](https://docs.google.com/document/d/1YFFCcTooSb2t5Q9pmNCOxLtujwKTM4SXTuUtj5Oma7Q/edit#bookmark=id.hv46zl6gv16), we want to add back in daily user throttling, but have it not block the user forever, only until they are back under the limit. In this PR I:
- Converted our turned-off daily throttling to be this temporary model, and added a new key `USER_BLOCKED_TEMPORARY` that we will send if the user reaches their limit in a day.
- Updated the near limit message to include the interval and whether this is a permanent or temporary block.
- Updated our daily and hourly limits such that if the limit is 0, there is no limit. We need this because we don't want hourly limits on javabuilder-demo, and we don't want a daily limit on production javabuilder (for now).

This PR cannot be merged until the [corresponding code.org](https://github.com/code-dot-org/code-dot-org/pull/51570) PR has been merged and deployed.