### PR TITLE
BREAKING CHANGE - Align content bucket name with url

### DIFF
--- a/cicd/3-app/javabuilder/template.yml.erb
+++ b/cicd/3-app/javabuilder/template.yml.erb
@@ -465,7 +465,7 @@ Resources:
   ContentBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !If [IsDevCondition, !Sub "cdo-dev-${SubdomainName}-content", !Sub "cdo-${SubdomainName}-content"]
+      BucketName: !Sub "${SubdomainName}-content.${BaseDomainName}"
       CorsConfiguration:
         CorsRules:
           - AllowedMethods: [GET, PUT]


### PR DESCRIPTION
This change aligns the name of the Content Bucket with the name of the URL and CDN used to access. This is a common practice for S3-backed domains, and helps to eliminate the one use of `IsDevCondition` in our template.

## Deployment

Deployed as-is, this will attempt to delete the existing content bucket. Here is a possible plan for deploying this change:

1. First, deploy a change that adds `DeletionPolicy: Retain` to the ContentBucket resource
2. Then, deploy this change. The new bucket should be created and wired up correctly, and the old bucket should be left untouched and now disconnected from javabuilder.
3. Copy all files from the old content bucket to the new one, restoring all content to the expected location

This would result in service degradation between step 2 and the completion of step 3, because some content would be missing until it is restored.