### PR TITLE
Validate seconds in PauseAction constructor

### DIFF
--- a/org-code-javabuilder/theater/src/main/java/org/code/theater/support/PauseAction.java
+++ b/org-code-javabuilder/theater/src/main/java/org/code/theater/support/PauseAction.java
@@ -4,6 +4,9 @@ public class PauseAction implements SceneAction {
   private final double seconds;
 
   public PauseAction(double seconds) {
+    if (!Double.isFinite(seconds)) {
+      throw new IllegalArgumentException("Pause seconds must be finite");
+    }
     this.seconds = seconds;
   }
 


### PR DESCRIPTION
Passing Double.POSITIVE_INFINITY to Scene.pause() crashed the environment

I have made a bug report, though official channels.