### PR TITLE
Fix bug with session id name

### DIFF
--- a/api-gateway-routes/api_gateway_proxy_function.rb
+++ b/api-gateway-routes/api_gateway_proxy_function.rb
@@ -4,7 +4,9 @@ require 'aws-sdk-lambda'
 require 'aws-sdk-apigatewaymanagementapi'
 require 'uri'
 require_relative 'auth_response_helper'
+require_relative 'session_id_helper'
 include AuthResponseHelper
+include SessionIdHelper
 
 MAX_SQS_RETRIES = 3
 INITIAL_RETRY_SLEEP_S = 0.5
@@ -174,15 +176,6 @@ end
 # ARN is of the format arn:aws:lambda:{region}:{account_id}:function:{lambda_name}
 def get_region(context)
   context.invoked_function_arn.split(':')[3]
-end
-
-# SQS queues can only be named with the following characters:
-# alphanumeric characters, hyphens (-), and underscores (_)
-# See https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SQS/Client.html#create_queue-instance_method
-# The connection ID always ends with an '='. We remove that here so we can use the connection ID as
-# our session ID.
-def get_session_id(event)
-  event["requestContext"]["connectionId"].delete_suffix("=")
 end
 
 def get_sqs_url(event, context)

--- a/api-gateway-routes/session_id_helper.rb
+++ b/api-gateway-routes/session_id_helper.rb
@@ -6,6 +6,8 @@ module SessionIdHelper
   # The connection ID is base64-encoded, so it can end with one or more '='
   # padding characters. We remove all of them here.
   def get_session_id(event)
+    stripped_connection_id = event["requestContext"]["connectionId"].sub(/=+$/, "")
+    puts "session_id_helper stripped connection id: #{stripped_connection_id}, original connection id: #{event["requestContext"]["connectionId"]}"
     event["requestContext"]["connectionId"].sub(/=+$/, "")
   end
 end

--- a/api-gateway-routes/session_id_helper.rb
+++ b/api-gateway-routes/session_id_helper.rb
@@ -1,0 +1,11 @@
+module SessionIdHelper
+  # The session ID is the connection ID with any trailing '=' removed, so it can
+  # be used as an SQS queue name. SQS queues can only be named with the following
+  # characters: alphanumeric characters, hyphens (-), and underscores (_).
+  # See https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SQS/Client.html#create_queue-instance_method
+  # The connection ID is base64-encoded, so it can end with one or more '='
+  # padding characters. We remove all of them here.
+  def get_session_id(event)
+    event["requestContext"]["connectionId"].sub(/=+$/, "")
+  end
+end

--- a/api-gateway-routes/session_id_helper.rb
+++ b/api-gateway-routes/session_id_helper.rb
@@ -6,8 +6,6 @@ module SessionIdHelper
   # The connection ID is base64-encoded, so it can end with one or more '='
   # padding characters. We remove all of them here.
   def get_session_id(event)
-    stripped_connection_id = event["requestContext"]["connectionId"].sub(/=+$/, "")
-    puts "session_id_helper stripped connection id: #{stripped_connection_id}, original connection id: #{event["requestContext"]["connectionId"]}"
     event["requestContext"]["connectionId"].sub(/=+$/, "")
   end
 end

--- a/api-gateway-routes/test/session_id_helper_test.rb
+++ b/api-gateway-routes/test/session_id_helper_test.rb
@@ -1,0 +1,23 @@
+require 'minitest/autorun'
+require_relative '../session_id_helper'
+include SessionIdHelper
+
+class SessionIdHelperTest < Minitest::Test
+  def test_strips_single_trailing_padding_character
+    assert_equal 'PoofdetIoAMCJpg', get_session_id(event_with_connection_id('PoofdetIoAMCJpg='))
+  end
+
+  def test_strips_multiple_trailing_padding_characters
+    assert_equal 'gQwo_Q8CiQAYKAImwA', get_session_id(event_with_connection_id('gQwo_Q8CiQAYKAImwA=='))
+  end
+
+  def test_leaves_connection_id_without_padding_unchanged
+    assert_equal 'abc-123_XYZ', get_session_id(event_with_connection_id('abc-123_XYZ'))
+  end
+
+  private
+
+  def event_with_connection_id(connection_id)
+    {"requestContext" => {"connectionId" => connection_id}}
+  end
+end


### PR DESCRIPTION
I noticed today that Javabuilder was frequently failing to connect, with the websocket request returning a 502. I (with help from Claude) tracked the error down to `StartSessionsAndRelayMessagesFunction`, which was logging
`"errorMessage": "The name of a FIFO queue can only include alphanumeric characters, hyphens, or underscores, must end with .fifo suffix and be 1 to 80 in length.",`. This error pointed to how we were naming our SQS queues. This hasn't changed on our end, but we make an assumption that the websocket connection ids we use to generate the queue names end with a single `=`. In the case of the failures I found, the ids ended with 2 equals signs. The equals signs aren't valid in FIFO queue names, and therefore we were failing to make the queues.

It seems like this is a recent change in how websocket connection ids are generated. I've been using Javabuilder a lot lately and only noticed this happening frequently today. The last week of logs confirm this:
<img width="1454" height="546" alt="Screenshot 2026-06-12 at 10 47 09 AM" src="https://github.com/user-attachments/assets/dcc400b8-f376-4886-9c92-9e07a8010103" />

To fix this, instead of only stripping the last `=` from the connection id, we instead will strip all `=`. 

## Testing
I tried to deploy a dev javabuilder instance, but the permissions are broken right now. This change seems pretty safe and I added unit tests for it, so I feel ok about pushing it forward without full testing.