### PR TITLE
Switch Content S3 Bucket to Use CloudFront Origin Access Control

### DIFF
--- a/cicd/3-app/javabuilder/template.yml.erb
+++ b/cicd/3-app/javabuilder/template.yml.erb
@@ -487,16 +487,32 @@ Resources:
             Status: Enabled
             ExpirationInDays: 1
 
+  ContentOriginAccessControl:
+    Type: AWS::CloudFront::OriginAccessControl
+    Properties:
+      OriginAccessControlConfig:
+        Name: !Sub "${SubdomainName}-${BaseDomainName}-content-oac"
+        OriginAccessControlOriginType: s3
+        SigningBehavior: always
+        SigningProtocol: sigv4
+
   ContentBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
       Bucket: !Ref ContentBucket
       PolicyDocument:
+        Version: '2012-10-17'
         Statement:
-        - Action: ['s3:GetObject']
-          Effect: Allow
-          Resource: !Sub "arn:aws:s3:::${ContentBucket}/*"
-          Principal: '*'
+          - Sid: AllowCloudFrontRead
+            Effect: Allow
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Action:
+              - s3:GetObject
+            Resource: !Sub "arn:aws:s3:::${ContentBucket}/*"
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Sub "arn:aws:cloudfront::${AWS::AccountId}:distribution/${ContentCDN}"
 
   ContentApiCertificate:
     Type: AWS::CertificateManager::Certificate
@@ -537,8 +553,10 @@ Resources:
         #   Prefix: !Sub "${SubdomainName}-content.${BaseDomainName}"
         Origins:
           - Id: ContentBucket
-            DomainName: !GetAtt ContentBucket.DomainName
-            S3OriginConfig: {}
+            DomainName: !GetAtt ContentBucket.RegionalDomainName
+            OriginAccessControlId: !GetAtt ContentOriginAccessControl.Id
+            S3OriginConfig:
+              OriginAccessIdentity: ""
         DefaultCacheBehavior:
           TargetOriginId: ContentBucket
           AllowedMethods: [DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT]


### PR DESCRIPTION
We're no longer able to provision new Javabuilder Stacks. CloudFormation cannot provision the `ContentBucketPolicy` because of the `BlockPublicPolicy` setting.

Switch to using CloudFront Origin Access Control to enable students/teachers (the public) to fetch Objects in this bucket. 

The Javabuilder Lambdas still have access through their Roles to read/write Objects in this Bucket.